### PR TITLE
enh(ui): disable UI notification mechanism if not needed by user

### DIFF
--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -43,8 +43,8 @@ if (!isset($sid) || !isset($_GET['refresh_rate'])) {
     exit;
 }
 
-$refresh_rate = (int)$_GET['refresh_rate'] / 1000;
-$refresh_rate += ($refresh_rate / 2);
+$refreshRate = (int)$_GET['refresh_rate'] / 1000;
+$refreshRate += ($refreshRate / 2);
 
 $obj = new CentreonXMLBGRequest($dependencyInjector, $sid, 1, 1, 0, 1);
 
@@ -57,17 +57,47 @@ if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id,
     exit;
 }
 
-$service_state_label = array(0 => "OK", 1 => "Warning", 2 => "Critical", 3 => "Unknown");
-$service_class_label = array(0 => "success", 1 => "warning", 2 => "error", 3 => "alert");
-$host_state_label = array(0 => "Up", 1 => "Down", 2 => "Unreachable");
-$host_class_label = array(0 => "success", 1 => "error", 2 => "alert");
+if (!isset($_SESSION['centreon_notification_preferences'])) {
+    $userId = $centreon->user->get_id();
+    $resPref = $obj->DB->query("SELECT cp_key, cp_value
+         FROM contact_param 
+         WHERE cp_key LIKE 'monitoring%notification%'
+         AND cp_contact_id = '" . $obj->DB->escape($userId) . "'");
+    $notificationPreferences = [];
+    while ($rowPref = $resPref->fetch()) {
+        $notificationPreferences[$rowPref['cp_key']] = $rowPref['cp_value'];
+    }
+    $_SESSION['centreon_notification_preferences'] = $notificationPreferences;
+} else {
+    $notificationPreferences = $_SESSION['centreon_notification_preferences'];
+}
+$notificationEnabled = 0;
+foreach ($notificationPreferences as $key => $value) {
+    if (preg_match('/monitoring_(host|svc)_notification_/', $key) && !is_null($value) && $value == 1) {
+        $notificationEnabled = 1;
+        break;
+    }
+}
+
+if ($notificationEnabled == 0) {
+    $obj->XML->startElement("data");
+    $obj->XML->endElement();
+    $obj->header();
+    $obj->XML->output();
+    return;
+}
+
+$serviceStateLabel = array(0 => "OK", 1 => "Warning", 2 => "Critical", 3 => "Unknown");
+$serviceClassLabel = array(0 => "success", 1 => "warning", 2 => "error", 3 => "alert");
+$hostStateLabel = array(0 => "Up", 1 => "Down", 2 => "Unreachable");
+$hostClassLabel = array(0 => "success", 1 => "error", 2 => "alert");
 
 $sql = "SELECT name, description, s.state
         FROM services s, hosts h %s
         WHERE h.host_id = s.host_id
         AND h.name NOT LIKE '\_Module\_%%'
         AND (description NOT LIKE 'meta\_%%' AND description NOT LIKE 'ba\_%%')
-        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refresh_rate.")
+        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
         AND s.scheduled_downtime_depth=0
         AND s.acknowledged=0
         %s
@@ -77,7 +107,7 @@ $sql = "SELECT name, description, s.state
         WHERE h.host_id = s.host_id
         AND h.name LIKE '\_Module\_Meta%%'
         AND description LIKE 'meta\_%%'
-        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refresh_rate.")
+        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
         AND s.scheduled_downtime_depth=0
         AND s.acknowledged=0
         %s
@@ -87,7 +117,7 @@ $sql = "SELECT name, description, s.state
         WHERE h.host_id = s.host_id
         AND h.name LIKE '\_Module\_BAM%%'
         AND description LIKE 'ba\_%%'
-        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refresh_rate.")
+        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
         AND s.scheduled_downtime_depth=0
         AND s.acknowledged=0
         %s
@@ -95,7 +125,7 @@ $sql = "SELECT name, description, s.state
         SELECT name, NULL, h.state
         FROM hosts h %s
         WHERE name NOT LIKE '\_Module\_%%'
-        AND h.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refresh_rate.")
+        AND h.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
         AND h.scheduled_downtime_depth=0
         AND h.acknowledged=0
         %s";
@@ -119,63 +149,49 @@ if ($obj->is_admin) {
 }
 $res = $obj->DBC->query($sql);
 $obj->XML->startElement("data");
-if (!isset($_SESSION['centreon_notification_preferences'])) {
-    $user_id = $centreon->user->get_id();
-    $res_pref = $obj->DB->query("SELECT cp_key, cp_value
-         FROM contact_param 
-         WHERE cp_key LIKE 'monitoring%notification%'
-         AND cp_contact_id = '" . $obj->DB->escape($user_id) . "'");
-    $notification_preferences = array();
-    while ($row_pref = $res_pref->fetch()) {
-        $notification_preferences[$row_pref['cp_key']] = $row_pref['cp_value'];
-    }
-    $_SESSION['centreon_notification_preferences'] = $notification_preferences;
-} else {
-    $notification_preferences = $_SESSION['centreon_notification_preferences'];
-}
 while ($row = $res->fetch()) {
     $obj->XML->startElement("message");
     if ($row['description']) {
-        if (isset($notification_preferences['monitoring_svc_notification_' . $row['state']])) {
+        if (isset($notificationPreferences['monitoring_svc_notification_' . $row['state']])) {
             $obj->XML->writeAttribute(
                 "output",
                 sprintf(
                     "%s / %s is %s",
                     $row['name'],
                     $row['description'],
-                    $service_state_label[$row['state']]
+                    $serviceStateLabel[$row['state']]
                 )
             );
-            $obj->XML->writeAttribute("class", $service_class_label[$row['state']]);
+            $obj->XML->writeAttribute("class", $serviceClassLabel[$row['state']]);
         }
         if (!isset($_SESSION['disable_sound']) &&
-            isset($notification_preferences['monitoring_sound_svc_notification_' . $row['state']]) &&
-            $notification_preferences['monitoring_sound_svc_notification_' . $row['state']]
+            isset($notificationPreferences['monitoring_sound_svc_notification_' . $row['state']]) &&
+            $notificationPreferences['monitoring_sound_svc_notification_' . $row['state']]
         ) {
             $obj->XML->writeAttribute(
                 "sound",
-                $notification_preferences['monitoring_sound_svc_notification_' . $row['state']]
+                $notificationPreferences['monitoring_sound_svc_notification_' . $row['state']]
             );
         }
     } else {
-        if (isset($notification_preferences['monitoring_host_notification_' . $row['state']])) {
+        if (isset($notificationPreferences['monitoring_host_notification_' . $row['state']])) {
             $obj->XML->writeAttribute(
                 "output",
                 sprintf(
                     "%s is %s",
                     $row['name'],
-                    $host_state_label[$row['state']]
+                    $hostStateLabel[$row['state']]
                 )
             );
-            $obj->XML->writeAttribute("class", $host_class_label[$row['state']]);
+            $obj->XML->writeAttribute("class", $hostClassLabel[$row['state']]);
         }
         if (!isset($_SESSION['disable_sound']) &&
-            isset($notification_preferences['monitoring_sound_host_notification_' . $row['state']]) &&
-            $notification_preferences['monitoring_sound_host_notification_' . $row['state']]
+            isset($notificationPreferences['monitoring_sound_host_notification_' . $row['state']]) &&
+            $notificationPreferences['monitoring_sound_host_notification_' . $row['state']]
         ) {
             $obj->XML->writeAttribute(
                 "sound",
-                $notification_preferences['monitoring_sound_host_notification_' . $row['state']]
+                $notificationPreferences['monitoring_sound_host_notification_' . $row['state']]
             );
         }
     }

--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -71,15 +71,15 @@ if (!isset($_SESSION['centreon_notification_preferences'])) {
 } else {
     $notificationPreferences = $_SESSION['centreon_notification_preferences'];
 }
-$notificationEnabled = 0;
+$notificationEnabled = false;
 foreach ($notificationPreferences as $key => $value) {
     if (preg_match('/monitoring_(host|svc)_notification_/', $key) && !is_null($value) && $value == 1) {
-        $notificationEnabled = 1;
+        $notificationEnabled = true;
         break;
     }
 }
 
-if ($notificationEnabled == 0) {
+if ($notificationEnabled === false) {
     $obj->XML->startElement("data");
     $obj->XML->endElement();
     $obj->header();

--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -167,7 +167,8 @@ while ($row = $res->fetch()) {
                 $serviceClassLabel[$row['state']]
             );
         }
-        if (!isset($_SESSION['disable_sound']) &&
+        if (
+            !isset($_SESSION['disable_sound']) &&
             isset($notificationPreferences['monitoring_sound_svc_notification_' . $row['state']]) &&
             $notificationPreferences['monitoring_sound_svc_notification_' . $row['state']]
         ) {
@@ -191,7 +192,8 @@ while ($row = $res->fetch()) {
                 $hostClassLabel[$row['state']]
             );
         }
-        if (!isset($_SESSION['disable_sound']) &&
+        if (
+            !isset($_SESSION['disable_sound']) &&
             isset($notificationPreferences['monitoring_sound_host_notification_' . $row['state']]) &&
             $notificationPreferences['monitoring_sound_host_notification_' . $row['state']]
         ) {

--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -97,7 +97,7 @@ $sql = "SELECT name, description, s.state
         WHERE h.host_id = s.host_id
         AND h.name NOT LIKE '\_Module\_%%'
         AND (description NOT LIKE 'meta\_%%' AND description NOT LIKE 'ba\_%%')
-        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
+        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - " . (int)$refreshRate . ")
         AND s.scheduled_downtime_depth=0
         AND s.acknowledged=0
         %s
@@ -107,7 +107,7 @@ $sql = "SELECT name, description, s.state
         WHERE h.host_id = s.host_id
         AND h.name LIKE '\_Module\_Meta%%'
         AND description LIKE 'meta\_%%'
-        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
+        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - " . (int)$refreshRate . ")
         AND s.scheduled_downtime_depth=0
         AND s.acknowledged=0
         %s
@@ -117,7 +117,7 @@ $sql = "SELECT name, description, s.state
         WHERE h.host_id = s.host_id
         AND h.name LIKE '\_Module\_BAM%%'
         AND description LIKE 'ba\_%%'
-        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
+        AND s.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - " . (int)$refreshRate . ")
         AND s.scheduled_downtime_depth=0
         AND s.acknowledged=0
         %s
@@ -125,7 +125,7 @@ $sql = "SELECT name, description, s.state
         SELECT name, NULL, h.state
         FROM hosts h %s
         WHERE name NOT LIKE '\_Module\_%%'
-        AND h.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - ".(int)$refreshRate.")
+        AND h.last_hard_state_change > (UNIX_TIMESTAMP(NOW()) - " . (int)$refreshRate . ")
         AND h.scheduled_downtime_depth=0
         AND h.acknowledged=0
         %s";
@@ -162,7 +162,10 @@ while ($row = $res->fetch()) {
                     $serviceStateLabel[$row['state']]
                 )
             );
-            $obj->XML->writeAttribute("class", $serviceClassLabel[$row['state']]);
+            $obj->XML->writeAttribute(
+                "class",
+                $serviceClassLabel[$row['state']]
+            );
         }
         if (!isset($_SESSION['disable_sound']) &&
             isset($notificationPreferences['monitoring_sound_svc_notification_' . $row['state']]) &&
@@ -183,7 +186,10 @@ while ($row = $res->fetch()) {
                     $hostStateLabel[$row['state']]
                 )
             );
-            $obj->XML->writeAttribute("class", $hostClassLabel[$row['state']]);
+            $obj->XML->writeAttribute(
+                "class",
+                $hostClassLabel[$row['state']]
+            );
         }
         if (!isset($_SESSION['disable_sound']) &&
             isset($notificationPreferences['monitoring_sound_host_notification_' . $row['state']]) &&


### PR DESCRIPTION
## Description

This story aims to “disable” the alerts retrieving mechanism if user don’t want any notification.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
