### PR TITLE
enh(uri): enhance regexp to handle api v1 rest call

### DIFF
--- a/src/Centreon/Application/Controller/AbstractController.php
+++ b/src/Centreon/Application/Controller/AbstractController.php
@@ -61,7 +61,11 @@ abstract class AbstractController extends AbstractFOSRestController
 
         if (
             isset($_SERVER['REQUEST_URI'])
-            && preg_match('/^(.+)\/((api|widgets|modules|include)\/|main(\.get)?\.php).+/', $_SERVER['REQUEST_URI'], $matches)
+            && preg_match(
+                '/^(.+)\/((api|widgets|modules|include)\/|main(\.get)?\.php).+/',
+                $_SERVER['REQUEST_URI'],
+                $matches
+            )
         ) {
             $baseUri = $matches[1];
         }

--- a/src/Centreon/Application/Controller/AbstractController.php
+++ b/src/Centreon/Application/Controller/AbstractController.php
@@ -61,7 +61,7 @@ abstract class AbstractController extends AbstractFOSRestController
 
         if (
             isset($_SERVER['REQUEST_URI'])
-            && preg_match('/^(.+)\/((api|widgets|modules)\/|main(\.get)\.php).+/', $_SERVER['REQUEST_URI'], $matches)
+            && preg_match('/^(.+)\/((api|widgets|modules|include)\/|main(\.get)?\.php).+/', $_SERVER['REQUEST_URI'], $matches)
         ) {
             $baseUri = $matches[1];
         }


### PR DESCRIPTION
Main reason is for redirection links for BAM that uses calls to the APIV1

**Example**: `/centreon/include/common/webServices/rest/internal.php?object=centreon_bam_kpi...`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
