### PR TITLE
fix(web): remove service category massive change options

### DIFF
--- a/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -190,7 +190,6 @@ $form->addElement(
         null => _("More actions..."),
         "m" => _("Duplicate"),
         "d" => _("Delete"),
-        "mc" => _("Massive Change"),
         "ms" => _("Enable"),
         "mu" => _("Disable")
     ),
@@ -222,7 +221,6 @@ $form->addElement(
         null => _("More actions"),
         "m" => _("Duplicate"),
         "d" => _("Delete"),
-        "mc" => _("Massive Change"),
         "ms" => _("Enable"),
         "mu" => _("Disable")
     ),

--- a/www/include/configuration/configObject/service_categories/serviceCategories.php
+++ b/www/include/configuration/configObject/service_categories/serviceCategories.php
@@ -67,9 +67,6 @@ $aclDbName = $acl->getNameDBAcl();
 $scString = $acl->getServiceCategoriesString();
 
 switch ($o) {
-    case "mc":
-        require_once($path . "formServiceCategories.php");
-        break; # Massive Change
     case "a":
         require_once($path . "formServiceCategories.php");
         break; #Add a service category


### PR DESCRIPTION
## Description

Remove the massive change option from configuration > services > categories menu.
As this option is not implemented at all
![image](https://user-images.githubusercontent.com/34628915/97337394-84555f00-1880-11eb-8e0e-6c0b6449f9c9.png)


And no submit is available 
![image](https://user-images.githubusercontent.com/34628915/97337439-946d3e80-1880-11eb-82d5-c4372e3b543b.png)

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

