### PR TITLE
fix(sec): avoid sql injection in downtimes page

### DIFF
--- a/www/include/common/autoNumLimit.php
+++ b/www/include/common/autoNumLimit.php
@@ -43,9 +43,9 @@ $sessionLimitKey = "results_limit_{$url}";
 
 // Setting the limit filter
 if (isset($_POST['limit']) && $_POST['limit']) {
-    $limit = $_POST['limit'];
+    $limit = filter_input(INPUT_POST, 'limit', FILTER_VALIDATE_INT, ['options' => ['default' => 20]]);
 } elseif (isset($_GET['limit'])) {
-    $limit = $_GET['limit'];
+    $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, ['options' => ['default' => 20]]);
 } elseif ($limitNotInRequestParameter && $historyLimitNotDefault) {
     $limit = $centreon->historyLimit[$url];
 } elseif (isset($_SESSION[$sessionLimitKey])) {

--- a/www/include/monitoring/downtime/listDowntime.php
+++ b/www/include/monitoring/downtime/listDowntime.php
@@ -183,12 +183,14 @@ $request .= (isset($search_service) && $search_service != "" ? "AND 1 = 0 " : ""
         " AND d.comment_data NOT LIKE '%Downtime cycle%' " : "") .
     " AND d.author LIKE :author" .
     ") ORDER BY scheduled_start_time DESC " .
-    "LIMIT " . $num * $limit . ", " . $limit;
+    "LIMIT :offset, :limit";
 $downtimesStatement = $pearDBO->prepare($request);
 $downtimesStatement->bindValue(':service', '%' . $search_service . '%', \PDO::PARAM_STR);
 $downtimesStatement->bindValue(':host', '%' . $host_name . '%', \PDO::PARAM_STR);
 $downtimesStatement->bindValue(':output', '%' . $search_output . '%', \PDO::PARAM_STR);
 $downtimesStatement->bindValue(':author', '%' . $search_author . '%', \PDO::PARAM_STR);
+$downtimesStatement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
+$downtimesStatement->bindValue(':limit', $limit, \PDO::PARAM_INT);
 $downtimesStatement->execute();
 
 $rows = $pearDBO->query("SELECT FOUND_ROWS()")->fetchColumn();

--- a/www/include/monitoring/downtime/listDowntime.php
+++ b/www/include/monitoring/downtime/listDowntime.php
@@ -181,7 +181,7 @@ $request .= (isset($search_service) && $search_service != "" ? "AND 1 = 0 " : ""
     (isset($view_all) && $view_all == 0 ? "AND d.end_time > '" . time() . "' " : "") .
     (isset($view_downtime_cycle) && $view_downtime_cycle == 0 ?
         " AND d.comment_data NOT LIKE '%Downtime cycle%' " : "") .
-    (isset($search_author) && $search_author != "" ? " AND d.author LIKE :author" : "") .
+    " AND d.author LIKE :author" .
     ") ORDER BY scheduled_start_time DESC " .
     "LIMIT " . $num * $limit . ", " . $limit;
 $downtimesStatement = $pearDBO->prepare($request);
@@ -195,10 +195,10 @@ $rows = $pearDBO->query("SELECT FOUND_ROWS()")->fetchColumn();
 
 for ($i = 0; $data = $downtimesStatement->fetchRow(); $i++) {
     $tab_downtime_svc[$i] = $data;
-    
+
     $tab_downtime_svc[$i]['comment_data'] =
         CentreonUtils::escapeAllExceptSelectedTags($data['comment_data']);
-    
+
     $tab_downtime_svc[$i]['scheduled_start_time'] = $tab_downtime_svc[$i]["scheduled_start_time"] . " ";
     $tab_downtime_svc[$i]['scheduled_end_time'] = $tab_downtime_svc[$i]["scheduled_end_time"] . " ";
 


### PR DESCRIPTION
## Description

sanitize request parameters in downtimes page to avoid sql injection

**Fixes** MON-5913

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)