### PR TITLE
enh(menu): rename events view to resources status

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15535,3 +15535,6 @@ msgstr "Une erreur est survenue lors de la récupération en DB des utilisateurs
 
 msgid "An error occurred while retrieving groups linked to ViewId on database"
 msgstr "Une erreur est survenue lors de la récupération en DB des groupes liés à ViewId"
+
+msgid "Resources Status"
+msgstr "Statut des ressources"

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -37,9 +37,9 @@
 class CentreonAuth
 {
     /**
-     * The default page has to be Events view
+     * The default page has to be Resources status
      */
-    public const DEFAULT_PAGE = 104;
+    public const DEFAULT_PAGE = 200;
     public const PWS_OCCULTATION = '******';
 
     // Declare Values

--- a/www/front_src/src/route-maps/route-map.js
+++ b/www/front_src/src/route-maps/route-map.js
@@ -9,7 +9,7 @@ const routeMap = {
   pollerList: '/main.php?p=60901',
   extensionsManagerPage: '/administration/extensions/manager',
   notAllowedPage: '/not-allowed',
-  resources: '/monitoring/events',
+  resources: '/monitoring/resources',
 };
 
 export default routeMap;

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -82,7 +82,7 @@ if ($o == "c") {
         $cct[$row['cp_key']] = $row['cp_value'];
     }
 
-    // selected by default is Events view page
+    // selected by default is Resources status page
     $cct['default_page'] = $cct['default_page'] ?: CentreonAuth::DEFAULT_PAGE;
 }
 

--- a/www/install/insertTopology.sql
+++ b/www/install/insertTopology.sql
@@ -185,7 +185,7 @@ INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_p
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`) VALUES ('Manager', '/administration/extensions/manager', '1', '1', 507, 50709, 1);
 
 -- Add unified view page entry
-INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`, `topology_order`) VALUES ('Events view (beta)', '/monitoring/events', '1', '1', 1, 104, 1, 2);
+INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`, `topology_order`) VALUES ('Resources Status', '/monitoring/resources', '1', '1', 2, 200, 1, 2);
 
 /*!40000 ALTER TABLE `topology` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/www/install/sql/centreon/Update-DB-20.10.0.sql
+++ b/www/install/sql/centreon/Update-DB-20.10.0.sql
@@ -9,3 +9,7 @@ CREATE TABLE IF NOT EXISTS `user_filter` (
     PRIMARY KEY (`id`),
     CONSTRAINT `filter_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Rename and move events view menu
+UPDATE `topology` SET `topology_name` = 'Resources Status', `topology_url` = '/monitoring/resources', `topology_parent` = 2, `topology_page` = 200 WHERE `topology_page` = 104;
+UPDATE `contact` SET `default_page` = 200 WHERE `default_page` = 104;


### PR DESCRIPTION
## Description

* Rename "Events View (beta)" to "Resources Status"
* Move access menu to "monitoring > Resources Status" instead of "Home > Events view (beta)"

**Fixes** MON-5930

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check menu access