### PR TITLE
fix(openid): fix PHP warning

### DIFF
--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -179,7 +179,7 @@ class CentreonAuthSSO extends CentreonAuth
                     );
                 }
 
-                if (!isset($user['error'])) {
+                if (!isset($user['error']) && isset($user["preferred_username"])) {
                     $this->ssoUsername = $user["preferred_username"];
                     if ($this->checkSsoClient()) {
                         $this->ssoMandatory = 1;


### PR DESCRIPTION
## Description

Fix PHP warning when user is disconnected:

`[19-Oct-2020 11:14:54 Europe/Paris] PHP Notice:  Undefined variable: user in /usr/share/centreon/www/class/centreonAuth.SSO.class.php on line 183`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
