### PR TITLE
enh(wizard): Register informations from Wizard into platform_topology table

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2622,6 +2622,17 @@ msgstr "Statut de la plateforme"
 msgid "Engine Statistics"
 msgstr "Statistiques du moteur"
 
+#: centreon-web/src/CentreonRemote/Application/WebService/CentreonConfigurationRemote.php:365
+msgid "This IP Address already exist"
+msgstr "Cette adresse IP existe déjà"
+
+#: centreon-web/src/CentreonRemote/Application/WebService/CentreonConfigurationRemote.php:608
+msgid "This server is already registered"
+msgstr "Ce serveur est déjà enregistré"
+
+#: centreon-web/src/CentreonRemote/Application/WebService/CentreonConfigurationRemote.php:622
+msgid "No Central in topology,please edit it from Configuration > Pollers menu"
+msgstr "Pas de Central dans la topologie,Editez le depuis le menu Configurations > Collecteurs"
 
 #: centreon-web/www/install/smarty_translate.php:942
 msgid "No downtime scheduled"

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
@@ -29,7 +29,7 @@ namespace Centreon\Domain\PlatformTopology;
 class PlatformTopology
 {
     public const TYPE_CENTRAL = 'central';
-    private const TYPE_POLLER = 'poller';
+    public const TYPE_POLLER = 'poller';
     public const TYPE_REMOTE = 'remote';
     private const TYPE_MAP = 'map';
     private const TYPE_MBI = 'mbi';

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -2,7 +2,6 @@
 
 namespace CentreonRemote\Application\Webservice;
 
-use Exception;
 use Centreon\Domain\Entity\Task;
 use CentreonRemote\Domain\Value\ServerWizardIdentity;
 use Centreon\Domain\PlatformTopology\PlatformTopology;
@@ -361,7 +360,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $dbAdapter->query('SELECT * FROM `nagios_server` WHERE `ns_ip_address` = ?', [$serverIP]);
         $isInNagios = $dbAdapter->count();
         if ($isInNagios) {
-            throw new Exception('This IP Address already exist');
+            throw new \Exception('This IP Address already exist');
         }
 
         $sql = 'SELECT * FROM `remote_servers` WHERE `ip` = ?';

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -357,9 +357,11 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         /**
          * Avoid Ip duplication
          */
-        $dbAdapter->query('SELECT * FROM `nagios_server` WHERE `ns_ip_address` = ?', [$serverIP]);
-        $isInNagios = $dbAdapter->count();
-        if ($isInNagios) {
+        $statement = $this->pearDB->prepare('SELECT COUNT(*) as `total` FROM `nagios_server` WHERE `ns_ip_address` = :serverIp');
+        $statement->bindValue(':serverIp', $serverIP, \PDO::PARAM_STR);
+        $statement->execute();
+        $isInNagios = $statement->fetch(\PDO::FETCH_ASSOC);
+        if ((int) $isInNagios['total'] > 0) {
             throw new \Exception('This IP Address already exist');
         }
 

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -76,6 +76,21 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
     }
 
     /**
+     * Get Pollers servers waitlist
+     *
+     * @return array
+     */
+    public function postGetPollerWaitList(): array
+    {
+        $statement = $this->pearDB->query('
+            SELECT id, address as ip, name as server_name FROM `platform_topology`
+            WHERE `type` = "poller" AND server_id IS NULL
+        ');
+
+        return $statement->fetchAll();
+    }
+
+    /**
      * @OA\Get(
      *   path="/internal.php?object=centreon_configuration_remote&action=list",
      *   description="Get list with connected remotes",

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -2,10 +2,11 @@
 
 namespace CentreonRemote\Application\Webservice;
 
-use CentreonRemote\Application\Validator\WizardConfigurationRequestValidator;
+use Exception;
 use Centreon\Domain\Entity\Task;
 use CentreonRemote\Domain\Value\ServerWizardIdentity;
-use Exception;
+use Centreon\Domain\PlatformTopology\PlatformTopology;
+use CentreonRemote\Application\Validator\WizardConfigurationRequestValidator;
 
 /**
  * @OA\Tag(name="centreon_configuration_remote", description="")
@@ -454,7 +455,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             );
             $this->setCentreonInstanceAsCentral();
             $this->updateServerInPlatformTopology([
-                'type' => 'remote',
+                'type' => PlatformTopology::TYPE_REMOTE,
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
@@ -470,7 +471,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $additionalRemotes = $pollerConfigurationBridge->getAdditionalRemoteServers();
             $pollerConfigurationService->linkPollerToAdditionalRemoteServers($pollers[0], $additionalRemotes);
             $this->updateServerInPlatformTopology([
-                'type' => 'poller',
+                'type' => PlatformTopology::TYPE_POLLER,
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
@@ -478,7 +479,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             ]);
         } else {
             $this->updateServerInPlatformTopology([
-                'type' => 'poller',
+                'type' => PlatformTopology::TYPE_POLLER,
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -357,7 +357,9 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         /**
          * Avoid Ip duplication
          */
-        $statement = $this->pearDB->prepare('SELECT COUNT(*) as `total` FROM `nagios_server` WHERE `ns_ip_address` = :serverIp');
+        $statement = $this->pearDB->prepare(
+            'SELECT COUNT(*) as `total` FROM `nagios_server` WHERE `ns_ip_address` = :serverIp'
+        );
         $statement->bindValue(':serverIp', $serverIP, \PDO::PARAM_STR);
         $statement->execute();
         $isInNagios = $statement->fetch(\PDO::FETCH_ASSOC);

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -346,17 +346,20 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $serverName = substr($this->arguments['server_name'], 0, 40);
 
         // Check IPv6, IPv4 and FQDN format
-        if (!filter_var($serverIP, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) && !filter_var($serverIP, FILTER_VALIDATE_IP)) {
+        if (
+            !filter_var($serverIP, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
+            && !filter_var($serverIP, FILTER_VALIDATE_IP)
+        ) {
             return ['error' => true, 'message' => "Invalid IP address"];
         }
         $dbAdapter = $this->getDi()['centreon.db-manager']->getAdapter('configuration_db');
 
         /**
-         * Avoid Ip duplication 
+         * Avoid Ip duplication
          */
         $dbAdapter->query('SELECT * FROM `nagios_server` WHERE `ns_ip_address` = ?', [$serverIP]);
         $isInNagios = $dbAdapter->count();
-        if($isInNagios) {
+        if ($isInNagios) {
             throw new Exception('This IP Address already exist');
         }
 

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -362,7 +362,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $statement->execute();
         $isInNagios = $statement->fetch(\PDO::FETCH_ASSOC);
         if ((int) $isInNagios['total'] > 0) {
-            throw new \Exception('This IP Address already exist');
+            throw new \Exception(_('This IP Address already exist'));
         }
 
         $sql = 'SELECT * FROM `remote_servers` WHERE `ip` = ?';
@@ -605,7 +605,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $server = $statement->fetch(\PDO::FETCH_ASSOC);
 
         if (isset($server['nagios_id'])) {
-            throw new \Exception('This server is already registered');
+            throw new \Exception(_('This server is already registered'));
         }
         if (!empty($topologyInformations['parent'])) {
             $statement = $this->pearDB->prepare('SELECT id FROM platform_topology WHERE server_id = :serverId');
@@ -619,7 +619,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $statement = $this->pearDB->query("SELECT id FROM `platform_topology` WHERE type = 'central'");
             $parent = $statement->fetch(\PDO::FETCH_ASSOC);
             if (empty($parent['id'])) {
-                throw new \Exception('No Central in topology,please edit it from Poller menu');
+                throw new \Exception(_('No Central in topology,please edit it from Configuration > Pollers menu'));
             }
         }
         /**

--- a/www/front_src/src/components/forms/poller/PollerFormStepOne.js
+++ b/www/front_src/src/components/forms/poller/PollerFormStepOne.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* eslint-disable react/jsx-filename-extension */
 /* eslint-disable react/prop-types */
 /* eslint-disable react/prefer-stateless-function */
@@ -26,7 +27,8 @@ class PollerFormStepOne extends Component {
   }
 
   initializeFromRest = (value) => {
-    this.props.change('inputTypeManual', !value);
+    const { change } = this.props;
+    change('inputTypeManual', !value);
     this.setState({
       initialized: true,
       inputTypeManual: !value,
@@ -41,14 +43,14 @@ class PollerFormStepOne extends Component {
     }
     this.setState({
       initialized: true,
-      centreon_folder: '/centreon/',
     });
   };
 
   handleChange = (e, value) => {
-    const server = this.props.waitList.find((server) => server.ip === value)
-    this.props.change('server_name', server.server_name)
-  }
+    const { waitList, change } = this.props;
+    const platform = waitList.find((server) => server.ip === value);
+    change('server_name', platform.server_name);
+  };
 
   render() {
     const { error, handleSubmit, onSubmit, waitList, t } = this.props;
@@ -62,7 +64,7 @@ class PollerFormStepOne extends Component {
             </h2>
           </div>
           <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
-          <Field
+            <Field
               name="inputTypeManual"
               onChange={() => {
                 this.onManualInputChanged(true);
@@ -72,34 +74,34 @@ class PollerFormStepOne extends Component {
               label={t('Create new Poller')}
             />
             {inputTypeManual ? (
-            <div>
-              <Field
-                name="server_name"
-                component={InputField}
-                type="text"
-                placeholder=""
-                label={`${t('Server Name')}:`}
-                validate={validateFieldRequired(t)}
-              />
-              <Field
-                name="server_ip"
-                component={InputField}
-                type="text"
-                placeholder=""
-                label={`${t('Server IP address')}:`}
-                validate={validateFieldRequired(t)}
-              />
-              <Field
-                name="centreon_central_ip"
-                component={InputField}
-                type="text"
-                placeholder=""
-                label={`${t(
-                  'Centreon Central IP address, as seen by this server',
-                )}:`}
-                validate={validateFieldRequired(t)}
-              />
-            </div>
+              <div>
+                <Field
+                  name="server_name"
+                  component={InputField}
+                  type="text"
+                  placeholder=""
+                  label={`${t('Server Name')}:`}
+                  validate={validateFieldRequired(t)}
+                />
+                <Field
+                  name="server_ip"
+                  component={InputField}
+                  type="text"
+                  placeholder=""
+                  label={`${t('Server IP address')}:`}
+                  validate={validateFieldRequired(t)}
+                />
+                <Field
+                  name="centreon_central_ip"
+                  component={InputField}
+                  type="text"
+                  placeholder=""
+                  label={`${t(
+                    'Centreon Central IP address, as seen by this server',
+                  )}:`}
+                  validate={validateFieldRequired(t)}
+                />
+              </div>
             ) : null}
             <Field
               name="inputTypeManual"
@@ -158,7 +160,7 @@ class PollerFormStepOne extends Component {
                   validate={validateFieldRequired(t)}
                 />
               </div>
-            ): null }
+            ) : null}
             <div className={styles['form-buttons']}>
               <button className={styles.button} type="submit">
                 {t('Next')}

--- a/www/front_src/src/components/forms/poller/PollerFormStepOne.js
+++ b/www/front_src/src/components/forms/poller/PollerFormStepOne.js
@@ -38,7 +38,6 @@ class PollerFormStepOne extends Component {
     const { initialized } = this.state;
     if (waitList && !initialized) {
       this.initializeFromRest(waitList.length > 0);
-      // this.initializeFromRest(true);//set to true of false if abandon the upper case condition
     }
     this.setState({
       initialized: true,

--- a/www/front_src/src/components/forms/poller/PollerFormStepOne.js
+++ b/www/front_src/src/components/forms/poller/PollerFormStepOne.js
@@ -13,9 +13,13 @@ import InputField from '../../form-fields/InputField';
 import { validateFieldRequired } from '../../../helpers/validators';
 
 class PollerFormStepOne extends Component {
+  state = {
+    inputTypeManual: true,
+  }
+
   render() {
     const { error, handleSubmit, onSubmit, t } = this.props;
-
+    const { inputTypeManual } = this.state;
     return (
       <div className={styles['form-wrapper']}>
         <div className={styles['form-inner']}>
@@ -50,6 +54,15 @@ class PollerFormStepOne extends Component {
                 'Centreon Central IP address, as seen by this server',
               )}:`}
               validate={validateFieldRequired(t)}
+            />
+            <Field
+              name="inputTypeManual"
+              onClick={() => {
+                this.onManualInputChanged(false);
+              }}
+              checked={!inputTypeManual}
+              component={RadioField}
+              label={`${t('Select a Pending Poller')}:`}
             />
             <div className={styles['form-buttons']}>
               <button className={styles.button} type="submit">

--- a/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
+++ b/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
@@ -22,7 +22,6 @@ class RemoteServerFormStepOne extends Component {
   state = {
     inputTypeManual: true,
     initialized: false,
-    name: ''
   };
 
   onManualInputChanged(inputTypeManual) {
@@ -53,8 +52,8 @@ class RemoteServerFormStepOne extends Component {
   };
 
   handleChange = (e, value) => {
-    const {change} = this.props
-    change('server_name', value)
+    const server = this.props.waitList.find((server) => server.ip === value)
+    this.props.change('server_name', server.server_name)
   }
 
   render() {
@@ -158,8 +157,8 @@ class RemoteServerFormStepOne extends Component {
               <div>
                 {waitList ? (
                   <Field
-                    onChange={handleChange}
                     name="server_ip"
+                    onChange={this.handleChange}
                     component={SelectField}
                     label={`${t('Select Pending Remote Links')}:`}
                     required
@@ -171,7 +170,7 @@ class RemoteServerFormStepOne extends Component {
                         value: '',
                       },
                     ].concat(
-                      waitList.map((c) => ({ value: c.id, text: c.ip })),
+                      waitList.map((c) => ({ value: c.ip, text: c.ip })),
                     )}
                   />
                 ) : null}

--- a/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
+++ b/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
@@ -22,6 +22,7 @@ class RemoteServerFormStepOne extends Component {
   state = {
     inputTypeManual: true,
     initialized: false,
+    name: ''
   };
 
   onManualInputChanged(inputTypeManual) {
@@ -50,6 +51,11 @@ class RemoteServerFormStepOne extends Component {
       centreon_folder: '/centreon/',
     });
   };
+
+  handleChange = (e, value) => {
+    const {change} = this.props
+    change('server_name', value)
+  }
 
   render() {
     const { error, handleSubmit, onSubmit, waitList, t } = this.props;
@@ -152,6 +158,7 @@ class RemoteServerFormStepOne extends Component {
               <div>
                 {waitList ? (
                   <Field
+                    onChange={handleChange}
                     name="server_ip"
                     component={SelectField}
                     label={`${t('Select Pending Remote Links')}:`}

--- a/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
+++ b/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
@@ -51,8 +51,9 @@ class RemoteServerFormStepOne extends Component {
   };
 
   handleChange = (e, value) => {
-    const platform = this.props.waitList.find((server) => server.ip === value);
-    this.props.change('server_name', platform.server_name);
+    const { waitList, change } = this.props;
+    const platform = waitList.find((server) => server.ip === value);
+    change('server_name', platform.server_name);
   };
 
   render() {

--- a/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
+++ b/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
@@ -51,9 +51,9 @@ class RemoteServerFormStepOne extends Component {
   };
 
   handleChange = (e, value) => {
-    const server = this.props.waitList.find((server) => server.ip === value)
-    this.props.change('server_name', server.server_name)
-  }
+    const platform = this.props.waitList.find((server) => server.ip === value);
+    this.props.change('server_name', platform.server_name);
+  };
 
   render() {
     const { error, handleSubmit, onSubmit, waitList, t } = this.props;

--- a/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
+++ b/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
@@ -43,7 +43,6 @@ class RemoteServerFormStepOne extends Component {
     const { initialized } = this.state;
     if (waitList && !initialized) {
       this.initializeFromRest(waitList.length > 0);
-      // this.initializeFromRest(true);//set to true of false if abandon the upper case condition
     }
     this.setState({
       initialized: true,

--- a/www/front_src/src/route-components/pollerStep1/index.js
+++ b/www/front_src/src/route-components/pollerStep1/index.js
@@ -12,6 +12,7 @@ import { setPollerWizard } from '../../redux/actions/pollerWizardActions';
 import ProgressBar from '../../components/progressBar';
 import routeMap from '../../route-maps/route-map';
 import BaseWizard from '../../components/forms/baseWizard';
+import axios from '../../axios';
 
 class PollerStepOneRoute extends Component {
   links = [
@@ -27,6 +28,29 @@ class PollerStepOneRoute extends Component {
   ];
 
   state = {
+    waitList: null,
+  };
+
+  wizardFormWaitListApi = axios(
+    'internal.php?object=centreon_configuration_remote&action=getPollerWaitList',
+  );
+
+  getWaitList = () => {
+    this.wizardFormWaitListApi
+      .post()
+      .then((response) => {
+        this.setState({ waitList: response.data });
+      })
+      .catch(() => {
+        this.setState({ waitList: [] });
+      });
+  };
+
+  componentDidMount = () => {
+    this.getWaitList();
+  };
+
+  state = {
     error: null,
   };
 
@@ -38,10 +62,11 @@ class PollerStepOneRoute extends Component {
 
   render() {
     const { links } = this;
+    const { waitList } = this.state;
     return (
       <BaseWizard>
         <ProgressBar links={links} />
-        <Form onSubmit={this.handleSubmit.bind(this)} initialValues={{}} />
+        <Form onSubmit={this.handleSubmit.bind(this)} initialValues={{}} waitList={waitList}/>
       </BaseWizard>
     );
   }

--- a/www/front_src/src/route-components/pollerStep1/index.js
+++ b/www/front_src/src/route-components/pollerStep1/index.js
@@ -28,6 +28,7 @@ class PollerStepOneRoute extends Component {
   ];
 
   state = {
+    error: null,
     waitList: null,
   };
 
@@ -50,10 +51,6 @@ class PollerStepOneRoute extends Component {
     this.getWaitList();
   };
 
-  state = {
-    error: null,
-  };
-
   handleSubmit = (data) => {
     const { history, setPollerWizard } = this.props;
     setPollerWizard(data);
@@ -66,7 +63,11 @@ class PollerStepOneRoute extends Component {
     return (
       <BaseWizard>
         <ProgressBar links={links} />
-        <Form onSubmit={this.handleSubmit.bind(this)} initialValues={{}} waitList={waitList}/>
+        <Form
+          onSubmit={this.handleSubmit.bind(this)}
+          initialValues={{}}
+          waitList={waitList}
+        />
       </BaseWizard>
     );
   }


### PR DESCRIPTION
## Description

This PR allow the Wizard to register informations into platform_topology table. 
Also, the Select Remote Server autocompletion is now made from platform_topology, and an autocompletion for Poller part has been added.

**Fixes** # MON-5866 MON-5867

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a new poller  / Remote Server into the wizard, you should see it into the platform_topology table.
- Create a new poller / Remote Server using the Radio button "Select a Poller / Remote Server", you should select some pending Remote / Poller.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
