### PR TITLE
fix(clapi): avoid duplicated export of contact and contactgroup

### DIFF
--- a/www/class/centreon-clapi/centreonService.class.php
+++ b/www/class/centreon-clapi/centreonService.class.php
@@ -1408,7 +1408,7 @@ class CentreonService extends CentreonObject
                 "AND"
             );
             foreach ($cgelements as $cgelement) {
-                CentreonContactGroup::getInstance()->export($element['cg_name']);
+                CentreonContactGroup::getInstance()->export($cgelement['cg_name']);
                 echo $this->action . $this->delim . "addcontactgroup" . $this->delim
                     . $element['host_name'] . $this->delim
                     . $cgelement['service_description'] . $this->delim
@@ -1429,7 +1429,7 @@ class CentreonService extends CentreonObject
                 "AND"
             );
             foreach ($celements as $celement) {
-                CentreonContact::getInstance()->export($element['contact_name']);
+                CentreonContact::getInstance()->export($celement['contact_name']);
                 echo $this->action . $this->delim . "addcontact" . $this->delim
                     . $element['host_name'] . $this->delim
                     . $celement['service_description'] . $this->delim


### PR DESCRIPTION
## Description

avoid duplicated export of contact and contactgroup

**Fixes** IBT-136

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Link a contact to 2 services
* Link a contactgroup to 2 services
* export configuration using clapi : `/usr/share/centreon/bin/centreon -u admin -p centreon -e`
==> check contact & contactgroup are not exported twice