### PR TITLE
fix(openid): remove php warning

### DIFF
--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -161,13 +161,15 @@ class CentreonAuthSSO extends CentreonAuth
                     }
                 }
 
-                $user = $this->getOpenIdConnectIntrospectionToken(
-                    $introspectionEndpoint,
-                    $clientId,
-                    $clientSecret,
-                    $tokenInfo['access_token'],
-                    $verifyPeer
-                );
+                if (!empty($tokenInfo) && is_array($tokenInfo)) {
+                    $user = $this->getOpenIdConnectIntrospectionToken(
+                        $introspectionEndpoint,
+                        $clientId,
+                        $clientSecret,
+                        $tokenInfo['access_token'],
+                        $verifyPeer
+                    );
+                }
 
                 if (!isset($user["preferred_username"]) && isset($userInfoEndpoint)) {
                     $user = $this->getOpenIdConnectUserInfo(

--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -161,7 +161,7 @@ class CentreonAuthSSO extends CentreonAuth
                     }
                 }
 
-                if (!empty($tokenInfo) && is_array($tokenInfo)) {
+                if (!empty($tokenInfo['access_token'])) {
                     $user = $this->getOpenIdConnectIntrospectionToken(
                         $introspectionEndpoint,
                         $clientId,


### PR DESCRIPTION
## Description

Remove PHP warning:

```
[15-Oct-2020 15:00:16 Europe/Paris] PHP Fatal error:  Uncaught TypeError: Argument 4 passed to CentreonAuthSSO::getOpenIdConnectIntrospectionToken() must be of the type string, null given, called in /usr/share/centreon/www/class/centreonAuth.SSO.class.php on line 169 and defined in /usr/share/centreon/www/class/centreonAuth.SSO.class.php:339
Stack trace:
#0 /usr/share/centreon/www/class/centreonAuth.SSO.class.php(169): CentreonAuthSSO->getOpenIdConnectIntrospectionToken('http://10.30.2....', 'testing-jira-ti...', 'b890d1c9-3d67-4...', NULL, '0')
#1 /usr/share/centreon/www/include/core/login/processLogin.php(100): CentreonAuthSSO->__construct(Object(Pimple\Container), NULL, NULL, 0, Object(CentreonDB), Object(CentreonUserLog), 1, '', Array)
#2 /usr/share/centreon/www/include/core/login/login.php(68): require_once('/usr/share/cent...')
#3 /usr/share/centreon/www/index.php(142): include_once('/usr/share/cent...')
#4 {main}
  thrown in /usr/share/centreon/www/class/centreonAuth.SSO.class.php on line 339
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
