### PR TITLE
MON-6152: partitioning starts at epoch

### DIFF
--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -142,10 +142,15 @@ class PartEngine
         date_default_timezone_set($table->getTimezone());
         $how_much_forward = 0;
         $ltime = localtime();
-        $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3], $ltime[5] + 1900);
+        $currentTime = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3], $ltime[5] + 1900);
+
+        # Avoid to add since 1970 if we have only pmax partition
+        if ($lastTime == 0) {
+            $lastTime = $currentTime;
+        }
 
         # Gap when you have a cron not updated
-        while ($lastTime < $current_time) {
+        while ($lastTime < $currentTime) {
             $ntime = localtime($lastTime);
             $lastTime = $this->updateAddDailyPartitions(
                 $db,
@@ -156,9 +161,9 @@ class PartEngine
                 $hasMaxValuePartition
             );
         }
-        while ($current_time < $lastTime) {
+        while ($currentTime < $lastTime) {
             $how_much_forward++;
-            $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3] + $how_much_forward, $ltime[5] + 1900);
+            $currentTime = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3] + $how_much_forward, $ltime[5] + 1900);
         }
         $num_days_forward = $table->getRetentionForward();
         while ($how_much_forward < $num_days_forward) {


### PR DESCRIPTION
## Description

In some cases, when installing a fresh Centreon Central, partitioning is done starting at epoch.

It has been seen several times with the OVF/OVA build.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [X] 20.04.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

-

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
