### PR TITLE
fix(pollerform): Re assign parent id when deleting remote

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -261,7 +261,11 @@ function deleteServerInDB(array $serverIds): void
             $statement = $pearDB->query('SELECT id FROM `platform_topology` WHERE parent_id IS NULL');
             $topPlatform = $statement->fetch(\PDO::FETCH_ASSOC);
 
-            $statement2 = $pearDB->prepare('UPDATE `platform_topology` SET `parent_id` = :topPlatformId WHERE `parent_id` = :remoteId');
+            $statement2 = $pearDB->prepare('
+                UPDATE `platform_topology`
+                SET `parent_id` = :topPlatformId
+                WHERE `parent_id` = :remoteId
+            ');
             $statement2->bindValue(':topPlatformId', (int) $topPlatform['id'], \PDO::PARAM_INT);
             $statement2->bindValue(':remoteId', (int) $platformInTopology['id'], \PDO::PARAM_INT);
             $statement2->execute();

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -252,7 +252,6 @@ function deleteServerInDB(array $serverIds): void
     global $pearDB, $pearDBO, $centreon;
 
     foreach (array_keys($serverIds) as $serverId) {
-
         $statement = $pearDB->prepare('SELECT `id`, `type` FROM `platform_topology` WHERE server_id = :serverId ');
         $statement->bindValue(':serverId', (int) $serverId, \PDO::PARAM_INT);
         $statement->execute();

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -256,10 +256,12 @@ function deleteServerInDB(array $serverIds): void
         $statement = $pearDB->prepare('SELECT `id`, `type` FROM `platform_topology` WHERE server_id = :serverId ');
         $statement->bindValue(':serverId', (int) $serverId, \PDO::PARAM_INT);
         $statement->execute();
-        $platformInTopology = $statement->fetch(\PDO::FETCH_ASSOC);
 
         //If the deleted platform is a remote, reassign the parent_id of its children to the top level platform
-        if ($platformInTopology['type'] === PlatformTopology::TYPE_REMOTE) {
+        if (
+            ($platformInTopology = $statement->fetch(\PDO::FETCH_ASSOC))
+            && $platformInTopology['type'] === PlatformTopology::TYPE_REMOTE
+        ) {
             $statement = $pearDB->query('SELECT id FROM `platform_topology` WHERE parent_id IS NULL');
             if ($topPlatform = $statement->fetch(\PDO::FETCH_ASSOC)) {
                 $statement2 = $pearDB->prepare('

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -250,6 +250,23 @@ function deleteServerInDB(array $serverIds): void
     global $pearDB, $pearDBO, $centreon;
 
     foreach (array_keys($serverIds) as $serverId) {
+
+        $statement = $pearDB->prepare('SELECT `id`, `type` FROM `platform_topology` WHERE server_id = :serverId ');
+        $statement->bindValue(':serverId', (int) $serverId, \PDO::PARAM_INT);
+        $statement->execute();
+        $platformInTopology = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        //If the deleted platform is a remote, reassign the parent_id of its children to the top level platform
+        if ($platformInTopology['type'] === 'remote') {
+            $statement = $pearDB->query('SELECT id FROM `platform_topology` WHERE parent_id IS NULL');
+            $topPlatform = $statement->fetch(\PDO::FETCH_ASSOC);
+
+            $statement2 = $pearDB->prepare('UPDATE `platform_topology` SET `parent_id` = :topPlatformId WHERE `parent_id` = :remoteId');
+            $statement2->bindValue(':topPlatformId', (int) $topPlatform['id'], \PDO::PARAM_INT);
+            $statement2->bindValue(':remoteId', (int) $platformInTopology['id'], \PDO::PARAM_INT);
+            $statement2->execute();
+        }
+
         $result = $pearDB->query(
             "SELECT name, ns_ip_address AS ip FROM `nagios_server` WHERE `id` = " . $serverId . " LIMIT 1"
         );
@@ -265,12 +282,12 @@ function deleteServerInDB(array $serverIds): void
             $pearDB->query(
                 "DELETE FROM remote_servers WHERE ip = '" . $row['ip'] . "'"
             );
-            // Delete all relation bewteen this Remote Server and pollers
+            // Delete all relation between this Remote Server and pollers
             $pearDB->query(
                 "DELETE FROM rs_poller_relation WHERE remote_server_id = '" . $serverId . "'"
             );
         } else {
-            // Delete all relation bewteen this poller and Remote Servers
+            // Delete all relation between this poller and Remote Servers
             $pearDB->query(
                 "DELETE FROM rs_poller_relation WHERE poller_server_id = '" . $serverId . "'"
             );


### PR DESCRIPTION
## Description

Fix a bug where when we delete a remote server from the Configuration > Poller Form, its children where also removed. Now they are reattached to the Central.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add a Remote from the wizard, then attach a Poller to it.

Delete The Remote. The poller should now be link to the Central

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
