### PR TITLE
fix(security): don't display password value as plain text in Administration Logs menu 2.8.x

### DIFF
--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -295,7 +295,7 @@ class CentreonLogAction
                              */
                             if (
                                 isset($ref[$field["field_name"]])
-                                && !str_replace(',','',$ref[$field["field_name"]])
+                                && !str_replace(',', '', $ref[$field["field_name"]])
                             ) {
                                 foreach ($macroPasswordRef as $macroIdPassword) {
                                     $macroValueArray[$macroIdPassword] = self::PASSWORD_BEFORE;

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -40,7 +40,7 @@ class CentreonLogAction
     protected $uselessKey;
 
     /**
-     * Const use to keep the chnagelog mechanism with hidden password values
+     * Const use to keep the changelog mechanism with hidden password values
      */
     const PASSWORD_BEFORE = '*******';
     const PASSWORD_AFTER = '******';

--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -39,10 +39,15 @@ class CentreonLogAction
     protected $logUser;
     protected $uselessKey;
 
+    /**
+     * Const use to keep the chnagelog mechanism with hidden password values
+     */
+    const PASSWORD_BEFORE = '*******';
+    const PASSWORD_AFTER = '******';
+
     /*
      * Initializes variables
      */
-
     public function __construct($usr)
     {
         $this->logUser = $usr;
@@ -199,7 +204,7 @@ class CentreonLogAction
     public function getHostName($host_id)
     {
         global $pearDB, $pearDBO;
-        
+
         $query = "SELECT host_name FROM host WHERE host_register = '1' AND host_id = ".$host_id;
         $DBRESULT2 = $pearDB->query($query);
         $info = $DBRESULT2->fetchRow();
@@ -219,7 +224,7 @@ class CentreonLogAction
     public function getHostGroupName($hg_id)
     {
         global $pearDB, $pearDBO;
-        
+
         $query = "SELECT hg_name FROM hostgroup WHERE hg_id = ".$hg_id;
         $DBRESULT2 = $pearDB->query($query);
         $info = $DBRESULT2->fetchRow();
@@ -239,39 +244,99 @@ class CentreonLogAction
     /*
      *  returns list of modifications
      */
-    public function listModification($id, $object_type)
+    public function listModification($id, $objectType)
     {
         global $pearDBO;
         $list_modifications = array();
         $ref = array();
         $i = 0;
+        $id = filter_var($id, FILTER_VALIDATE_INT);
+        $objectType = filter_var($objectType, FILTER_SANITIZE_STRING);
 
-        $DBRESULT = $pearDBO->query(
-            "SELECT action_log_id, action_log_date, action_type
-                FROM log_action
-                WHERE object_id = '" . CentreonDB::escape($id) . "'
-                AND object_type = '" . CentreonDB::escape($object_type) . "' ORDER BY action_log_date ASC"
-        );
-        while ($row = $DBRESULT->fetchRow()) {
-            $DBRESULT2 = $pearDBO->query(
-                "SELECT action_log_id,field_name,field_value
-                    FROM `log_action_modification`
-                    WHERE action_log_id='" . CentreonDB::escape($row['action_log_id']) . "'"
-            );
-            while ($field = $DBRESULT2->fetchRow()) {
-                if (!isset($ref[$field["field_name"]]) && $field["field_value"] != "") {
-                    $list_modifications[$i]["action_log_id"] = $field["action_log_id"];
-                    $list_modifications[$i]["field_name"] = $field["field_name"];
-                    $list_modifications[$i]["field_value_before"] = "";
-                    $list_modifications[$i]["field_value_after"] = $field["field_value"];
-                } elseif (isset($ref[$field["field_name"]]) && $ref[$field["field_name"]] != $field["field_value"]) {
-                    $list_modifications[$i]["action_log_id"] = $field["action_log_id"];
-                    $list_modifications[$i]["field_name"] = $field["field_name"];
-                    $list_modifications[$i]["field_value_before"] = $ref[$field["field_name"]];
-                    $list_modifications[$i]["field_value_after"] = $field["field_value"];
+        if ($id !== false) {
+            $statement = $pearDBO->prepare("
+                SELECT action_log_id, action_log_date, action_type
+                    FROM log_action
+                    WHERE object_id = ?
+                    AND object_type = ? ORDER BY action_log_date ASC
+            ");
+            $DBRESULT = $pearDBO->execute($statement, array($id, $objectType));
+            while ($row = $DBRESULT->fetchRow()) {
+                $DBRESULT2 = $pearDBO->query(
+                    "SELECT action_log_id,field_name,field_value
+                        FROM `log_action_modification`
+                        WHERE action_log_id = " . (int) $row['action_log_id']
+                );
+                $macroPasswordStatement = $pearDBO->query(
+                    "SELECT field_value
+                        FROM `log_action_modification`
+                        WHERE action_log_id = " . (int) $row['action_log_id'] . "
+                        AND field_name = 'refMacroPassword'"
+                );
+                $result = $macroPasswordStatement->fetchRow();
+                $macroPasswordRef = explode(',', $result['field_value']);
+                while ($field = $DBRESULT2->fetchRow()) {
+                    switch ($field['field_name']) {
+                        case 'macroValue':
+                            /**
+                             * explode the macroValue string to easily change any password to ****** on the "After" part
+                             * of the changeLog
+                             */
+                            $macroValueArray = explode(',', $field['field_value']);
+                            foreach ($macroPasswordRef as $macroIdPassword) {
+                                if (!empty($macroValueArray[$macroIdPassword])) {
+                                    $macroValueArray[$macroIdPassword] = self::PASSWORD_AFTER;
+                                }
+                            }
+                            $field['field_value'] = implode(',', $macroValueArray);
+                            /**
+                             * change any password to ****** on the "Before" part of the changeLog
+                             * and don't change anything if the 'macroValue' string only contains commas
+                             */
+                            if (
+                                isset($ref[$field["field_name"]])
+                                && !str_replace(',','',$ref[$field["field_name"]])
+                            ) {
+                                foreach ($macroPasswordRef as $macroIdPassword) {
+                                    $macroValueArray[$macroIdPassword] = self::PASSWORD_BEFORE;
+                                }
+                                $ref[$field["field_name"]] = implode(',', $macroValueArray);
+                            }
+                            break;
+                        case 'contact_passwd':
+                        case 'contact_passwd2':
+                            $field['field_value'] = self::PASSWORD_AFTER;
+                            if (isset($ref[$field["field_name"]])) {
+                                $ref[$field["field_name"]] = self::PASSWORD_BEFORE;
+                            }
+                    }
+                    if (!isset($ref[$field["field_name"]]) && $field["field_value"] != "") {
+                        $list_modifications[$i]["action_log_id"] = $field["action_log_id"];
+                        $list_modifications[$i]["field_name"] = $field["field_name"];
+                        $list_modifications[$i]["field_value_before"] = "";
+                        $list_modifications[$i]["field_value_after"] = $field["field_value"];
+                        foreach ($macroPasswordRef as $macroPasswordId) {
+                            // handle the display modification for the fields macroOldValue_n while nothing was set before
+                            if (strpos($field["field_name"], 'macroOldValue_' . $macroPasswordId) !== false) {
+                                $list_modifications[$i]["field_value_after"] = self::PASSWORD_AFTER;
+                            }
+                        }
+                    } elseif (isset($ref[$field["field_name"]]) && $ref[$field["field_name"]] != $field["field_value"]) {
+                        $list_modifications[$i]["action_log_id"] = $field["action_log_id"];
+                        $list_modifications[$i]["field_name"] = $field["field_name"];
+                        $list_modifications[$i]["field_value_before"] = $ref[$field["field_name"]];
+                        $list_modifications[$i]["field_value_after"] = $field["field_value"];
+                        foreach ($macroPasswordRef as $macroPasswordId) {
+                            // handle the display modification for the fields macroOldValue_n for "Before" and "After" value
+                            if (strpos($field["field_name"], 'macroOldValue_' . $macroPasswordId) !== false) {
+                                $list_modifications[$i]["field_value_before"] = self::PASSWORD_BEFORE;
+                                $list_modifications[$i]["field_value_after"] = self::PASSWORD_AFTER;
+                            }
+                        }
+                    }
+                    $ref[$field["field_name"]] = $field["field_value"];
+                    $i++;
                 }
-                $ref[$field["field_name"]] = $field["field_value"];
-                $i++;
             }
         }
         return $list_modifications;
@@ -349,9 +414,27 @@ class CentreonLogAction
             return array();
         } else {
             $info = array();
+            $oldMacroPassword = array();
             foreach ($ret as $key => $value) {
                 if (!isset($uselessKey[trim($key)])) {
                     if (is_array($value)) {
+                        /*
+                         * Set a new refMacroPassword value to be able to find which macro index is a password
+                         * in the listModification method and hash password in log_action_modification table
+                         */
+                        if ($key === 'macroValue' && isset($ret['macroPassword'])) {
+                            foreach ($value as $macroId => $macroValue) {
+                                if (array_key_exists($macroId, $ret['macroPassword'])) {
+                                    $info['refMacroPassword'] = implode(",", array_keys($ret['macroPassword']));
+                                    $value[$macroId] = md5($macroValue);
+                                    if (!empty($ret['macroOldValue_' . $macroId])) {
+                                        $oldMacroPassword['macroOldValue_' . $macroId] = md5(
+                                            $ret['macroOldValue_' . $macroId]
+                                        );
+                                    }
+                                }
+                            }
+                        }
                         if (isset($value[$key])) {
                             $info[$key] = $value[$key];
                         } else {
@@ -362,6 +445,9 @@ class CentreonLogAction
                     }
                 }
             }
+        }
+        foreach ($oldMacroPassword as $oldMacroPasswordName => $oldMacroPasswordValue) {
+            $info[$oldMacroPasswordName] = $oldMacroPasswordValue;
         }
         return $info;
     }


### PR DESCRIPTION
## Description

This PR replace the plain text value by "******" for macro values marked as password or contact password in Logs menu.

**Fixes** #MON-4541

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
