### PR TITLE
fix(chore): add missing 20.10.0 stable upgrade script

### DIFF
--- a/www/install/php/Update-20.10.0.php
+++ b/www/install/php/Update-20.10.0.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */


### PR DESCRIPTION
## Description

Add 20.10.0 stable upgrade script to correct displayed version in login and about pages
![image](https://user-images.githubusercontent.com/34628915/97286446-cad89880-1843-11eb-8161-dd6fe164a380.png)


Edit : the 20.10.0 stable rpm is not affected. Only internal rpms display the wrong version

**Fixes** # (none)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
