### PR TITLE
fix(build): temporary disable of centos 8 pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ try {
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh centos7"
         archiveArtifacts artifacts: 'rpms-centos7.tar.gz'
       }
-    },
+    }
     /*
     'centos8': {
       node {
@@ -150,7 +150,7 @@ try {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/web/${serie}/mon-web-bundle.sh centos7"
       }
-    },
+    }
     /*
     'centos8': {
       node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,7 @@ try {
         archiveArtifacts artifacts: 'rpms-centos7.tar.gz'
       }
     },
+    /*
     'centos8': {
       node {
         sh 'setup_centreon_build.sh'
@@ -137,6 +138,7 @@ try {
         archiveArtifacts artifacts: 'rpms-centos8.tar.gz'
       }
     }
+    */
     if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
       error('Package stage failure.');
     }
@@ -149,12 +151,14 @@ try {
         sh "./centreon-build/jobs/web/${serie}/mon-web-bundle.sh centos7"
       }
     },
+    /*
     'centos8': {
       node {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/web/${serie}/mon-web-bundle.sh centos8"
       }
     }
+    */
     if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
       error('Bundle stage failure.');
     }


### PR DESCRIPTION
## Description

net-snmp-perl-5.8-14.el8.2_1 is currently not available on centos8 ...

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Run CI