### PR TITLE
fix(security): check MIMEType of images and archives of images

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6939,6 +6939,12 @@ msgstr "Impossible"
 msgid "Add Image(s)"
 msgstr "Ajout d'image(s)"
 
+msgid "Invalid Image Format."
+msgstr "Format d'image invalide."
+
+msgid "Images already uploaded."
+msgstr "Images déjà uploadés."
+
 #: centreon-web/www/include/options/media/images/formImg.php:89
 #: centreon-web/www/include/options/media/images/formImg.php:108
 msgid "Existing or new directory"

--- a/www/class/centreonImageManager.php
+++ b/www/class/centreonImageManager.php
@@ -76,12 +76,32 @@ class CentreonImageManager extends centreonFileManager
 
         if ($parentUpload) {
             if ($insert) {
-                $img_ids[] = $this->insertImg(
-                    $this->destinationPath,
-                    $this->destinationDir,
-                    $this->newFile,
-                    $this->comment
-                );
+                $img_ids[] = $this->insertImg();
+                return $img_ids;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Upload file from Temp Directory
+     *
+     * @param string $tempDirectory
+     * @param boolean $insert
+     * @return array|bool
+     */
+    public function uploadFromDirectory(string $tempDirectory, $insert = true)
+    {
+        $tempFullPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $tempDirectory;
+        if (!parent::fileExist()) {
+            $this->moveImage(
+                $tempFullPath . DIRECTORY_SEPARATOR . $this->rawFile['tmp_name'],
+                $this->destinationPath . DIRECTORY_SEPARATOR . $this->rawFile['name']
+            );
+            rmdir($tempFullPath);
+            if ($insert) {
+                $img_ids[] = $this->insertImg();
                 return $img_ids;
             }
         } else {
@@ -115,7 +135,7 @@ class CentreonImageManager extends centreonFileManager
         if (!empty($this->originalFile) && !empty($this->tmpFile)) {
             $this->deleteImg($this->mediaPath . $img_info["dir_alias"] . '/' . $img_info["img_path"]);
             $this->upload(false);
-            
+
             $stmt = $this->dbConfig->prepare(
                 "UPDATE view_img SET img_path  = :path WHERE img_id = :imgId"
             );
@@ -154,7 +174,7 @@ class CentreonImageManager extends centreonFileManager
         $stmt->bindParam(':dirId', $dirId);
         $stmt->bindParam(':imgId', $imgId);
         $stmt->execute();
-        
+
         return true;
     }
 

--- a/www/class/centreonImageManager.php
+++ b/www/class/centreonImageManager.php
@@ -33,12 +33,6 @@
  *
  */
 
-/**
- * Created by PhpStorm.
- * User: loic
- * Date: 31/10/17
- * Time: 11:55
- */
 class CentreonImageManager extends centreonFileManager
 {
     protected $legalExtensions;
@@ -99,7 +93,6 @@ class CentreonImageManager extends centreonFileManager
                 $tempFullPath . DIRECTORY_SEPARATOR . $this->rawFile['tmp_name'],
                 $this->destinationPath . DIRECTORY_SEPARATOR . $this->rawFile['name']
             );
-            rmdir($tempFullPath);
             if ($insert) {
                 $img_ids[] = $this->insertImg();
                 return $img_ids;

--- a/www/include/options/media/images/DB-Func.php
+++ b/www/include/options/media/images/DB-Func.php
@@ -425,7 +425,8 @@ function getListDirectory($filter = null)
 function isCorrectMIMEType($file)
 {
     $mimeType = mime_content_type($file['tmp_name']);
-    if ($mimeType !== 'image/png') {
+    var_dump($mimeType);
+    if (!preg_match('/(^image\/)|(^application\/zip$)/', $mimeType)) {
         return false;
     }
     return true;

--- a/www/include/options/media/images/DB-Func.php
+++ b/www/include/options/media/images/DB-Func.php
@@ -492,7 +492,7 @@ function removeRecursiveTempDirectory(string $dir): void
     if (is_dir($dir)) {
         $objects = scandir($dir);
         foreach ($objects as $object) {
-            if ($object != "." && $object != "..") {
+            if ($object !== "." && $object !== "..") {
                 if (is_dir($dir . DIRECTORY_SEPARATOR . $object) && !is_link($dir . DIRECTORY_SEPARATOR . $object)) {
                     removeRecursiveTempDirectory($dir . DIRECTORY_SEPARATOR . $object);
                 } else {

--- a/www/include/options/media/images/DB-Func.php
+++ b/www/include/options/media/images/DB-Func.php
@@ -337,7 +337,7 @@ function deleteDirectory($directoryId)
 {
     global $pearDB;
     $mediadir = "./img/media/";
-    
+
     $directoryId = (int) $directoryId;
     /*
      * Purge images of the directory
@@ -420,4 +420,13 @@ function getListDirectory($filter = null)
     }
     $dbresult->closeCursor();
     return $list_dir;
+}
+
+function isCorrectMIMEType($file)
+{
+    $mimeType = mime_content_type($file['tmp_name']);
+    if ($mimeType !== 'image/png') {
+        return false;
+    }
+    return true;
 }

--- a/www/include/options/media/images/formImg.php
+++ b/www/include/options/media/images/formImg.php
@@ -233,10 +233,13 @@ if ($form->validate()) {
     $imgId = $form->getElement('img_id')->getValue();
     $imgPath = $form->getElement('directories')->getValue();
     $imgComment = $form->getElement('img_comment')->getValue();
+    /**
+     * Check if an archive has been extracted into pendingMedia folder
+     */
     $filesToUpload = getFilesFromTempDirectory('pendingMedia');
 
     /**
-     * If an archive .zip or .tgz is uploaded
+     * If a single image is uploaded
      */
     if (empty($filesToUpload)) {
         $oImageUploader = new CentreonImageManager(
@@ -257,7 +260,7 @@ if ($form->validate()) {
             $form->setElementError('filename', "An image is not uploaded.");
         }
     /**
-     * If a single image is uploaded
+     * If an archive .zip or .tgz is uploaded
      */
     } else {
         foreach ($filesToUpload as $file) {
@@ -279,6 +282,9 @@ if ($form->validate()) {
                 $form->setElementError('filename', "Images already uploaded.");
             }
         }
+        /**
+         * Remove the folder after upload complete
+         */
         removeRecursiveTempDirectory(sys_get_temp_dir() . '/pendingMedia');
     }
 }

--- a/www/include/options/media/images/formImg.php
+++ b/www/include/options/media/images/formImg.php
@@ -111,6 +111,8 @@ if ($o == IMAGE_ADD) {
             "class" => "btc bt_success"
         )
     );
+    $form->registerRule('isCorrectMIMEType', 'callback', 'isCorrectMIMEType');
+    $form->addRule('filename', _('Invalid MIME type'), 'isCorrectMIMEType');
 } elseif ($o == IMAGE_MODIFY) {
     $form->addElement('header', 'title', _("Modify Image"));
     $form->addElement('text', 'img_name', _("Image Name"), $attrsText);


### PR DESCRIPTION
## Description

Fix an issue were it was possible to upload images or archive of images with invalid(s) MIME. 

**Fixes** # MON-5920

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
