### PR TITLE
fix(monitoring): do not encode output in service details page

### DIFF
--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -383,7 +383,7 @@ if (!is_null($host_id)) {
                 $i++;
             }
         }
-        $service_status["plugin_output"] = utf8_encode($service_status["plugin_output"]);
+
         $service_status["plugin_output"] = str_replace("'", "", $service_status["plugin_output"]);
         $service_status["plugin_output"] = str_replace("\"", "", $service_status["plugin_output"]);
         $service_status["plugin_output"] = str_replace("\\n", "<br>", $service_status["plugin_output"]);


### PR DESCRIPTION
## Description

Do not encode output in utf8 in service details page

**Fixes** MON-5910 #6930

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Create a passive service
* Submit result with a chinese character in output
* Check service details page