### PR TITLE
fix(version): Allows to compare API versions using the comma separator of a floating number.

### DIFF
--- a/src/Centreon/Domain/VersionHelper.php
+++ b/src/Centreon/Domain/VersionHelper.php
@@ -48,13 +48,17 @@ class VersionHelper
      */
     public static function compare(string $version1, string $version2, string $operator = self::EQUAL): bool
     {
-        $depthVersion1 = substr_count($version1, '.');
-        $depthVersion2 = substr_count($version2, '.');
+        $floatSeparationSymbol = '.';
+        if ((substr_count($version1, ',') + substr_count($version2, ',')) > 0) {
+            $floatSeparationSymbol = ',';
+        }
+        $depthVersion1 = substr_count($version1, $floatSeparationSymbol);
+        $depthVersion2 = substr_count($version2, $floatSeparationSymbol);
         if ($depthVersion1 > $depthVersion2) {
-            $version2 = self::regularizeDepthVersion($version2, $depthVersion1);
+            $version2 = self::regularizeDepthVersion($version2, $depthVersion1, $floatSeparationSymbol);
         }
         if ($depthVersion2 > $depthVersion1) {
-            $version1 = self::regularizeDepthVersion($version1, $depthVersion2);
+            $version1 = self::regularizeDepthVersion($version1, $depthVersion2, $floatSeparationSymbol);
         }
         return version_compare($version1, $version2, $operator);
     }
@@ -64,19 +68,20 @@ class VersionHelper
      *
      * @param string $version Version number to update
      * @param int $depth Depth destination
+     * @param string $glue
      * @return string Returns the updated version number with the destination depth
      */
-    public static function regularizeDepthVersion(string $version, int $depth = 2): string
+    public static function regularizeDepthVersion(string $version, int $depth = 2, string $glue = '.'): string
     {
-        $actualDepth = substr_count($version, '.');
+        $actualDepth = substr_count($version, $glue);
         if ($actualDepth == $depth) {
             return $version;
         } elseif ($actualDepth > $depth) {
-            $parts = array_slice(explode('.', $version), 0, ($depth + 1));
-            return implode('.', $parts);
+            $parts = array_slice(explode($glue, $version), 0, ($depth + 1));
+            return implode($glue, $parts);
         }
         for ($loop = $actualDepth; $loop < $depth; $loop++) {
-            $version .= '.0';
+            $version .= $glue . '0';
         }
         return $version;
     }

--- a/tests/php/Centreon/Domain/VersionHelperTest.php
+++ b/tests/php/Centreon/Domain/VersionHelperTest.php
@@ -25,8 +25,7 @@ use PHPUnit\Framework\TestCase;
 
 class VersionHelperTest extends TestCase
 {
-
-    public function testCompare()
+    public function testCompareWithPoint()
     {
         $this->assertFalse(VersionHelper::compare('1', '2', VersionHelper::EQUAL));
         $this->assertTrue(VersionHelper::compare('1', '1.0', VersionHelper::EQUAL));
@@ -39,12 +38,34 @@ class VersionHelperTest extends TestCase
         $this->assertTrue(VersionHelper::compare('1.1.0', '1.1', VersionHelper::EQUAL));
     }
 
-    public function testRegularizeDepthVersion()
+    public function testRegularizeDepthVersionWithPoint()
     {
         $this->assertEquals('1.0.0', VersionHelper::regularizeDepthVersion('1', 2));
         $this->assertEquals('2.1.0', VersionHelper::regularizeDepthVersion('2.1', 2));
         $this->assertEquals('2.2', VersionHelper::regularizeDepthVersion('2.2', 1));
         $this->assertEquals('9', VersionHelper::regularizeDepthVersion('9.8.5', 0));
         $this->assertEquals('9.8', VersionHelper::regularizeDepthVersion('9.8.6', 1));
+    }
+
+    public function testCompareWithComma()
+    {
+        $this->assertFalse(VersionHelper::compare('1', '2', VersionHelper::EQUAL));
+        $this->assertTrue(VersionHelper::compare('1', '1,0', VersionHelper::EQUAL));
+        $this->assertTrue(VersionHelper::compare('1,2', '1,0', VersionHelper::GT));
+        $this->assertTrue(VersionHelper::compare('1,2', '1,0', VersionHelper::GE));
+        $this->assertTrue(VersionHelper::compare('1,2', '1,2', VersionHelper::GE));
+        $this->assertTrue(VersionHelper::compare('1,0', '2,0', VersionHelper::LT));
+        $this->assertTrue(VersionHelper::compare('1,2', '2,0', VersionHelper::LE));
+        $this->assertTrue(VersionHelper::compare('1,2', '2,0', VersionHelper::LE));
+        $this->assertTrue(VersionHelper::compare('1,1,0', '1,1', VersionHelper::EQUAL));
+    }
+
+    public function testRegularizeDepthVersionWithComma()
+    {
+        $this->assertEquals('1,0,0', VersionHelper::regularizeDepthVersion('1', 2, ','));
+        $this->assertEquals('2,1,0', VersionHelper::regularizeDepthVersion('2,1', 2, ','));
+        $this->assertEquals('2,2', VersionHelper::regularizeDepthVersion('2,2', 1, ','));
+        $this->assertEquals('9', VersionHelper::regularizeDepthVersion('9,8,5', 0, ','));
+        $this->assertEquals('9,8', VersionHelper::regularizeDepthVersion('9,8,6', 1, ','));
     }
 }


### PR DESCRIPTION
## Description

Allows to compare API versions using the comma separator of a floating number.

**Fixes** # (issue)

The problem was converting strings to a floating number. In US the numeric separator is a point but in French it is a comma.
The comparison method tried to compare floating numbers with '.' and ',' at the same time.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
