### PR TITLE
Added hide custom view functionality

### DIFF
--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -222,6 +222,7 @@ class CentreonCustomView
             'setRotate' => self::TOPOLOGY_PAGE_SET_ROTATE,
             'deleteView' => self::TOPOLOGY_PAGE_DELETE_VIEW,
             'add' => self::TOPOLOGY_PAGE_ADD_VIEW,
+            'unload' => self::TOPOLOGY_PAGE_ADD_VIEW,
             'setDefault' => self::TOPOLOGY_PAGE_SET_DEFAULT_VIEW
         ];
 
@@ -712,6 +713,54 @@ class CentreonCustomView
         }
 
         return $viewLoadId;
+    }
+
+    /**
+     * Unloads the Custom View attached to the customViewId
+     * @param int $customViewId
+     * @param bool $authorized
+     * @throws Exception
+     */
+    public function unloadCustomView(int $customViewId, bool $authorized)
+    {
+        if (!$authorized) {
+            throw new CentreonCustomViewException('You are not allowed to unload a custom view');
+        }
+
+        $isOwner = false;
+        $query = 'SELECT is_owner FROM custom_view_user_relation WHERE ' .
+                ' custom_view_id = :customViewId AND user_id = :userId';
+        $stmt = $this->db->prepare($query);
+        $stmt->bindParam(':customViewId', $customViewId, PDO::PARAM_INT);
+        $stmt->bindParam(':userId', $this->userId, PDO::PARAM_INT);
+
+        $dbResult = $stmt->execute();
+        if (!$dbResult) {
+            throw new \Exception("An error occured");
+        }
+        if ($row = $stmt->fetch()) {
+            if ($row['is_owner'] == "1") {
+                $isOwner = true;
+            }
+        }
+
+        if ($isOwner) {
+            $query = 'UPDATE custom_view_user_relation SET is_consumed=0 WHERE ' .
+                ' custom_view_id = :customViewId AND user_id = :userId';
+            $stmt = $this->db->prepare($query);
+            $stmt->bindParam(':customViewId', $customViewId, PDO::PARAM_INT);
+            $stmt->bindParam(':userId', $this->userId, PDO::PARAM_INT);
+        } else {
+            $query = 'DELETE FROM custom_view_user_relation WHERE ' .
+            ' custom_view_id = :customViewId AND user_id = :userId';
+            $stmt = $this->db->prepare($query);
+            $stmt->bindParam(':customViewId', $customViewId, PDO::PARAM_INT);
+            $stmt->bindParam(':userId', $this->userId, PDO::PARAM_INT);
+        }
+        $dbResult = $stmt->execute();
+        if (!$dbResult) {
+            throw new \Exception("An error occured");
+        }
     }
 
     /**

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -64,6 +64,7 @@ class CentreonCustomView
     public const TOPOLOGY_PAGE_SET_ROTATE = 10305;
     public const TOPOLOGY_PAGE_DELETE_VIEW = 10306;
     public const TOPOLOGY_PAGE_ADD_VIEW = 10307;
+    public const TOPOLOGY_PAGE_UNLOAD_VIEW = 10307;
     public const TOPOLOGY_PAGE_SET_DEFAULT_VIEW = 10308;
 
     /**
@@ -208,6 +209,7 @@ class CentreonCustomView
         /* associate the called action with the toplogy page.
          * Special behaviour for the deleteWidget action which does not have any possible configuration in ACL Menus.
          * We do consider through that if user can create a widget then he also can delete it.
+         * Same concept for adding and unloading a custom view
          * Also "defaultEditMode" action has no link with ACL this action is authorized for all.
          */
         if ($action == 'defaultEditMode') {
@@ -222,7 +224,7 @@ class CentreonCustomView
             'setRotate' => self::TOPOLOGY_PAGE_SET_ROTATE,
             'deleteView' => self::TOPOLOGY_PAGE_DELETE_VIEW,
             'add' => self::TOPOLOGY_PAGE_ADD_VIEW,
-            'unload' => self::TOPOLOGY_PAGE_ADD_VIEW,
+            'unload' => self::TOPOLOGY_PAGE_UNLOAD_VIEW,
             'setDefault' => self::TOPOLOGY_PAGE_SET_DEFAULT_VIEW
         ];
 

--- a/www/include/home/customViews/action.php
+++ b/www/include/home/customViews/action.php
@@ -217,6 +217,9 @@ try {
                 }
             }
             break;
+        case 'unload':
+            $viewObj->unloadCustomView($postInputs['custom_view_id'], $authorized);
+            break;
         case 'edit':
             if ($postInputs['custom_view_id']) {
                 $viewObj->updateCustomView(

--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -109,6 +109,11 @@
         <button class='deleteView btnExtraAction btc bt_danger'>{t}Delete view{/t}</button>
         {/if}
 
+        <!-- Button for hiding a view -->
+        {if $aclAddView == 1}
+        <button class='hideView btnExtraAction btc bt_warning'>{t}Hide view{/t}</button>
+        {/if}
+
         <!-- Button for set default a view -->
         {if $aclSetDefault == 1}
         <button class='setDefault btnExtraAction btc bt_default'>{t}Set default{/t}</button>
@@ -441,6 +446,30 @@ function submitAddWidget() {
   });
 }
 
+/* Hide action */
+function submitHideView() {
+  var viewId = jQuery(
+    jQuery('#tabs .ui-tabs-tab.ui-state-active')[0]
+  ).data('cvId');
+  jQuery.ajax({
+    type: "POST",
+    dataType: "xml",
+    url: "./include/home/customViews/action.php",
+    data: {
+      action: "unload",
+      custom_view_id: viewId
+    },
+    success :	function(response) {
+      var view = response.getElementsByTagName('custom_view_id');
+      if (typeof(view) != 'undefined') {
+        deleteTab(viewId);
+      } else if (typeof(error) != 'undefined') {
+        var errorMsg = error.item(0).firstChild.data;
+      }
+    }
+  });
+}
+
 /* Delete action */
 function submitDeleteView() {
   var viewId = jQuery(
@@ -701,6 +730,10 @@ jQuery(function () {
         jQuery("#deleteViewConfirm").centreonPopin({
             open: true
         });
+    });
+
+    jQuery('.hideView').button({ icons : { primary: 'ui-icon-closethick'}}).on('click', function () {
+        submitHideView();
     });
 
   jQuery('.shareView').button({ icons : { primary: 'ui-icon-folder-open'}}).on('click', function () {

--- a/www/include/home/customViews/layouts/widgetScript.js
+++ b/www/include/home/customViews/layouts/widgetScript.js
@@ -48,10 +48,11 @@ jQuery(function () {
 
         if (!ownership) {
             jQuery('.shareView').button('disable');
+            jQuery('.deleteView').button('disable');
         } else {
             jQuery('.shareView').button('enable');
+            jQuery('.deleteView').button('enable');
         }
-        jQuery('.deleteView').button('enable');
 
         jQuery(".portlet").addClass("ui-widget ui-widget-content ui-helper-clearfix ui-corner-all")
             .find(".portlet-header")


### PR DESCRIPTION
## Description

This new functionality allows to hide a custom view without deleting it.

It is useful if you want to cleanup your custom views list that you shared without having to delete them.

It also adds clarity by having a clear distinction between the action for hiding a view and for deleting a view because currently there is only a "Delete view" button.

**Fixes**
#4721

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Open the custom views page
2. Create a new view or add an existing one
3. If a new view was created, both the "Delete view" and "Hide view" buttons are active
4. If an existing view was added, only the "Hide view" button is active

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
