### PR TITLE
fix(widget): correct updateWidgetPositions variable name

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -731,22 +731,20 @@ class CentreonWidget
         if (empty($customViewId)) {
             throw new CentreonWidgetException('No custom view id provided');
         }
-        if (!empty($position) && is_array($position)) {
-            foreach ($position as $rawData) {
-                if (preg_match('/([0-9]+)_([0-9]+)_([0-9]+)/', $rawData, $matches)) {
-                    $widgetOrder = "{$matches[1]}_{$matches[2]}";
-                    $widgetId = $matches[3];
+        foreach ($position as $rawData) {
+            if (preg_match('/([0-9]+)_([0-9]+)_([0-9]+)/', $rawData, $matches)) {
+                $widgetOrder = "{$matches[1]}_{$matches[2]}";
+                $widgetId = $matches[3];
 
-                    $query = 'UPDATE widget_views SET widget_order = :widgetOrder ' .
-                        'WHERE custom_view_id = :viewId ' .
-                        'AND widget_id = :widgetId';
-                    $stmt = $this->db->prepare($query);
-                    $stmt->bindParam(':widgetOrder', $widgetOrder, PDO::PARAM_STR);
-                    $stmt->bindParam(':viewId', $customViewId, PDO::PARAM_INT);
-                    $stmt->bindParam(':widgetId', $widgetId, PDO::PARAM_INT);
-                    $dbResult = $stmt->execute();
-
-                }
+                $stmt = $this->db->prepare('
+                    UPDATE widget_views SET widget_order = :widgetOrder
+                    WHERE custom_view_id = :viewId
+                    AND widget_id = :widgetId
+                ');
+                $stmt->bindParam(':widgetOrder', $widgetOrder, PDO::PARAM_STR);
+                $stmt->bindParam(':viewId', $customViewId, PDO::PARAM_INT);
+                $stmt->bindParam(':widgetId', $widgetId, PDO::PARAM_INT);
+                $stmt->execute();
             }
         }
     }

--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -731,8 +731,8 @@ class CentreonWidget
         if (empty($customViewId)) {
             throw new CentreonWidgetException('No custom view id provided');
         }
-        if (!empty($positions) && is_array($positions)) {
-            foreach ($positions as $rawData) {
+        if (!empty($position) && is_array($position)) {
+            foreach ($position as $rawData) {
                 if (preg_match('/([0-9]+)_([0-9]+)_([0-9]+)/', $rawData, $matches)) {
                     $widgetOrder = "{$matches[1]}_{$matches[2]}";
                     $widgetId = $matches[3];


### PR DESCRIPTION
## Description

The variable name differs from the method's argument. Resulting in a loop never used

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check that the widget position are properly computed
