### PR TITLE
feat(web): register / edit poller in platformtopology via poller form

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11828,6 +11828,12 @@ msgstr ""
 msgid "The name of the poller is mandatory"
 msgstr "Le nom du collecteur est obligatoire"
 
+msgid "The IP address is already registered on another poller"
+msgstr "L'adresse IP est déjà enregistrée sur un autre collecteur"
+
+msgid "The IP address is already registered"
+msgstr "L'adresse IP est déjà enregistrée"
+
 #: centreon-web/www/include/configuration/configServers/listServers.php:112
 msgid "Localhost"
 msgstr "Hôte local"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7916,6 +7916,12 @@ msgstr "Diretorio de banco de dados leve para traps SNMP"
 msgid "The name of the poller is mandatory"
 msgstr "O nome do coletor é obrigatorio"
 
+#: msgid "The IP address is already registered on another poller"
+#: msgstr ""
+
+#: msgid "The IP address is already registered"
+#: msgstr ""
+
 #: centreon-web/www/include/configuration/configServers/listServers.php:133
 msgid "Server type"
 msgstr "Tipo de servidor"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -7917,6 +7917,12 @@ msgstr "Diretorio de banco de dados leve para traps SNMP"
 msgid "The name of the poller is mandatory"
 msgstr "O nome do coletor é obrigatorio"
 
+#: msgid "The IP address is already registered on another poller"
+#: msgstr ""
+
+#: msgid "The IP address is already registered"
+#: msgstr ""
+
 #: centreon-web/www/include/configuration/configServers/listServers.php:133
 msgid "Server type"
 msgstr "Tipo de servidor"

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -953,7 +953,6 @@ function updateServer(int $id, array $data): void
         $stmt->bindValue($key, $value);
     }
     $stmt->execute();
-    var_dump($retValue);
     try {
         updateServerIntoPlatformTopology($retValue, $id);
     } catch (\Exception $e) {

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1182,7 +1182,7 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
 
     if ($type === 'central') {
         $parentId = null;
-    }else {
+    } else {
         /**
          * Prepare statement to get the Parent depending on Remote attachment or not.
          */

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1135,10 +1135,13 @@ function insertServerIntoPlatformTopology(array $pollerInformations, int $poller
     /**
      * If no Parent, Poller isn't attached to any remote server or Central
      */
-    if ($parent) {
+    if (!empty($parent['id'])) {
         $parentId = (int) $parent['id'];
     } else {
-        throw new \Exception('Missing parent platform, check if your Remote or Central are working well');
+        throw new \Exception(
+            'Missing parent platform topology. Please register the parent first using the endpoint
+            or the available script. For more details check the documentation'
+        );
     }
 
     $statement = $pearDB->prepare("INSERT INTO `platform_topology` (`address`, `name`, `type`, `parent_id`, `server_id`)
@@ -1199,10 +1202,13 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
         /**
          * If no Parent, Poller isn't attached to any remote server or Central
          */
-        if ($parent) {
+        if (!empty($parent['id'])) {
             $parentId = (int) $parent['id'];
         } else {
-            throw new \Exception('Missing parent platform, check if your Remote or Central are working well');
+            throw new \Exception(
+                'Missing parent platform topology. Please register the parent first using the endpoint
+                or the available script. For more details check the documentation'
+            );
         }
     }
 
@@ -1217,8 +1223,8 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
      */
     if ($platform) {
         $statement = $pearDB->prepare("
-            UPDATE platform_topology
-            SET address = :address,
+            UPDATE platform_topology SET
+            address = :address,
             name = :name,
             type = :type,
             parent_id = :parent
@@ -1241,7 +1247,7 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
 
 /**
  * Check if a poller IP can be registered and display an error in form if it can't
- * This ruleset avoid IP duplication in Poller formulary
+ * This ruleset avoid IP duplication in Poller form
  *
  * @param array $formParameters
  * @return boolean
@@ -1264,7 +1270,7 @@ function ipCanBeRegistered(string $serverIp): bool
 
 /**
  * Check if a poller IP can be updated and display an error in form if it can't
- * This ruleset avoid IP duplication in Poller formulary
+ * This ruleset avoid IP duplication in Poller form
  */
 function ipCanBeUpdated(array $options): bool
 {
@@ -1285,7 +1291,7 @@ function ipCanBeUpdated(array $options): bool
     $platform = $statement->fetch(\PDO::FETCH_ASSOC);
 
     /**
-     * check if the previously found platform is the platform we're editing
+     * check if previously found platform is the platform we're editing
      */
     if ($platform) {
         if ((int) $platform['id'] === $serverId) {
@@ -1294,8 +1300,8 @@ function ipCanBeUpdated(array $options): bool
         return false;
     } else {
         /**
-         * If nothing was found in nagios server check if it existing in platform topology
-         * e.g: a Central is 127.0.0.1 in NS but is display with his true IP in platform_topology
+         * If nothing was found in nagios server check if it exists in platform topology
+         * e.g: a Central is 127.0.0.1 in NS but is displayed with its true IP in platform_topology
          */
         $statement = $pearDB->prepare("SELECT * FROM `platform_topology` WHERE `address` = :address");
         $statement->bindValue(':address', $serverIp, \PDO::PARAM_STR);

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1123,11 +1123,11 @@ function insertServerIntoPlatformTopology(array $pollerInformations, int $poller
      * Prepare statement to get the Parent depending on Remote attachment or not.
      */
     if (isset($pollerInformations[':remote_id'])) {
-        $statement = $pearDB->prepare("SELECT * FROM `platform_topology` WHERE `server_id` = :remoteId");
+        $statement = $pearDB->prepare("SELECT id FROM `platform_topology` WHERE `server_id` = :remoteId");
         $statement->bindValue(':remoteId', (int) $pollerInformations[':remote_id'], \PDO::PARAM_INT);
         $statement->execute();
     } else {
-        $statement = $pearDB->query("SELECT * FROM `platform_topology` WHERE `type` = 'central'");
+        $statement = $pearDB->query("SELECT id FROM `platform_topology` WHERE `type` = 'central'");
     }
     $parent = $statement->fetch(\PDO::FETCH_ASSOC);
     $statement->closeCursor();
@@ -1190,11 +1190,11 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
          * Prepare statement to get the Parent depending on Remote attachment or not.
          */
         if (!empty($pollerInformations[':remote_id'])) {
-            $statement = $pearDB->prepare("SELECT * FROM `platform_topology` WHERE `server_id` = :remoteId");
+            $statement = $pearDB->prepare("SELECT id FROM `platform_topology` WHERE `server_id` = :remoteId");
             $statement->bindValue(':remoteId', (int) $pollerInformations[':remote_id'], \PDO::PARAM_INT);
             $statement->execute();
         } else {
-            $statement = $pearDB->query("SELECT * FROM `platform_topology` WHERE `type` = 'central'");
+            $statement = $pearDB->query("SELECT id FROM `platform_topology` WHERE `type` = 'central'");
         }
         $parent = $statement->fetch(\PDO::FETCH_ASSOC);
         $statement->closeCursor();

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -233,7 +233,7 @@ $form->addElement('text', 'nagios_perfdata', _("Perfdata file"), $attrsText2);
 
 $tab = array();
 if ($serverType !== "central") {
-    $form->addElement('text', 'ssh_port', _("SSH Legacy port"), $attrsText3);    
+    $form->addElement('text', 'ssh_port', _("SSH Legacy port"), $attrsText3);
 }
 
 $tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("ZMQ"), ZMQ);
@@ -365,6 +365,7 @@ $form->registerRule('testAdditionalRemoteServer', 'callback', 'testAdditionalRem
 $form->registerRule('isValidIpAddress', 'callback', 'isValidIpAddress');
 $form->addRule('name', _("Name is already in use"), 'exist');
 $form->addRule('name', _("The name of the poller is mandatory"), 'required');
+$form->addRule('ns_ip_address', _("Compulsory Name"), 'required');
 if ($serverType === 'poller') {
     $form->addRule(
         array('remote_additional_id', 'remote_id'),
@@ -402,6 +403,12 @@ if ($o == SERVER_WATCH) {
      */
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
+    $form->registerRule('ipCanBeUpdated', 'callback', 'ipCanBeUpdated');
+    $form->addRule(
+        ['ns_ip_address','id'],
+        _("The IP address is already registered on another poller"),
+        'ipCanBeUpdated'
+    );
     $form->setDefaults($nagios);
 } elseif ($o == SERVER_ADD) {
     /*
@@ -409,6 +416,8 @@ if ($o == SERVER_WATCH) {
      */
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
+    $form->registerRule('ipCanBeRegistered', 'callback', 'ipCanBeRegistered');
+    $form->addRule('ns_ip_address', _("The IP address is already registered"), 'ipCanBeRegistered');
 }
 
 $valid = false;


### PR DESCRIPTION
## Description
This PR allow the Configuration Poller formulary to create / update informations of a poller into the platform_topology page

**Fixes** #MON-5869

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a Poller using the Configuration Poller Form.
- You should see it into platform_topology table.
- Edit this poller (IP, Name, parent remote server)
- the Poller should have been updated into platform_topology table.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
