### PR TITLE
fix(submit): wrong variable used for resources authorization

### DIFF
--- a/src/Centreon/Application/Controller/Monitoring/SubmitResultController.php
+++ b/src/Centreon/Application/Controller/Monitoring/SubmitResultController.php
@@ -154,7 +154,7 @@ class SubmitResultController extends AbstractController
          * If user has no rights to submit result for host and/or service
          * return view with unauthorized HTTP header response
          */
-        if (!$this->hasSubmitResultRightsForResources($contact, $results)) {
+        if (!$this->hasSubmitResultRightsForResources($contact, $results['resources'])) {
             return $this->view(null, Response::HTTP_UNAUTHORIZED);
         }
 


### PR DESCRIPTION
## Description

Wrong variable used and passed to the function `hasSubmitResultRightsForResources` that checks if user has submit result rights on the posted resources

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Submit result to resources with an admin and limited user

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
