### PR TITLE
fix(secu): correct ACL on returned user list

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15529,3 +15529,6 @@ msgstr "Le server du type Central : '%s'@'%s' ne correspond pas à celui configu
 
 msgid "Missing mandatory parent address, to link the platform : '%s'@'%s'"
 msgstr "Adresse du server parent manquante, pour pouvoir lier la plateforme : '%s'@'%s'"
+
+msgid "An error occurred while retrieving users linked to ViewId on database"
+msgstr "Une erreur est survenue lors de la récupération en DB des utilisateurs liés à ViewId"

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -1070,10 +1070,10 @@ class CentreonCustomView
             $allowedContactIds = '';
             foreach (array_keys($aclListOfContactIds) as $contactId) {
                 // result concatenation
-                if ('' !== $allowedContactIds) {
-                    $allowedContactIds .= ', ';
-                }
                 if (false !== filter_var($contactId, FILTER_VALIDATE_INT)) {
+                    if ('' !== $allowedContactIds) {
+                        $allowedContactIds .= ', ';
+                    }
                     $allowedContactIds .= $contactId;
                 }
             }

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -1073,7 +1073,10 @@ class CentreonCustomView
                 if ('' !== $aclListOfContacts) {
                     $aclListOfContacts .= ', ';
                 }
-                $aclListOfContacts .= implode(',', $contactIdAsArray);
+                $contactIdAsArray .= implode(',', $contactIdAsArray);
+                if (false !== filter_var($contactIdAsArray, FILTER_VALIDATE_INT)) {
+                    $aclListOfContacts .= $contactIdAsArray;
+                }
             }
 
             /**

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -1044,27 +1044,28 @@ class CentreonCustomView
     }
 
     /**
-     * @param $viewId
+     * @param int $viewId
      * @return array
      * @throws Exception
      */
-    public function getUsersFromViewId($viewId)
+    public function getUsersFromViewId(int $viewId)
     {
         static $userList;
 
         if (!isset($userList)) {
             $userList = array();
-            $query = 'SELECT contact_name, user_id, locked ' .
-                'FROM contact c, custom_view_user_relation cvur ' .
-                'WHERE c.contact_id = cvur.user_id ' .
-                'AND cvur.custom_view_id = :viewId ' .
-                'AND cvur.is_share = 1 ' .
-                'ORDER BY contact_name';
-            $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
+            $stmt = $this->db->prepare(
+                'SELECT contact_name, user_id, locked
+                FROM contact c, custom_view_user_relation cvur
+                WHERE c.contact_id = cvur.user_id
+                AND cvur.custom_view_id = :viewId
+                AND cvur.is_share = 1
+                ORDER BY contact_name'
+            );
+            $stmt->bindParam(':viewId', $viewId, \PDO::PARAM_INT);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
-                throw new \Exception("An error occured");
+                throw new \Exception(_("An error occurred while retrieving users linked to ViewId on database"));
             }
             while ($row = $stmt->fetch()) {
                 $userList[$row['user_id']]['contact_name'] = $row['contact_name'];

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -1068,12 +1068,11 @@ class CentreonCustomView
             );
 
             $allowedContactIds = '';
-            foreach ($aclListOfContactIds as $contactId) {
+            foreach (array_keys($aclListOfContactIds) as $contactId) {
                 // result concatenation
                 if ('' !== $allowedContactIds) {
                     $allowedContactIds .= ', ';
                 }
-                $contactId .= implode(',', $contactId);
                 if (false !== filter_var($contactId, FILTER_VALIDATE_INT)) {
                     $allowedContactIds .= $contactId;
                 }

--- a/www/include/configuration/configObject/contact/contact.php
+++ b/www/include/configuration/configObject/contact/contact.php
@@ -42,6 +42,33 @@ if (!isset($centreon)) {
     exit();
 }
 
+// LDAP import form
+const LDAP_IMPORT_FORM = 'li';
+// Massive Change
+const MASSIVE_CHANGE = 'mc';
+// Add a contact
+const ADD_CONTACT = 'a';
+// Watch a contact
+const WATCH_CONTACT = 'w';
+// Modify a contact
+const MODIFY_CONTACT = 'c';
+// Activate a contact
+const ACTIVATE_CONTACT = 's';
+// Massive activate on selected contacts
+const MASSIVE_ACTIVATE_CONTACT = 'ms';
+// Deactivate a contact
+const DEACTIVATE_CONTACT = 'u';
+// Massive deactivate on selected contacts
+const MASSIVE_DEACTIVATE_CONTACT = 'mu';
+// Duplicate n contacts and notify it
+const DUPLICATE_CONTACTS = 'm';
+// Delete n contacts and notify it
+const DELETE_CONTACTS = 'd';
+// display notification
+const DISPLAY_NOTIFICATION = 'dn';
+// Synchronize selected contacts with the LDAP
+const SYNC_LDAP_CONTACTS = 'sync';
+
 isset($_GET["contact_id"]) ? $cG = $_GET["contact_id"] : $cG = null;
 isset($_POST["contact_id"]) ? $cP = $_POST["contact_id"] : $cP = null;
 $cG ? $contactId = $cG : $contactId = $cP;
@@ -137,42 +164,32 @@ $eventDispatcher->addEventHandler(
 );
 
 switch ($o) {
-    case "li":
-        // LDAP import form
+    case LDAP_IMPORT_FORM:
         require_once($path . "ldapImportContact.php");
         break;
-    case "mc":
-        // Massive Change
-    case "a":
-        // Add a contact
-    case "w":
-        // Watch a contact
-    case "c":
-        // Modify a contact
+    case MASSIVE_CHANGE:
+    case ADD_CONTACT:
+    case WATCH_CONTACT:
+    case MODIFY_CONTACT:
         require_once($path . "formContact.php");
         break;
-    case "s":
-        // Activate a contact
+    case ACTIVATE_CONTACT:
         enableContactInDB($contactId);
         require_once($path . "listContact.php");
         break;
-    case "ms":
-        // Massive activate on selected contacts
+    case MASSIVE_ACTIVATE_CONTACT:
         enableContactInDB(null, isset($select) ? $select : array());
         require_once($path . "listContact.php");
         break;
-    case "u":
-        // Deactivate a contact
+    case DEACTIVATE_CONTACT:
         disableContactInDB($contactId);
         require_once($path . "listContact.php");
         break;
-    case "mu":
-        // Massive deactivate on selected contacts
+    case MASSIVE_DEACTIVATE_CONTACT:
         disableContactInDB(null, isset($select) ? $select : array());
         require_once($path . "listContact.php");
         break;
-    case "m":
-        // Duplicate n contacts and notify it
+    case DUPLICATE_CONTACTS:
         $eventDispatcher->notify(
             'contact.form',
             EventDispatcher::EVENT_DUPLICATE,
@@ -183,8 +200,7 @@ switch ($o) {
         );
         require_once($path . "listContact.php");
         break;
-    case "d":
-        // Delete n contacts and notify it
+    case DELETE_CONTACTS:
         $eventDispatcher->notify(
             'contact.form',
             EventDispatcher::EVENT_DELETE,
@@ -192,11 +208,10 @@ switch ($o) {
         );
         require_once($path . "listContact.php");
         break;
-    case "dn":
+    case DISPLAY_NOTIFICATION:
         require_once $path . 'displayNotification.php';
         break;
-    case "sync":
-        // Synchronize selected contacts with the LDAP
+    case SYNC_LDAP_CONTACTS:
         $eventDispatcher->notify(
             'contact.form',
             EventDispatcher::EVENT_SYNCHRONIZE,

--- a/www/include/configuration/configObject/contact/contact.php
+++ b/www/include/configuration/configObject/contact/contact.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -58,9 +59,6 @@ $cG ? $dupNbr = $cG : $dupNbr = $cP;
  */
 $path = "./include/configuration/configObject/contact/";
 
-/*
- * PHP functions
- */
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
@@ -143,35 +141,36 @@ switch ($o) {
         require_once($path . "ldapImportContact.php");
         break; # LDAP import form	# Wistof
     case "mc":
-        require_once($path . "formContact.php");
-        break; # Massive Change
+        // Massive Change
     case "a":
+        // Add a contact
         require_once($path . "formContact.php");
-        break; #Add a contact
     case "w":
-        require_once($path . "formContact.php");
-        break; #Watch a contact
+        // Watch a contact
     case "c":
+        // Modify a contact
         require_once($path . "formContact.php");
-        break; #Modify a contact
+        break;
     case "s":
+        // Activate a contact
         enableContactInDB($contactId);
         require_once($path . "listContact.php");
-        break; #Activate a contact
+        break;
     case "ms":
         enableContactInDB(null, isset($select) ? $select : array());
         require_once($path . "listContact.php");
         break;
     case "u":
+        // Deactivate a contact
         disableContactInDB($contactId);
         require_once($path . "listContact.php");
-        break; #Desactivate a contact
+        break;
     case "mu":
         disableContactInDB(null, isset($select) ? $select : array());
         require_once($path . "listContact.php");
         break;
     case "m":
-        // We notify that we have made a duplicate
+        // Duplicate n contacts and notify it
         $eventDispatcher->notify(
             'contact.form',
             EventDispatcher::EVENT_DUPLICATE,
@@ -180,29 +179,29 @@ switch ($o) {
                 'numbers' => $dupNbr
             ]
         );
-
         require_once($path . "listContact.php");
-        break; #Duplicate n contacts
+        break;
     case "d":
-        // We notify that we have made a delete
+        // Delete n contacts and notify it
         $eventDispatcher->notify(
             'contact.form',
             EventDispatcher::EVENT_DELETE,
             ['contact_ids' => $select]
         );
         require_once($path . "listContact.php");
-        break; #Delete n contacts
+        break;
     case "dn":
         require_once $path . 'displayNotification.php';
         break;
     case "sync":
+        // Synchronize selected contacts with the LDAP
         $eventDispatcher->notify(
             'contact.form',
             EventDispatcher::EVENT_SYNCHRONIZE,
             ['contact_ids' => $select]
         );
         require_once($path . "listContact.php");
-        break; #Synchronize selected contacts with the LDAP
+        break;
     default:
         require_once($path . "listContact.php");
         break;

--- a/www/include/configuration/configObject/contact/contact.php
+++ b/www/include/configuration/configObject/contact/contact.php
@@ -138,13 +138,13 @@ $eventDispatcher->addEventHandler(
 
 switch ($o) {
     case "li":
+        // LDAP import form
         require_once($path . "ldapImportContact.php");
-        break; # LDAP import form	# Wistof
+        break;
     case "mc":
         // Massive Change
     case "a":
         // Add a contact
-        require_once($path . "formContact.php");
     case "w":
         // Watch a contact
     case "c":
@@ -157,6 +157,7 @@ switch ($o) {
         require_once($path . "listContact.php");
         break;
     case "ms":
+        // Massive activate on selected contacts
         enableContactInDB(null, isset($select) ? $select : array());
         require_once($path . "listContact.php");
         break;
@@ -166,6 +167,7 @@ switch ($o) {
         require_once($path . "listContact.php");
         break;
     case "mu":
+        // Massive deactivate on selected contacts
         disableContactInDB(null, isset($select) ? $select : array());
         require_once($path . "listContact.php");
         break;

--- a/www/include/home/customViews/action.php
+++ b/www/include/home/customViews/action.php
@@ -34,7 +34,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../../../config/centreon.config.php");
 require_once _CENTREON_PATH_ . "www/class/centreon.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonCustomView.class.php";
@@ -202,7 +202,7 @@ try {
     switch ($action) {
         case 'add':
             if (!empty($createLoad)) {
-                if ($createLoad == 'create') {
+                if ($createLoad === 'create') {
                     $postInputs['custom_view_id'] = $viewObj->addCustomView(
                         $postInputs['name'],
                         $postInputs['layout'],
@@ -212,7 +212,7 @@ try {
                     if ($postInputs['widget_id']) {
                         $widgetObj->updateViewWidgetRelations($postInputs['custom_view_id']);
                     }
-                } elseif ($createLoad == 'load' && !empty($postInputs['viewLoad'])) {
+                } elseif ($createLoad === 'load' && !empty($postInputs['viewLoad'])) {
                     $postInputs['custom_view_id'] = $viewObj->loadCustomView($postInputs['viewLoad'], $authorized);
                 }
             }
@@ -305,9 +305,10 @@ try {
             $_SESSION['customview_edit_mode'] = $_POST['editMode'];
             break;
         case 'get_share_info':
-            if (isset($_POST['viewId'])) {
-                $viewers = $viewObj->getUsersFromViewId($_POST['viewId']);
-                $viewerGroups = $viewObj->getUsergroupsFromViewId($_POST['viewId']);
+            $viewId = isset($_POST['viewId']) ? filter_var($_POST['viewId'], FILTER_VALIDATE_INT) : false;
+            if (false !== $viewId) {
+                $viewers = $viewObj->getUsersFromViewId($viewId);
+                $viewerGroups = $viewObj->getUsergroupsFromViewId($viewId);
                 $xml->startElement('contacts');
                 foreach ($viewers as $viewer) {
                     if ($viewer['user_id'] != $centreon->user->user_id) {


### PR DESCRIPTION
## Description

Returns only allowed user list on the internal API, called from the share view feature instead of the whole user list on the platform

**Fixes** # (MON-5530)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please contact me
