### PR TITLE
fix(acl): fix access to resources status page

### DIFF
--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2285,15 +2285,15 @@ function get_child($id_page, $lcaTStr)
     global $pearDB;
 
     if ($lcaTStr != "") {
-        $rq = " SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt 
-                FROM topology 
-                WHERE  topology_page IN ($lcaTStr) 
-                AND topology_parent = '" . $id_page . "' AND topology_page IS NOT NULL AND topology_show = '1' 
+        $rq = " SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react
+                FROM topology
+                WHERE topology_page IN ($lcaTStr)
+                AND topology_parent = '" . $id_page . "' AND topology_page IS NOT NULL AND topology_show = '1'
                 ORDER BY topology_order, topology_group ";
     } else {
-        $rq = " SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt 
-                FROM topology 
-                WHERE  topology_parent = '" . $id_page . "' AND topology_page IS NOT NULL AND topology_show = '1' 
+        $rq = " SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react
+                FROM topology
+                WHERE topology_parent = '" . $id_page . "' AND topology_page IS NOT NULL AND topology_show = '1'
                 ORDER BY topology_order, topology_group ";
     }
 

--- a/www/main.get.php
+++ b/www/main.get.php
@@ -142,6 +142,15 @@ if ($acl_page == 1 || $acl_page == 2) {
                 }
             } elseif ($ret['topology_url']) {
                 $url = $ret['topology_url'];
+                if ($ret['is_react'] === '1') {
+                    // workaround to update react page without refreshing whole page
+                    echo '<script>'
+                        . 'window.top.history.pushState("", "", ".' . $ret['topology_url'] . '");'
+                        . 'window.top.history.pushState("", "", ".' . $ret['topology_url'] . '");'
+                        . 'window.top.history.go(-1);'
+                        . '</script>';
+                    exit();
+                }
             } else {
                 $url = "./include/core/errors/alt_error.php";
             }


### PR DESCRIPTION
## Description

* fix acl migration when user did not have access to monitoring pages
* fix breadcrumb level 1 from legacy monitoring pages

**Fixes** MON-5930

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)