### PR TITLE
fix(resource): wrong property names used in serializer for external l…

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.ResourceExternalLinks.yml
+++ b/config/packages/serializer/Centreon/Monitoring.ResourceExternalLinks.yml
@@ -1,10 +1,10 @@
 Centreon\Domain\Monitoring\ResourceExternalLinks:
     properties:
-        action_url:
+        actionUrl:
             type: string
             groups:
                 - 'resource_status_main'
-        notes_url:
+        notesUrl:
             type: string
             groups:
                 - 'resource_status_main'


### PR DESCRIPTION
…inks

## Description

External links were correctly handled for the resource detail but not for the listing serializing context due to a incorrect name for the properties

![image](https://user-images.githubusercontent.com/31647811/98663799-d51d8b00-2349-11eb-939b-c9bf405d2e87.png)


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Call listing resource endpoints and check that externals obj is populated with data set for the resources

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
