### PR TITLE
fix(api): fix search of servicegroups by name

### DIFF
--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -808,15 +808,8 @@ paths:
 
         The available parameters to **search** / **sort_by** are:
 
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.state
-        * poller.id
-        * service.display_name
-        * service_group.id
-        * service_group.name
+        * id
+        * name
       parameters:
         - $ref: '#/components/parameters/ShowService'
         - $ref: '#/components/parameters/ShowHost'
@@ -4013,10 +4006,6 @@ components:
           type: string
           description: "Name of the service group"
           example: "MySG"
-        host:
-          allOf:
-            - $ref: '#/components/schemas/Monitoring.HostMin'
-            - $ref: '#/components/schemas/Monitoring.HostWithService'
     Monitoring.ServiceMin:
       type: object
       properties:

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -928,9 +928,9 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $serviceGroups;
         }
 
-        $hostGroupConcordanceArray = [
-            'id' => 'hg.hostgroup_id',
-            'name' => 'hg.name'
+        $serviceGroupConcordanceArray = [
+            'id' => 'sg.servicegroup_id',
+            'name' => 'sg.name'
         ];
 
         // To allow to find host groups relating to host information
@@ -954,14 +954,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $shouldJoinHost = false;
         if (count(array_intersect($searchParameters, array_keys($hostConcordanceArray))) > 0) {
             $shouldJoinHost = true;
-            $hostGroupConcordanceArray = array_merge($hostGroupConcordanceArray, $hostConcordanceArray);
+            $serviceGroupConcordanceArray = array_merge($serviceGroupConcordanceArray, $hostConcordanceArray);
         }
 
         if (count(array_intersect($searchParameters, array_keys($serviceConcordanceArray))) > 0) {
             $shouldJoinHost = true;
-            $hostGroupConcordanceArray = array_merge($hostGroupConcordanceArray, $serviceConcordanceArray);
+            $serviceGroupConcordanceArray = array_merge($serviceGroupConcordanceArray, $serviceConcordanceArray);
         }
-        $this->sqlRequestTranslator->setConcordanceArray($hostGroupConcordanceArray);
+        $this->sqlRequestTranslator->setConcordanceArray($serviceGroupConcordanceArray);
 
         $sqlExtraParameters = [];
         $subRequest = '';
@@ -988,14 +988,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                     ON gcgr.acl_group_id = grp.acl_group_id
                 LEFT JOIN `:db`.contactgroup_contact_relation cgcr
                     ON cgcr.contactgroup_cg_id = gcgr.cg_cg_id
-                    AND cgcr.contact_contact_id = :contact_id 
+                    AND cgcr.contact_contact_id = :contact_id
                     OR gcr.contact_contact_id = :contact_id';
         }
 
         // This join will only be added if a search parameter corresponding to one of the host parameter
         if ($shouldJoinHost) {
             $subRequest .=
-                ' INNER JOIN `:dbstg`.services_servicegroups ssg 
+                ' INNER JOIN `:dbstg`.services_servicegroups ssg
                     ON ssg.servicegroup_id = sg.servicegroup_id
                     AND ssg.service_id = srv.service_id
                 INNER JOIN `:dbstg`.hosts h
@@ -1011,7 +1011,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $request =
-            'SELECT SQL_CALC_FOUND_ROWS DISTINCT sg.* 
+            'SELECT SQL_CALC_FOUND_ROWS DISTINCT sg.*
             FROM `:dbstg`.`servicegroups` sg ' . $subRequest;
         $request = $this->translateDbName($request);
 


### PR DESCRIPTION
## Description

fix search of servicegroups by name

**Fixes** MON-5637

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Try to search in servicegroup filter of reources status page