### PR TITLE
fix(api): fix severity display & filtering in monitoring pages

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -785,7 +785,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             'severity_'
         );
 
-        if ($severity->getLevel()) {
+        if ($severity->getLevel() !== null) {
             $resource->setSeverity($severity);
         }
 

--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -785,7 +785,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             'severity_'
         );
 
-        if ($severity->getLevel() && $severity->getName()) {
+        if ($severity->getLevel()) {
             $resource->setSeverity($severity);
         }
 

--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -148,14 +148,14 @@ $rq1 .= " `hosts` h
     LEFT JOIN hosts_hosts_parents hph
     ON hph.parent_id = h.host_id
     LEFT JOIN `customvariables` cv
-    ON (cv.host_id = h.host_id AND cv.service_id IS NULL AND cv.name = 'CRITICALITY_LEVEL')
+    ON (cv.host_id = h.host_id AND cv.service_id = 0 AND cv.name = 'CRITICALITY_LEVEL')
     WHERE h.name NOT LIKE '_Module_%'
     AND h.instance_id = i.instance_id ";
 
 if ($criticalityId) {
     $rq1 .= " AND h.host_id = cvs.host_id
         AND cvs.name = 'CRITICALITY_ID'
-        AND cvs.service_id IS NULL
+        AND cvs.service_id = 0
         AND cvs.value = :criticalityId ";
     $queryValues['criticalityId'] = [
         \PDO::PARAM_STR => $criticalityId
@@ -268,7 +268,7 @@ $critRes = $obj->DBC->query(
     "SELECT value, host_id
     FROM customvariables
     WHERE name = 'CRITICALITY_ID'
-    AND service_id IS NULL"
+    AND service_id = 0"
 );
 $criticalityUsed = 0;
 $critCache = [];


### PR DESCRIPTION
## Description

fix severity display & filtering in monitoring pages :
* `monitoring > status details > hosts`
* `monitoring > status details > resources status`

**Fixes** MON-5975

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)