### PR TITLE
MON-6061: gorgone user can apply cfg + enhance security files

### DIFF
--- a/www/class/config-generate-remote/Abstracts/AbstractObject.php
+++ b/www/class/config-generate-remote/Abstracts/AbstractObject.php
@@ -123,6 +123,7 @@ abstract class AbstractObject
         if (!($this->fp = @fopen($fullFile, 'a+'))) {
             throw new Exception("Cannot open file (writing permission) '" . $fullFile . "'");
         }
+        chmod($fullFile, 0660);
 
         if ($this->type == 'infile') {
             Manifest::getInstance($this->dependencyInjector)->addFile(

--- a/www/class/config-generate-remote/Backend.php
+++ b/www/class/config-generate-remote/Backend.php
@@ -125,9 +125,10 @@ class Backend
                     throw new Exception("Generation path '" . $dir . "' is not a directory.");
                 }
             } else {
-                if (!mkdir($dir, 0775, true)) {
+                if (!mkdir($dir, 0770, true)) {
                     throw new Exception("Cannot create directory '" . $dir . "'");
                 }
+                chmod($dir, 0770);
             }
         }
 

--- a/www/class/config-generate/abstract/object.class.php
+++ b/www/class/config-generate/abstract/object.class.php
@@ -130,6 +130,7 @@ abstract class AbstractObject
         if (!($this->fp = @fopen($full_file, 'w+'))) {
             throw new Exception("Cannot open file (writing permission) '" . $full_file . "'");
         }
+        chmod($full_file, 0660);
         $this->setHeader();
     }
 

--- a/www/class/config-generate/backend.class.php
+++ b/www/class/config-generate/backend.class.php
@@ -100,6 +100,7 @@ class Backend
                 if (!mkdir($dir, 0770, true)) {
                     throw new Exception("Cannot create directory '" . $dir . "'");
                 }
+                chmod($dir, 0770);
             }
         }
 
@@ -132,6 +133,7 @@ class Backend
         if (!mkdir($this->full_path . '/' . $this->tmp_dir, 0770, true)) {
             throw new Exception("Cannot create directory '" . $dir . "'");
         }
+        chmod($this->full_path . '/' . $this->tmp_dir, 0770);
         $this->full_path .= '/' . $this->tmp_dir;
     }
 


### PR DESCRIPTION
## Description

Gorgone user can use clapi command to generate configuration

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Gorgone user cannot execute: centreon -u admin -p centreon -a APPLYCFG -v 3

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
