### PR TITLE
fix(clapi) fix services dependencies comment export

### DIFF
--- a/www/class/centreon-clapi/centreonDependency.class.php
+++ b/www/class/centreon-clapi/centreonDependency.class.php
@@ -380,7 +380,8 @@ class CentreonDependency extends CentreonObject
             if (in_array($params[1], array('comment', 'name', 'description')) && !preg_match("/^dep_/", $params[1])) {
                 $params[1] = "dep_" . $params[1];
             }
-            $updateParams = array($params[1] => $params[2]);
+            $params[2] = str_replace("<br/>", "\n", $params[2]);
+            $updateParams = array($params[1] => htmlentities($params[2], ENT_QUOTES, "UTF-8"));
             $updateParams['objectId'] = $objectId;
             return $updateParams;
         } else {
@@ -1209,6 +1210,7 @@ class CentreonDependency extends CentreonObject
                         continue;
                     }
                     // setparam
+                    $v = CentreonUtils::convertLineBreak($v);
                     echo
                         implode(
                             $this->delim,
@@ -1217,7 +1219,7 @@ class CentreonDependency extends CentreonObject
                                 'SETPARAM',
                                 $row['dep_name'],
                                 $k,
-                                $v,
+                                html_entity_decode($v, ENT_QUOTES, "UTF-8"),
                             )
                         ) . "\n";
                 }


### PR DESCRIPTION
## Description

User try to import CLAPI export containing carriage return, and it fails.
It fails on import, and on export it breaks comments containing carriage return, so comments aren’t full on export.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create a comment, on dependancy for example :

   1 Go to Configuration > Notifications > Services and create a new dependancy with comment containing carriage return (multiple line comment),
   2 Export with CLAPI,
   3 Delete your dependancy conf,
   4 First problem, the export file contain only the first line of the comment
   5 Modify your export, and add missing lines to this comment
   6 Import with CLAPI

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
