### PR TITLE
(feat) Poller behaviour with select2 MON-10870

### DIFF
--- a/www/class/centreonInstance.class.php
+++ b/www/class/centreonInstance.class.php
@@ -215,20 +215,31 @@ class CentreonInstance
      */
     public function getObjectForSelect2($values = array(), $options = array())
     {
+        global $centreon;
+
         $selectedInstances = '';
         $items = array();
+
+        if (empty($values)) {
+            return $items;
+        }
+
+        # get list of authorized pollers
+        if (!$centreon->user->access->admin) {
+            $pollerAcl = $centreon->user->access->getPollers();
+        }
+
         $listValues = '';
         $queryValues = array();
-        if (!empty($values)) {
-            foreach ($values as $k => $v) {
-                $listValues .= ':instance' . $v . ',';
-                $queryValues['instance' . $v] = (int)$v;
+        foreach ($values as $k => $v) {
+            $multipleValues = explode(',', $v);
+            foreach ($multipleValues as $item) {
+                $listValues .= ':pId_' . $item . ', ';
+                $queryValues['pId_' . $item] = (int)$item;
             }
-            $listValues = rtrim($listValues, ',');
-            $selectedInstances .= "AND rel.instance_id IN ($listValues) ";
-        } else {
-            $listValues .= '""';
         }
+        $listValues = rtrim($listValues, ', ');
+        $selectedInstances .= " AND rel.instance_id IN ($listValues) ";
 
         $query = 'SELECT DISTINCT p.name as name, p.id  as id FROM cfg_resource r, nagios_server p, ' .
             'cfg_resource_instance_relations rel ' .
@@ -238,17 +249,19 @@ class CentreonInstance
             ' ORDER BY p.name';
 
         $stmt = $this->db->prepare($query);
-        if (!empty($queryValues)) {
-            foreach ($queryValues as $key => $id) {
-                $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
-            }
+        foreach ($queryValues as $key => $id) {
+            $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
         }
         $stmt->execute();
-
         while ($data = $stmt->fetch()) {
+            $hide = false;
+            if (!$centreon->user->access->admin && count($pollerAcl) && !in_array($data['id'], array_keys($pollerAcl))) {
+                $hide = true;
+            }
             $items[] = array(
                 'id' => $data['id'],
-                'text' => $data['name']
+                'text' => $data['name'],
+                'hide' => $hide
             );
         }
 

--- a/www/class/centreonInstance.class.php
+++ b/www/class/centreonInstance.class.php
@@ -224,7 +224,7 @@ class CentreonInstance
             return $items;
         }
 
-        # get list of authorized pollers
+        // get list of authorized pollers
         if (!$centreon->user->access->admin) {
             $pollerAcl = $centreon->user->access->getPollers();
         }


### PR DESCRIPTION
The PDO request try to bind a string of multiple id separated with comma, instead of binding each id
+ adds poller acl into the select2 list
this is mostly a rip-off of #7119

# Pull Request Template

## Description

this PR is needed for this PR: https://github.com/centreon/centreon-widget-engine-status/pull/22

* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>
you need to use the engine-status widget with this PR: 
https://github.com/centreon/centreon-widget-engine-status/pull/22

when you install this widget with the aformentioned PR, you're going to be able to filter on one or more host categories. Select at least two of them in the parameters of your widget.

Save your parameters.
get back to the widget parameters, you'll have a PDO issue and all your categories will have vanished.

With this PR, they won't vanish anymore. @sc979 knows what I'm talking about ;)

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
