### PR TITLE
fix(graph): avoid B unit in y axis

### DIFF
--- a/www/include/views/graphs/javascript/centreon-graph.js
+++ b/www/include/views/graphs/javascript/centreon-graph.js
@@ -671,7 +671,7 @@
      */
     roundTickByte: function (value) {
       if (value < 0) {
-          return '-' + numeral(value).format('0.0[0]0ib').replace(/i?B/, '');
+          return '-' + numeral(Math.abs(value)).format('0.0[0]0ib').replace(/i?B/, '');
       }
       return numeral(value).format('0.0[0]0ib').replace(/i?B/, '');
     },

--- a/www/include/views/graphs/javascript/centreon-graph.js
+++ b/www/include/views/graphs/javascript/centreon-graph.js
@@ -671,9 +671,9 @@
      */
     roundTickByte: function (value) {
       if (value < 0) {
-          return '-' + numeral(Math.abs(value)).format('0.0[0]0ib').replace(/iB/, 'B');
+          return '-' + numeral(value).format('0.0[0]0ib').replace(/i?B/, '');
       }
-      return numeral(value).format('0.0[0]0ib').replace(/iB/, 'B');
+      return numeral(value).format('0.0[0]0ib').replace(/i?B/, '');
     },
     /**
      * Get base for 1000 or 1024 for a curve
@@ -681,7 +681,7 @@
      * @param {String} id - The curve id
      * @return {Integer} - 1000 or 1024
      */
-    getBase: function (id) {
+    getBase: function () {
       if (this.chartData.global.base) {
         return this.chartData.global.base;
       }


### PR DESCRIPTION
## Description

Avoid x axis to display `B` if base is 1024

**Fixes** MON-5814

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
