### PR TITLE
fix(api): fix global search in events view

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -83,7 +83,6 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         'last_status_change' => 'resource.last_status_change',
         'tries' => 'resource.tries',
         'last_check' => 'resource.last_check',
-        'information' => 'resource.information',
         'h.group' => 'hg.name',
         'h.group.id' => 'hhg.hostgroup_id',
     ];


### PR DESCRIPTION
## Description

only `information` column was filtered when used global search in events view

**Fixes** MON-5980

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check search bar in events view page