### PR TITLE
fix(security): don't display password value as plain text in Administration Logs menu

### DIFF
--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -288,7 +288,7 @@ class CentreonLogAction
                         $field['field_value'] = implode(',', $macroValueArray);
                         // same thing here but for the "Before" Value, and handle special case where no macro are set
                         if (
-                            isset($ref[$field["field_name"]]) 
+                            isset($ref[$field["field_name"]])
                             && !empty(str_replace(',','',$ref[$field["field_name"]]))
                         ) {
                             foreach ($macroPasswordRef as $macroIdPassword) {

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -32,6 +32,7 @@
  * For more information : contact@centreon.com
  *
  */
+require_once(__DIR__ . '/centreonAuth.class.php');
 
 class CentreonLogAction
 {

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -278,7 +278,10 @@ class CentreonLogAction
             while ($field = $DBRESULT2->fetchRow()) {
                 switch ($field['field_name']) {
                     case 'macroValue':
-                        // explode the macroValue string to easily change any password type to ******
+                        /**
+                         * explode the macroValue string to easily change any password to ****** on the "After" part
+                         * of the changeLog
+                         */
                         $macroValueArray = explode(',', $field['field_value']);
                         foreach ($macroPasswordRef as $macroIdPassword) {
                             if (!empty($macroValueArray[$macroIdPassword])) {
@@ -286,7 +289,10 @@ class CentreonLogAction
                             }
                         }
                         $field['field_value'] = implode(',', $macroValueArray);
-                        // same thing here but for the "Before" Value, and handle special case where no macro are set
+                        /**
+                         * change any password to ****** on the "Before" part of the changeLog and don't change anything
+                         *  if the 'macroValue' string only contains commas
+                         */
                         if (
                             isset($ref[$field["field_name"]])
                             && !empty(str_replace(',','',$ref[$field["field_name"]]))

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -287,7 +287,10 @@ class CentreonLogAction
                         }
                         $field['field_value'] = implode(',', $macroValueArray);
                         // same thing here but for the "Before" Value, and handle special case where no macro are set
-                        if (isset($ref[$field["field_name"]]) && $ref[$field["field_name"]] !== ',,,,,,,,,') {
+                        if (
+                            isset($ref[$field["field_name"]]) 
+                            && !empty(str_replace(',','',$ref[$field["field_name"]]))
+                        ) {
                             foreach ($macroPasswordRef as $macroIdPassword) {
                                 $macroValueArray[$macroIdPassword] = self::PASSWORD_BEFORE;
                             }

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -389,13 +389,13 @@ class CentreonLogAction
             foreach ($ret as $key => $value) {
                 if (!isset($uselessKey[trim($key)])) {
                     if (is_array($value)) {
-                        if($key === 'macroValue' && isset($ret['macroPassword'])) {
-                            foreach(array_keys($value) as $macroId) {
+                        if ($key === 'macroValue' && isset($ret['macroPassword'])) {
+                            foreach (array_keys($value) as $macroId) {
                                 /*
                                  * Set a new refMacroPassword value to be able to find which macro index is a password
                                  * in the listModification method
                                  */
-                                if(array_key_exists($macroId, $ret['macroPassword'])) {
+                                if (array_key_exists($macroId, $ret['macroPassword'])) {
                                     $info['refMacroPassword'] = implode(",", array_keys($ret['macroPassword']));
                                 }
                             }

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -43,7 +43,7 @@ class CentreonLogAction
      * Const use to keep the chnagelog mechanism with hidden password values
      */
     const PASSWORD_BEFORE = '*******';
-    const PASSWORD_AFTER = '******';
+    const PASSWORD_AFTER = CentreonAuth::PWS_OCCULTATION;
     /*
      * Initializes variables
      */

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -40,7 +40,7 @@ class CentreonLogAction
     protected $uselessKey;
 
     /**
-     * Const use to keep the chnagelog mechanism with hidden password values
+     * Const use to keep the changelog mechanism with hidden password values
      */
     const PASSWORD_BEFORE = '*******';
     const PASSWORD_AFTER = '******';
@@ -295,7 +295,7 @@ class CentreonLogAction
                          */
                         if (
                             isset($ref[$field["field_name"]])
-                            && !empty(str_replace(',','',$ref[$field["field_name"]]))
+                            && !empty(str_replace(',', '', $ref[$field["field_name"]]))
                         ) {
                             foreach ($macroPasswordRef as $macroIdPassword) {
                                 $macroValueArray[$macroIdPassword] = self::PASSWORD_BEFORE;

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -389,12 +389,12 @@ class CentreonLogAction
             foreach ($ret as $key => $value) {
                 if (!isset($uselessKey[trim($key)])) {
                     if (is_array($value)) {
+                        /*
+                         * Set a new refMacroPassword value to be able to find which macro index is a password
+                         * in the listModification method
+                         */
                         if ($key === 'macroValue' && isset($ret['macroPassword'])) {
                             foreach (array_keys($value) as $macroId) {
-                                /*
-                                 * Set a new refMacroPassword value to be able to find which macro index is a password
-                                 * in the listModification method
-                                 */
                                 if (array_key_exists($macroId, $ret['macroPassword'])) {
                                     $info['refMacroPassword'] = implode(",", array_keys($ret['macroPassword']));
                                 }

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -290,8 +290,8 @@ class CentreonLogAction
                         }
                         $field['field_value'] = implode(',', $macroValueArray);
                         /**
-                         * change any password to ****** on the "Before" part of the changeLog and don't change anything
-                         *  if the 'macroValue' string only contains commas
+                         * change any password to ****** on the "Before" part of the changeLog
+                         * and don't change anything if the 'macroValue' string only contains commas
                          */
                         if (
                             isset($ref[$field["field_name"]])


### PR DESCRIPTION
## Description

This PR replace the plain text value by "******" for macro values marked as password or contact password in Logs menu.

**Fixes** #Mon-4541

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
