### PR TITLE
MON-5552: too much rows in extended_service_informations

### DIFF
--- a/www/class/config-generate-remote/Relations/ExtendedHostInformation.php
+++ b/www/class/config-generate-remote/Relations/ExtendedHostInformation.php
@@ -47,7 +47,7 @@ class ExtendedHostInformation extends AbstractObject
     public function add(array $object, int $hostId)
     {
         if ($this->checkGenerate($hostId)) {
-            return null
+            return null;
         }
 
         $object['host_host_id'] = $hostId;

--- a/www/class/config-generate-remote/Relations/ExtendedHostInformation.php
+++ b/www/class/config-generate-remote/Relations/ExtendedHostInformation.php
@@ -46,7 +46,11 @@ class ExtendedHostInformation extends AbstractObject
      */
     public function add(array $object, int $hostId)
     {
+        if ($this->checkGenerate($hostId)) {
+            return null
+        }
+
         $object['host_host_id'] = $hostId;
-        $this->generateObjectInFile($object);
+        $this->generateObjectInFile($object, $hostId);
     }
 }

--- a/www/class/config-generate-remote/Relations/ExtendedServiceInformation.php
+++ b/www/class/config-generate-remote/Relations/ExtendedServiceInformation.php
@@ -45,7 +45,11 @@ class ExtendedServiceInformation extends AbstractObject
      */
     public function add(array $object, int $serviceId)
     {
+        if ($this->checkGenerate($serviceId)) {
+            return null
+        }
+
         $object['service_service_id'] = $serviceId;
-        $this->generateObjectInFile($object);
+        $this->generateObjectInFile($object, $serviceId);
     }
 }

--- a/www/class/config-generate-remote/Relations/ExtendedServiceInformation.php
+++ b/www/class/config-generate-remote/Relations/ExtendedServiceInformation.php
@@ -46,7 +46,7 @@ class ExtendedServiceInformation extends AbstractObject
     public function add(array $object, int $serviceId)
     {
         if ($this->checkGenerate($serviceId)) {
-            return null
+            return null;
         }
 
         $object['service_service_id'] = $serviceId;


### PR DESCRIPTION
## Description

Too much rows in extended_service_informations

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Link a remote server to several pollers
- Export the configuration of the remote server
- wait for synchronization to finish

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
