### PR TITLE
fix(engine configuration): Correctly set debug verbosity

### DIFF
--- a/www/include/configuration/configNagios/DB-Func.php
+++ b/www/include/configuration/configNagios/DB-Func.php
@@ -251,7 +251,6 @@ function insertNagios($ret = array(), $brokerTab = array())
     if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-
     $rq = "INSERT INTO cfg_nagios ("
         . "`nagios_id` , `nagios_name` , `use_timezone`, `nagios_server_id`, `log_file` , `cfg_dir` , "
         . "`temp_file` , "
@@ -1002,8 +1001,8 @@ function insertNagios($ret = array(), $brokerTab = array())
         $rq .= "'0', ";
     }
 
-    if (isset($ret["debug_verbosity"]["debug_verbosity"]) && $ret["debug_verbosity"]["debug_verbosity"] != 2) {
-        $rq .= "'" . $ret["debug_verbosity"]["debug_verbosity"] . "',  ";
+    if (isset($ret["debug_verbosity"]) && $ret["debug_verbosity"] != 2) {
+        $rq .= "'" . $ret["debug_verbosity"] . "',  ";
     } else {
         $rq .= "'2', ";
     }
@@ -2021,8 +2020,8 @@ function updateNagios($nagios_id = null)
         $rq .= "debug_level = NULL, ";
     }
 
-    if (isset($ret["debug_verbosity"]["debug_verbosity"]) && $ret["debug_verbosity"]["debug_verbosity"] != 2) {
-        $rq .= "debug_verbosity = '" . $ret["debug_verbosity"]["debug_verbosity"] . "',  ";
+    if (isset($ret["debug_verbosity"]) && $ret["debug_verbosity"] != 2) {
+        $rq .= "debug_verbosity = '" . $ret["debug_verbosity"] . "',  ";
     } else {
         $rq .= "debug_verbosity = '2', ";
     }


### PR DESCRIPTION
## Description

This PR Remove an inexistent index in POST values, to correctly write or update the debug_verbosity into cfg_nagios. 

**Fixes** # MON-6239

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to Configurations > Poller > Engine Configuration >  Select a Poller > Debug Tab, set the debug verbosity to anything else than Highly Detailed Information.
- Save the form
- Return to the Debug tab. the value of debug_verbosity should be the chosen one.

- Go to Configurations > Poller > Engine Configuration >  click on Add Button set the debug verbosity to anything else than Highly Detailed Information.
- Save the form
- Return to the Debug tab. the value of debug_verbosity should be the chosen one.

In MySQL > select debug_verbosity FROM cfg_nagios WHERE  nagios_name = "your_poller_name";
- The index should be the correct one:
    '0' => "Basic information",
    '1' => "More detailed information",
    '2' => "Highly detailed information"

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
