### PR TITLE
fix(configuration): move session_expire validation rule after required

### DIFF
--- a/www/include/Administration/parameters/general/form.php
+++ b/www/include/Administration/parameters/general/form.php
@@ -89,12 +89,6 @@ $form->addElement('text', 'oreon_path', _("Directory"), $attrsText);
 $form->addElement('text', 'oreon_web_path', _("Centreon Web Directory"), $attrsText);
 
 $form->addElement('text', 'session_expire', _("Sessions Expiration Time"), $attrsText2);
-$form->registerRule('isSessionDurationValid', 'callback', 'isSessionDurationValid');
-$form->addRule(
-    'session_expire',
-    _("This value needs to be an integer lesser than") . " " . SESSION_DURATION_LIMIT . " min",
-    'isSessionDurationValid'
-);
 
 $inheritanceMode = array();
 $inheritanceMode[] = $form->createElement(
@@ -352,6 +346,12 @@ $form->addRule('maxViewMonitoring', _('Mandatory field'), 'required');
 $form->addRule('maxViewMonitoring', _('Must be a number'), 'numeric');
 $form->addRule('session_expire', _('Mandatory field'), 'required');
 $form->addRule('session_expire', _('Must be a number'), 'numeric');
+$form->registerRule('isSessionDurationValid', 'callback', 'isSessionDurationValid');
+$form->addRule(
+    'session_expire',
+    _("This value needs to be an integer lesser than") . " " . SESSION_DURATION_LIMIT . " min",
+    'isSessionDurationValid'
+);
 
 /*
  * Smarty template Init


### PR DESCRIPTION
## Description

move session_expire validation rule after required rule
It validates it's an integer before checking the value against session duration limit

**Fixes** MON-6241

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)