### PR TITLE
fix(sec): fix 'reach centreon frontend' option management

### DIFF
--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -327,6 +327,7 @@ class CentreonAuth
                         "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication succeeded for '" . $username . "'"
                     );
                 } else {
+                    $this->passwdOk = 0;
                     $this->CentreonLog->insertLog(
                         1,
                         "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] '" . $username . "' is not allowed to reach Centreon"


### PR DESCRIPTION
## Description

do not allow a user to login to centreon frontend if "reach centreon frontend" is set to "no"

**Fixes** MON-6215

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)