### PR TITLE
enh(monitoring): redirection link leads to Resource Status with basic…

### DIFF
--- a/www/include/monitoring/status/Hosts/host.php
+++ b/www/include/monitoring/status/Hosts/host.php
@@ -187,30 +187,25 @@ $resourceController = $kernel->getContainer()->get(
 );
 
 $deprecationMessage = _('[Page deprecated] Please use the new page: ');
-$jsonFilter = '{
-    "id":"",
-    "name":
-    "New+filter",
-    "criterias":{
-        "resourceTypes":[
-            {
-                "id":"host",
-                "name":"Host"
-            }
-        ],
-        "states":[
-            {
-                "id":"unhandled_problems",
-                "name":"Unhandled"
-            }
-        ],
-        "statuses":[],
-        "hostGroups":[],
-        "serviceGroups":[]
-    }
-}';
 
-$redirectionUrl = $resourceController->buildListingUri(['filter' => $jsonFilter]);
+$filter = [
+    'criterias' => [
+        'resourceTypes' => [
+            [
+                'id' => 'host',
+                'name' => 'Host'
+            ]
+        ],
+        'states' => [
+            [
+                'id' => 'unhandled_problems',
+                'name' => 'Unhandled'
+            ]
+        ],
+    ]
+];
+
+$redirectionUrl = $resourceController->buildListingUri(['filter' => json_encode($filter)]);
 
 //Smarty template Init
 $tpl = new Smarty();

--- a/www/include/monitoring/status/Hosts/host.php
+++ b/www/include/monitoring/status/Hosts/host.php
@@ -187,7 +187,30 @@ $resourceController = $kernel->getContainer()->get(
 );
 
 $deprecationMessage = _('[Page deprecated] Please use the new page: ');
-$redirectionUrl = $resourceController->buildListingUri([]);
+$jsonFilter = '{
+    "id":"",
+    "name":
+    "New+filter",
+    "criterias":{
+        "resourceTypes":[
+            {
+                "id":"host",
+                "name":"Host"
+            }
+        ],
+        "states":[
+            {
+                "id":"unhandled_problems",
+                "name":"Unhandled"
+            }
+        ],
+        "statuses":[],
+        "hostGroups":[],
+        "serviceGroups":[]
+    }
+}';
+
+$redirectionUrl = $resourceController->buildListingUri(['filter' => $jsonFilter]);
 
 //Smarty template Init
 $tpl = new Smarty();

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -217,7 +217,31 @@ $resourceController = $kernel->getContainer()->get(
 );
 
 $deprecationMessage = _('[Page deprecated] Please use the new page: ');
-$redirectionUrl = $resourceController->buildListingUri([]);
+
+$jsonFilter = '{
+    "id":"",
+    "name":
+    "New+filter",
+    "criterias":{
+        "resourceTypes":[
+            {
+                "id":"service",
+                "name":"Service"
+            }
+        ],
+        "states":[
+            {
+                "id":"unhandled_problems",
+                "name":"Unhandled"
+            }
+        ],
+        "statuses":[],
+        "hostGroups":[],
+        "serviceGroups":[]
+    }
+}';
+
+$redirectionUrl = $resourceController->buildListingUri(['filter' => $jsonFilter]);
 
 /*
  * Smarty template Init

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -218,30 +218,24 @@ $resourceController = $kernel->getContainer()->get(
 
 $deprecationMessage = _('[Page deprecated] Please use the new page: ');
 
-$jsonFilter = '{
-    "id":"",
-    "name":
-    "New+filter",
-    "criterias":{
-        "resourceTypes":[
-            {
-                "id":"service",
-                "name":"Service"
-            }
+$filter = [
+    'criterias' => [
+        'resourceTypes' => [
+            [
+                'id' => 'service',
+                'name' => 'Service'
+            ]
         ],
-        "states":[
-            {
-                "id":"unhandled_problems",
-                "name":"Unhandled"
-            }
+        'states' => [
+            [
+                'id' => 'unhandled_problems',
+                'name' => 'Unhandled'
+            ]
         ],
-        "statuses":[],
-        "hostGroups":[],
-        "serviceGroups":[]
-    }
-}';
+    ]
+];
 
-$redirectionUrl = $resourceController->buildListingUri(['filter' => $jsonFilter]);
+$redirectionUrl = $resourceController->buildListingUri(['filter' => json_encode($filter)]);
 
 /*
  * Smarty template Init


### PR DESCRIPTION
… filter

## Description

This PR intends to modify the target of the deprecation message redirection link. Before it was redirecting simply to the Resource Status page unfiltered. Now it redirects to this page filtered according to the type of resource host/service.

Here is an example with the services.

![screen-capture](https://user-images.githubusercontent.com/31647811/94126092-795d7800-fe57-11ea-9892-f354293377cc.gif)


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to the deprecated monitoring pages of the services and hosts
The message should appear, and when clicking the redirection link the Resource Status page should be opened with the filter sets to

- Type of Resource -> Host|Service (regarding the initial page)
- State -> Unhandled

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
