### PR TITLE
fix(security): Sanitize servicegroups Inputs

### DIFF
--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -363,8 +363,9 @@ class CentreonHostgroups
             //As it happens that $v could be like "X,Y" when two hostgroups are selected, we added a second foreach
             $multiValues = explode(',', $v);
             foreach ($multiValues as $item) {
-                $listValues .= ':hgId_' . $item . ', ';
-                $queryValues['hgId_' . $item] = (int)$item;
+                $ids = explode('-', $item);
+                $listValues .= ':hgId_' . $ids[0] . ', ';
+                $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
             }
         }
         $listValues = rtrim($listValues, ', ');

--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -475,4 +475,22 @@ class CentreonUtils
         }
         return $occurrences;
     }
+
+    /**
+     *
+     * @param $coords -90.0,180.0
+     * @return bool
+     */
+    public static function validateGeoCoords($coords): bool
+    {
+        if (
+            preg_match(
+                '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/',
+                $coords
+            )
+        ) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -207,7 +207,6 @@ function multipleServiceGroupInDB($serviceGroups = [], $nbrDup = [])
                     $statement->execute();
                     $fields["sg_hgServices"] = "";
                     while ($service = $statement->fetch()) {
-                        $val = null;
                         $bindParams = [];
                         foreach ($service as $key2 => $value2) {
                             switch ($key2) {
@@ -231,9 +230,6 @@ function multipleServiceGroupInDB($serviceGroups = [], $nbrDup = [])
                                     break;
                             }
                             $bindParams[':servicegroup_sg_id'] = [\PDO::PARAM_INT => $maxId["MAX(sg_id)"]];
-                            $val
-                                ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                                : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
                         }
                         $statement2 = $pearDB->prepare("
                             INSERT INTO servicegroup_relation

--- a/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -457,7 +457,7 @@ function updateServiceGroupServices($sgId, $ret = [], $increment = false)
 
     $sgId = filter_var($sgId, FILTER_VALIDATE_INT);
 
-    if ($increment == false) {
+    if ($increment == false && $sgId !== false) {
         $statement = $pearDB->prepare("
             DELETE FROM servicegroup_relation
             WHERE servicegroup_sg_id = :sg_id

--- a/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -154,12 +154,7 @@ function multipleServiceGroupInDB($serviceGroups = [], $nbrDup = [])
                             : $bindParams[':sg_comment'] = [\PDO::PARAM_NULL => null];
                         break;
                     case 'geo_coords':
-                        $value2 = filter_var($value2, FILTER_VALIDATE_REGEXP, [
-                            "options" => [
-                                "regexp" => "/^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$/"
-                            ]
-                        ]);
-                        $value2
+                        centreonUtils::validateGeoCoords($value2)
                             ? $bindParams[':geo_coords'] = [\PDO::PARAM_STR => $value2]
                             : $bindParams[':geo_coords'] = [\PDO::PARAM_NULL => null];
                         break;
@@ -306,12 +301,7 @@ function insertServiceGroup($ret = [])
                     : $bindParams[':sg_comment'] = [\PDO::PARAM_NULL => null];
                 break;
             case 'geo_coords':
-                $value = filter_var($value, FILTER_VALIDATE_REGEXP, [
-                    "options" => [
-                        "regexp" => "/^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$/"
-                    ]
-                ]);
-                $value
+                centreonUtils::validateGeoCoords($value)
                     ? $bindParams[':geo_coords'] = [\PDO::PARAM_STR => $value]
                     : $bindParams[':geo_coords'] = [\PDO::PARAM_NULL => null];
                 break;
@@ -388,12 +378,7 @@ function updateServiceGroup($sgId, $ret = [])
                     : $bindParams[':sg_comment'] = [\PDO::PARAM_NULL => null];
                 break;
             case 'geo_coords':
-                $value = filter_var($value, FILTER_VALIDATE_REGEXP, [
-                    "options" => [
-                        "regexp" => "/^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$/"
-                    ]
-                ]);
-                $value
+                centreonUtils::validateGeoCoords($value)
                     ? $bindParams[':geo_coords'] = [\PDO::PARAM_STR => $value]
                     : $bindParams[':geo_coords'] = [\PDO::PARAM_NULL => null];
                 break;

--- a/www/include/configuration/configObject/servicegroup/serviceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/serviceGroup.php
@@ -79,7 +79,7 @@ $sgString = implode(',', array_map('mywrap', array_keys($sgs)));
 switch ($o) {
     case "a":
         require_once($path . "formServiceGroup.php");
-        break; #Add a Servicegroup
+        break; //Add a Servicegroup
     case "w":
         require_once($path . "formServiceGroup.php");
         break; //Watch a Servicegroup

--- a/www/include/configuration/configObject/servicegroup/serviceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/serviceGroup.php
@@ -95,11 +95,11 @@ switch ($o) {
         require_once($path."listServiceGroup.php");
         break; #Desactivate a Servicegroup
     case "m":
-        multipleServiceGroupInDB(isset($select) ? $select : array(), $dupNbr);
+        multipleServiceGroupInDB(isset($select) ? $select : [], $dupNbr);
         require_once($path."listServiceGroup.php");
         break; #Duplicate n Service grou
     case "d":
-        deleteServiceGroupInDB(isset($select) ? $select : array());
+        deleteServiceGroupInDB(isset($select) ? $select : []);
         require_once($path."listServiceGroup.php");
         break; #Delete n Service group
     default:

--- a/www/include/configuration/configObject/servicegroup/serviceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/serviceGroup.php
@@ -57,7 +57,7 @@ $path = "./include/configuration/configObject/servicegroup/";
 /*
  * PHP functions
  */
-require_once $path."DB-Func.php";
+require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
 /* Set the real page */
@@ -78,31 +78,31 @@ $sgString = implode(',', array_map('mywrap', array_keys($sgs)));
 
 switch ($o) {
     case "a":
-        require_once($path."formServiceGroup.php");
+        require_once($path . "formServiceGroup.php");
         break; #Add a Servicegroup
     case "w":
-        require_once($path."formServiceGroup.php");
+        require_once($path . "formServiceGroup.php");
         break; #Watch a Servicegroup
     case "c":
-        require_once($path."formServiceGroup.php");
+        require_once($path . "formServiceGroup.php");
         break; #Modify a Servicegroup
     case "s":
         enableServiceGroupInDB($sg_id);
-        require_once($path."listServiceGroup.php");
+        require_once($path . "listServiceGroup.php");
         break; #Activate a Servicegroup
     case "u":
         disableServiceGroupInDB($sg_id);
-        require_once($path."listServiceGroup.php");
+        require_once($path . "listServiceGroup.php");
         break; #Desactivate a Servicegroup
     case "m":
         multipleServiceGroupInDB(isset($select) ? $select : [], $dupNbr);
-        require_once($path."listServiceGroup.php");
+        require_once($path . "listServiceGroup.php");
         break; #Duplicate n Service grou
     case "d":
         deleteServiceGroupInDB(isset($select) ? $select : []);
-        require_once($path."listServiceGroup.php");
+        require_once($path . "listServiceGroup.php");
         break; #Delete n Service group
     default:
-        require_once($path."listServiceGroup.php");
+        require_once($path . "listServiceGroup.php");
         break;
 }

--- a/www/include/configuration/configObject/servicegroup/serviceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/serviceGroup.php
@@ -82,26 +82,26 @@ switch ($o) {
         break; #Add a Servicegroup
     case "w":
         require_once($path . "formServiceGroup.php");
-        break; #Watch a Servicegroup
+        break; //Watch a Servicegroup
     case "c":
         require_once($path . "formServiceGroup.php");
-        break; #Modify a Servicegroup
+        break; //Modify a Servicegroup
     case "s":
         enableServiceGroupInDB($sg_id);
         require_once($path . "listServiceGroup.php");
-        break; #Activate a Servicegroup
+        break; //Activate a Servicegroup
     case "u":
         disableServiceGroupInDB($sg_id);
         require_once($path . "listServiceGroup.php");
-        break; #Desactivate a Servicegroup
+        break; //Desactivate a Servicegroup
     case "m":
         multipleServiceGroupInDB(isset($select) ? $select : [], $dupNbr);
         require_once($path . "listServiceGroup.php");
-        break; #Duplicate n Service grou
+        break; //Duplicate n Service grou
     case "d":
         deleteServiceGroupInDB(isset($select) ? $select : []);
         require_once($path . "listServiceGroup.php");
-        break; #Delete n Service group
+        break; //Delete n Service group
     default:
         require_once($path . "listServiceGroup.php");
         break;


### PR DESCRIPTION
## Description

This PR sanitize the differents input for service group form

**Fixes** MON-5520

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
