### PR TITLE
fix(translation): translate redirection label on deprecated pages

### DIFF
--- a/www/include/monitoring/objectDetails/hostDetails.php
+++ b/www/include/monitoring/objectDetails/hostDetails.php
@@ -717,6 +717,7 @@ if (!$is_admin && !$haveAccess) {
         );
 
         $deprecationMessage = _('[Page deprecated] Please use the new page: ');
+        $resourcesStatusLabel = _('Resources Status');
         $redirectionUrl = $resourceController->buildHostDetailsUri($host_id);
 
         $tpl->display("hostDetails.ihtml");
@@ -783,11 +784,12 @@ if (!$is_admin && !$haveAccess) {
         function display_deprecated_banner() {
             const url = "<?php echo $redirectionUrl; ?>";
             const message = "<?php echo $deprecationMessage; ?>";
+            const label = "<?php echo $resourcesStatusLabel; ?>";
             jQuery('.pathway').append(
                 '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
-                '<a style="position:relative" href="' + url + '" isreact="isreact">Resource Status</a></span>'
+                '<a style="position:relative" href="' + url + '" isreact="isreact">' + label + '</a></span>'
             );
-    }
+        }
 
         function send_command(cmd, actiontype) {
             if (!confirm(glb_confirm)) {

--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -836,6 +836,7 @@ if (!is_null($host_id)) {
         );
 
         $deprecationMessage = _('[Page deprecated] Please use the new page: ');
+        $resourcesStatusLabel = _('Resources Status');
         $redirectionUrl = $resourceController->buildServiceDetailsUri($host_id, $service_id);
 
         // Check if central or remote server
@@ -914,11 +915,12 @@ if (!is_null($host_id)) {
         function display_deprecated_banner() {
             const url = "<?php echo $redirectionUrl; ?>";
             const message = "<?php echo $deprecationMessage; ?>";
+            const label = "<?php echo $resourcesStatusLabel; ?>";
             jQuery('.pathway').append(
                 '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
-                '<a style="position:relative" href="' + url + '" isreact="isreact">Resource Status</a></span>'
+                '<a style="position:relative" href="' + url + '" isreact="isreact">' + label + '</a></span>'
             );
-    }
+        }
 
         function send_command(cmd, actiontype) {
             if (!confirm(glb_confirm)) {

--- a/www/include/monitoring/status/Hosts/host.php
+++ b/www/include/monitoring/status/Hosts/host.php
@@ -187,6 +187,7 @@ $resourceController = $kernel->getContainer()->get(
 );
 
 $deprecationMessage = _('[Page deprecated] Please use the new page: ');
+$resourcesStatusLabel = _('Resources Status');
 
 $filter = [
     'criterias' => [
@@ -425,12 +426,13 @@ $tpl->display("host.ihtml");
     display_deprecated_banner();
 
     function display_deprecated_banner() {
-            const url = "<?php echo $redirectionUrl; ?>";
-            const message = "<?php echo $deprecationMessage; ?>";
-            jQuery('.pathway').append(
-                '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
-                '<a style="position:relative" href="' + url + '" isreact="isreact">Resource Status</a>'
-            );
+        const url = "<?php echo $redirectionUrl; ?>";
+        const message = "<?php echo $deprecationMessage; ?>";
+        const label = "<?php echo $resourcesStatusLabel; ?>";
+        jQuery('.pathway').append(
+            '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
+            '<a style="position:relative" href="' + url + '" isreact="isreact">' + label + '</a>'
+        );
     }
 
     jQuery('#statusHost').change(function () {

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -217,6 +217,7 @@ $resourceController = $kernel->getContainer()->get(
 );
 
 $deprecationMessage = _('[Page deprecated] Please use the new page: ');
+$resourcesStatusLabel = _('Resources Status');
 
 $filter = [
     'criterias' => [
@@ -519,12 +520,13 @@ $tpl->display("service.ihtml");
     display_deprecated_banner();
 
     function display_deprecated_banner() {
-            const url = "<?php echo $redirectionUrl; ?>";
-            const message = "<?php echo $deprecationMessage; ?>";
-            jQuery('.pathway').append(
-                '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
-                '<a style="position:relative" href="' + url + '" isreact="isreact">Resource Status</a></span>'
-            );
+        const url = "<?php echo $redirectionUrl; ?>";
+        const message = "<?php echo $deprecationMessage; ?>";
+        const label = "<?php echo $resourcesStatusLabel; ?>";
+        jQuery('.pathway').append(
+            '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
+            '<a style="position:relative" href="' + url + '" isreact="isreact">' + label + '</a></span>'
+        );
     }
 
     jQuery('#statusService').change(function () {


### PR DESCRIPTION
## Description

translate redirection label on deprecated pages (Resources status)

**Fixes** MON-6130

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check french translation on legacy pages