### PR TITLE
fix(UI) use correct color codes

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -560,14 +560,14 @@ p.description a, p.description a:visited {
 /* ----------- States --------------- */
 
 .default_badge      {background-color: #00a499;}
-.host_down, .danger, .service_critical  {background-color: #e00b3d;}
-.host_unreachable, .unknown     {background-color: #818285;}
+.host_down, .danger, .service_critical  {background-color: #ED1C24;}
+.host_unreachable, .unknown     {background-color: #818185;}
 .host_downtime      {background-color: #cc99ff;}
 
-.service_ok,.host_up, .success  {background-color: #88b917;}
-.service_warning, .warning  {background-color: #ff9a13;}
+.service_ok,.host_up, .success  {background-color: #87BD23;}
+.service_warning, .warning  {background-color: #FF9913;}
 .pending    {background-color: #2AD1D4;}
-.service_unknown    {background-color: #bcbdc0;}
+.service_unknown    {background-color: #CDCDCD;}
 .info {background-color: #00bfb3;}
 .ack {background-color: #AA9C24;}
 


### PR DESCRIPTION
Hi,

## Description

Some color `#codes` are wrong, let's then update them according to the top counters ones.

All related color PRs :
https://github.com/centreon/centreon-widget-global-health/pull/23
https://github.com/centreon/centreon-widget-grid-map/pull/20
https://github.com/centreon/centreon-widget-hostgroup-monitoring/pull/36
https://github.com/centreon/centreon-widget-host-monitoring/pull/94
https://github.com/centreon/centreon-widget-servicegroup-monitoring/pull/31
https://github.com/centreon/centreon-widget-service-monitoring/pull/155
https://github.com/centreon/centreon-widget-logs/pull/16

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

Thank you 👍