### PR TITLE
fix(web): remove service category massive change options

### DIFF
--- a/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -30,9 +31,6 @@
  * do not wish to do so, delete this exception statement from your version.
  *
  * For more information : contact@centreon.com
- *
- * SVN : $URL$
- * SVN : $Id$
  *
  */
 
@@ -161,7 +159,7 @@ for ($i = 0; $sc = $DBRESULT->fetchRow(); $i++) {
                 "else if (this.form.elements['o1'].selectedIndex == 3 || this.form.elements['o1'].selectedIndex == 4 ||this.form.elements['o1'].selectedIndex == 5){" .
                 " 	setO(this.form.elements['o1'].value); submit();} " .
                 "this.form.elements['o1'].selectedIndex = 0");
-    $form->addElement('select', 'o1', null, array(null=>_("More actions..."), "m"=>_("Duplicate"), "d"=>_("Delete"), "mc"=>_("Massive Change"), "ms"=>_("Enable"), "mu"=>_("Disable")), $attrs1);
+    $form->addElement('select', 'o1', null, array(null=>_("More actions..."), "m"=>_("Duplicate"), "d"=>_("Delete"), "ms"=>_("Enable"), "mu"=>_("Disable")), $attrs1);
     $form->setDefaults(array('o1' => null));
 
     $attrs2 = array(
@@ -176,7 +174,7 @@ for ($i = 0; $sc = $DBRESULT->fetchRow(); $i++) {
                 "else if (this.form.elements['o2'].selectedIndex == 3 || this.form.elements['o2'].selectedIndex == 4 ||this.form.elements['o2'].selectedIndex == 5){" .
                 " 	setO(this.form.elements['o2'].value); submit();} " .
                 "this.form.elements['o2'].selectedIndex = 0");
-    $form->addElement('select', 'o2', null, array(null=>_("More actions"), "m"=>_("Duplicate"), "d"=>_("Delete"), "mc"=>_("Massive Change"), "ms"=>_("Enable"), "mu"=>_("Disable")), $attrs2);
+    $form->addElement('select', 'o2', null, array(null=>_("More actions"), "m"=>_("Duplicate"), "d"=>_("Delete"), "ms"=>_("Enable"), "mu"=>_("Disable")), $attrs2);
     $form->setDefaults(array('o2' => null));
 
     $o1 = $form->getElement('o1');

--- a/www/include/configuration/configObject/service_categories/serviceCategories.php
+++ b/www/include/configuration/configObject/service_categories/serviceCategories.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -58,7 +59,7 @@ require_once 'HTML/QuickForm/Renderer/ArraySmarty.php';
 $path = "./include/configuration/configObject/service_categories/";
 
 #PHP functions
-require_once $path."DB-Func.php";
+require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
 /* Set the real page */
@@ -72,45 +73,41 @@ $aclDbName = $acl->getNameDBAcl();
 $scString = $acl->getServiceCategoriesString();
 
 switch ($o) {
-    case "mc":
-        require_once($path."formServiceCategories.php");
-        break; # Massive Change
     case "a":
-        require_once($path."formServiceCategories.php");
-        break; #Add a service category
+        // Add a service category
     case "w":
-        require_once($path."formServiceCategories.php");
-        break; #Watch a service category
+        // Watch a service category
     case "c":
-        require_once($path."formServiceCategories.php");
-        break; #Modify a service category
+        // Modify a service category
+        require_once($path . "formServiceCategories.php");
+        break;
     case "s":
+        // Activate a Service category
         enableServiceCategorieInDB($sc_id);
-        require_once($path."listServiceCategories.php");
-        break; #Activate a Service category
+        require_once($path . "listServiceCategories.php");
+        break;
     case "ms":
         enableServiceCategorieInDB(null, isset($select) ? $select : array());
-        require_once($path."listServiceCategories.php");
+        require_once($path . "listServiceCategories.php");
         break;
     case "u":
+        // Deactivate a Service category
         disableServiceCategorieInDB($sc_id);
-        require_once($path."listServiceCategories.php");
-        break; #Desactivate a service category
+        require_once($path . "listServiceCategories.php");
+        break;
     case "mu":
         disableServiceCategorieInDB(null, isset($select) ? $select : array());
-        require_once($path."listServiceCategories.php");
+        require_once($path . "listServiceCategories.php");
         break;
-
     case "m":
+        // Duplicate n service categories
         multipleServiceCategorieInDB(isset($select) ? $select : array(), $dupNbr);
-        require_once($path."listServiceCategories.php");
-        break; #Duplicate n service categories
-
+        require_once($path . "listServiceCategories.php");
+        break;
     case "d":
+        // Delete n service categories
         deleteServiceCategorieInDB(isset($select) ? $select : array());
-        require_once($path."listServiceCategories.php");
-        break; #Delete n service categories
     default:
-        require_once($path."listServiceCategories.php");
+        require_once($path . "listServiceCategories.php");
         break;
 }


### PR DESCRIPTION
## Description

Remove the massive change option from configuration > services > categories menu.
As this option is not implemented at all
![image](https://user-images.githubusercontent.com/34628915/97337394-84555f00-1880-11eb-8e0e-6c0b6449f9c9.png)

And no submit is available 
![image](https://user-images.githubusercontent.com/34628915/97337439-946d3e80-1880-11eb-82d5-c4372e3b543b.png)

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x