### PR TITLE
enh(sec) Password-masking algorithm improvements

### DIFF
--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -373,7 +373,14 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
         );
 
         if (!empty($builtCommand)) {
-            $monitoringHost->setCheckCommand($builtCommand);
+            // Hide as much as possible passwords from Centreon Plugins options which may be used in non-password macros
+            $monitoringHost->setCheckCommand(
+                preg_replace(
+                    '/(--[0-9a-z-]*pass(phrase|word)=|--snmp-community=)[^ ]+/',
+                    '$1' . $replacementValue,
+                    $builtCommand
+                )
+            );
         }
     }
 
@@ -428,7 +435,14 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
         );
 
         if (!empty($builtCommand)) {
-            $monitoringService->setCommandLine($builtCommand);
+            // Hide as much as possible passwords from Centreon Plugins options which may be used in non-password macros
+            $monitoringService->setCommandLine(
+                preg_replace(
+                    '/(--[0-9a-z-]*pass(phrase|word)=|--snmp-community=)[^ ]+/',
+                    '$1' . $replacementValue,
+                    $builtCommand
+                )
+            );
         }
     }
 }

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -345,7 +345,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
     /**
      * @inheritDoc
      */
-    public function hidePasswordInHostCommandLine(Host $monitoringHost, string $replacementValue = '***'): void
+    public function hidePasswordInHostCommandLine(Host $monitoringHost, string $replacementValue = '$pw'): void
     {
         $monitoringCommand = $monitoringHost->getCheckCommand();
         if (empty($monitoringCommand)) {
@@ -387,7 +387,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
     /**
      * @inheritDoc
      */
-    public function hidePasswordInServiceCommandLine(Service $monitoringService, string $replacementValue = '***'): void
+    public function hidePasswordInServiceCommandLine(Service $monitoringService, string $replacementValue = '$pw'): void
     {
         $monitoringCommand = $monitoringService->getCommandLine();
         if (empty($monitoringCommand)) {


### PR DESCRIPTION
Hi,

## Description

This PR follows #8663 / #8781 by @callapa.

It improves password-masking algorithm, hiding passwords from Centreon Plugins which may be used in non-password macros. This is rather simple, as password options from Centreon Plugins almost all use the same naming pattern (perhaps a rule to follow then @garnier-quentin for the upcoming plugins, so that compatibility is kept).

This PR also changes the masking pattern `***` to `$pw`, really useful when we copy the command to paste it in a shell.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Use a macro in your command, and set it to `--authpassphrase=nicePassword`.
Be sure `nicePassword` is replaced with `$pw`.

Thank you 👍