### PR TITLE
fix(widget): correct widget and view relation

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -487,9 +487,10 @@ class CentreonWidget
 
     /**
      * @param int $viewId
+     * @param array $widgetList
      * @throws Exception
      */
-    public function udpateViewWidgetRelations($viewId)
+    public function udpateViewWidgetRelations($viewId, array $widgetList = [])
     {
         $query = 'DELETE FROM widget_views WHERE custom_view_id = :viewId';
         $stmt = $this->db->prepare($query);


### PR DESCRIPTION
## Description

a recent PR deleted an argument required to be able to update the relation between the custom views and the widgets.
Currently the method called by action.php + 232, delete the relations and do not insert them.

The LTS 20.04, 19.04 and 19.10 have been released with this behavior

**Fixes** # (MON-5951)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)