### PR TITLE
fix(timeline): avoid duplicated events on engine restart

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
@@ -289,6 +289,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
             AND (l.service_id = " . ($serviceId !== null ? ':service_id)' : '0 OR l.service_id IS NULL)') . "
             AND l.msg_type IN (0,1,8,9)
             AND l.output NOT LIKE 'INITIAL % STATE:%'
+            AND l.instance_name != ''
         ");
 
         $collector->addValue(':host_id', $hostId, \PDO::PARAM_INT);


### PR DESCRIPTION
## Description

avoid duplicated events on engine restart

**Fixes**MON-6156

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)