### PR TITLE
fix(engine configurations): Correctly set macro_filters

### DIFF
--- a/www/include/configuration/configNagios/DB-Func.php
+++ b/www/include/configuration/configNagios/DB-Func.php
@@ -2106,7 +2106,7 @@ function updateNagios($nagios_id = null)
     }
 
     /* Add whitelist macros to send to Centreon Broker */
-    if (isset($_REQUEST['macro_filter'])) {
+    if (isset($_REQUEST['macros_filter'])) {
         $macrosFilter = trim(
             join(
                 ',',

--- a/www/include/configuration/configNagios/DB-Func.php
+++ b/www/include/configuration/configNagios/DB-Func.php
@@ -1136,7 +1136,9 @@ function insertNagios($ret = array(), $brokerTab = array())
         $macrosFilter = trim(
             join(
                 ',',
-                array_map(function ($value) { return CentreonDB::escape($value); }, $_REQUEST['macros_filter'])
+                array_map(function ($value) {
+                    return CentreonDB::escape($value);
+                }, $_REQUEST['macros_filter'])
             )
         );
         $rq .= "'" . $macrosFilter . "')";
@@ -2110,7 +2112,9 @@ function updateNagios($nagios_id = null)
         $macrosFilter = trim(
             join(
                 ',',
-                array_map(function ($value) { return CentreonDB::escape($value); }, $_REQUEST['macros_filter'])
+                array_map(function ($value) {
+                    return CentreonDB::escape($value);
+                }, $_REQUEST['macros_filter'])
             )
         );
         $rq .= "macros_filter = '" . $macrosFilter . "', ";

--- a/www/include/configuration/configNagios/DB-Func.php
+++ b/www/include/configuration/configNagios/DB-Func.php
@@ -1130,14 +1130,19 @@ function insertNagios($ret = array(), $brokerTab = array())
     } else {
         $rq .= "'0', ";
     }
+
     /* Add whitelist macros to send to Centreon Broker */
-    $macrosFilter = trim(
-        join(
-            ',',
-            array_map(function ($value) { return CentreonDB::escape($value); }, $_REQUEST['macros_filter'])
-        )
-    );
-    $rq .= "'" . $macrosFilter . "')";
+    if (isset($_REQUEST['macros_filter'])) {
+        $macrosFilter = trim(
+            join(
+                ',',
+                array_map(function ($value) { return CentreonDB::escape($value); }, $_REQUEST['macros_filter'])
+            )
+        );
+        $rq .= "'" . $macrosFilter . "')";
+    } else {
+        $rq .= "NULL)";
+    }
 
     $dbResult = $pearDB->query($rq);
     $dbResult = $pearDB->query("SELECT MAX(nagios_id) FROM cfg_nagios");
@@ -2101,13 +2106,17 @@ function updateNagios($nagios_id = null)
     }
 
     /* Add whitelist macros to send to Centreon Broker */
-    $macrosFilter = trim(
-        join(
-            ',',
-            array_map(function ($value) { return CentreonDB::escape($value); }, $_REQUEST['macros_filter'])
-        )
-    );
-    $rq .= "macros_filter = '" . $macrosFilter . "', ";
+    if (isset($_REQUEST['macro_filter'])) {
+        $macrosFilter = trim(
+            join(
+                ',',
+                array_map(function ($value) { return CentreonDB::escape($value); }, $_REQUEST['macros_filter'])
+            )
+        );
+        $rq .= "macros_filter = '" . $macrosFilter . "', ";
+    } else {
+        $rq .= "macros_filter = NULL, ";
+    }
 
     $rq .= "nagios_activate = '" . $ret["nagios_activate"]["nagios_activate"] . "' ";
     $rq .= "WHERE nagios_id = '" . $nagios_id . "'";


### PR DESCRIPTION
## Description

Check if the macro_filters are set before using them into an array_map.

**Fixes** # MON-6297

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go To Configuration > Pollers > Engine Configuration
- Click on "Add" Button
- Fill the configuration name
- Submit

No Error should appears into PHP Logs

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
