### PR TITLE
Comparing only with value because it seems the data is of a different type

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -1359,7 +1359,7 @@ class CentreonWidget
         }
 
         //if user has no preferences take parent preferences
-        if ($this->db->numberRows() === 0) {
+        if ($this->db->numberRows() == 0) {
             try {
                 $query = 'SELECT pref.preference_value, param.parameter_code_name ' .
                     'FROM widget_preferences pref, widget_parameters param, widget_views wv ' .


### PR DESCRIPTION
## Description

When adding a view shared from another user, the preferences are not loaded

**Fixes**
Possible fix for #7875 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 19.04.x
- [X] 19.10.x
- [X] 20.04.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a custom view, set some preferences and share it
2. On another user, add the custom view
3. Preferences are loaded correctly

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
