### PR TITLE
fix(sec): avoid xss in widget rename webservice

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -1385,20 +1385,16 @@ class CentreonWidget
     /**
      * Rename widget
      *
-     * @param array $params
+     * @param string $elementId element id using format "title_<id>"
+     * @param string $newName widget new name
      * @return string
      */
-    public function rename($params)
+    public function rename(string $elementId, string $newName)
     {
-        if (!isset($params['elementId']) || !isset($params['newName'])) {
-            throw new CentreonWidgetException('Missing mandatory parameters elementId or newName');
-        }
-        if (preg_match("/title_(\d+)/", $params['elementId'], $matches)) {
-            if (isset($matches[1])) {
-                $widgetId = $matches[1];
-            }
-        }
-        if (!isset($widgetId)) {
+        $widgetId = null;
+        if (preg_match("/title_(\d+)/", $elementId, $matches)) {
+            $widgetId = $matches[1];
+        } else {
             throw new CentreonWidgetException('Missing widget id');
         }
 
@@ -1406,13 +1402,10 @@ class CentreonWidget
             'SET title = :title ' .
             'WHERE widget_id = :widgetId';
         $stmt = $this->db->prepare($query);
-        $stmt->bindParam(':title', $params['newName'], PDO::PARAM_STR);
+        $stmt->bindParam(':title', $newName, PDO::PARAM_STR);
         $stmt->bindParam(':widgetId', $widgetId, PDO::PARAM_INT);
-        $dbResult = $stmt->execute();
-        if (!$dbResult) {
-            throw new \Exception("An error occured");
-        }
+        $stmt->execute();
 
-        return $params['newName'];
+        return $newName;
     }
 }

--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -1385,19 +1385,12 @@ class CentreonWidget
     /**
      * Rename widget
      *
-     * @param string $elementId element id using format "title_<id>"
+     * @param int $elementId widget id
      * @param string $newName widget new name
      * @return string
      */
-    public function rename(string $elementId, string $newName)
+    public function rename(int $widgetId, string $newName)
     {
-        $widgetId = null;
-        if (preg_match("/title_(\d+)/", $elementId, $matches)) {
-            $widgetId = $matches[1];
-        } else {
-            throw new CentreonWidgetException('Missing widget id');
-        }
-
         $query = 'UPDATE widgets ' .
             'SET title = :title ' .
             'WHERE widget_id = :widgetId';

--- a/www/include/home/customViews/rename.php
+++ b/www/include/home/customViews/rename.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2005-2015 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -47,6 +48,33 @@ if (!isset($_SESSION['centreon'])) {
     exit();
 }
 
+$elementId = filter_input(
+    INPUT_POST,
+    'elementId',
+    FILTER_VALIDATE_REGEXP,
+    [
+        'options' => ['regexp' => '/^title_\d+$/']
+    ]
+);
+
+if ($elementId === null) {
+    echo 'missing elementId argument';
+    exit();
+} elseif ($elementId === false) {
+    echo 'elementId must use following regexp format : "title_\d+"';
+    exit();
+}
+
+$newName = filter_input(
+    INPUT_POST,
+    'newName',
+    FILTER_SANITIZE_STRING
+);
+if ($newName === null) {
+    echo 'missing newName argument';
+    exit();
+}
+
 $centreon = $_SESSION['centreon'];
 $db = new CentreonDB();
 
@@ -56,7 +84,7 @@ if (CentreonSession::checkSession(session_id(), $db) == 0) {
 
 $widgetObj = new CentreonWidget($centreon, $db);
 try {
-    echo $widgetObj->rename($_REQUEST);
+    echo $widgetObj->rename($elementId, $newName);
 } catch (CentreonWidgetException $e) {
     echo $e->getMessage();
 }

--- a/www/include/home/customViews/rename.php
+++ b/www/include/home/customViews/rename.php
@@ -65,6 +65,11 @@ if ($elementId === null) {
     exit();
 }
 
+$widgetId = null;
+if (preg_match('/^title_(\d+)$/', $_POST['elementId'], $matches)) {
+    $widgetId = $matches[1];
+}
+
 $newName = filter_input(
     INPUT_POST,
     'newName',
@@ -84,7 +89,7 @@ if (CentreonSession::checkSession(session_id(), $db) == 0) {
 
 $widgetObj = new CentreonWidget($centreon, $db);
 try {
-    echo $widgetObj->rename($elementId, $newName);
+    echo $widgetObj->rename($elementId, $widgetId);
 } catch (CentreonWidgetException $e) {
     echo $e->getMessage();
 }

--- a/www/include/home/customViews/rename.php
+++ b/www/include/home/customViews/rename.php
@@ -89,7 +89,7 @@ if (CentreonSession::checkSession(session_id(), $db) == 0) {
 
 $widgetObj = new CentreonWidget($centreon, $db);
 try {
-    echo $widgetObj->rename($elementId, $widgetId);
+    echo $widgetObj->rename($widgetId, $newName);
 } catch (CentreonWidgetException $e) {
     echo $e->getMessage();
 }


### PR DESCRIPTION
## Description

Avoid xss injection when calling directly widget rename endpoint

**Fixes** MON-5757

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

call directly this endpoint from your browser : `http://x.x.x.x/centreon/include/home/customViews/rename.php?newName=<script>alert('xss');</script>&elementId=title_1`
==> an alert appears if there is a security issue