### PR TITLE
chore(documentation): add monitoring resources service details to API Doc 

### DIFF
--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -528,7 +528,7 @@ paths:
     get:
       tags:
         - Resource
-      summary: "Get a host resources informations"
+      summary: "Get a host resources information"
       description: "Return a single host with full details of its resources status."
       parameters:
         - $ref: '#/components/parameters/HostId'

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -528,7 +528,7 @@ paths:
     get:
       tags:
         - Resource
-      summary: "Get a host resources information"
+      summary: "Get information on host resources"
       description: "Return a single host with full details of its resources status."
       parameters:
         - $ref: '#/components/parameters/HostId'
@@ -3542,20 +3542,20 @@ components:
         poller_name:
           type: string
           nullable: true
-          description: "Name of the monitoring server of the Host"
+          description: "Name of the monitoring server of the host"
           example: "Central"
         timezone:
           type: string
-          description: "Timezone used by Host"
+          description: "Timezone used by the host"
           example: "Europe/Paris"
         flapping:
           type: boolean
-          description: "Host is flapping or not"
+          description: "Is host flapping"
           example: false
         percent_state_change:
           type: number
           format: float
-          description: "Percent of Host state changing"
+          description: "Percent of Host state change"
           example: 20.10
         criticality:
           type: number
@@ -3566,12 +3566,12 @@ components:
         chart_url:
           type: string
           nullable: true
-          description: "Url of chart"
+          description: "Chart URL"
         last_notification:
           type: string
           nullable: true
           format: date-time
-          description: "DateTime of the last notification"
+          description: "Last notification date and time in ISO format"
           example: "2020-02-18T00:00:00"
         notification_number:
           type: number
@@ -3583,21 +3583,21 @@ components:
           type: string
           nullable: true
           format: date-time
-          description: "next planned check"
+          description: "Next planned check"
           example: "2020-11-23T10:26:19+01:00"
-        perofrmance_data:
+        performance_data:
           type: string
-          description: "Details of performances"
+          description: "Details of performance"
           example: "rta=0,098ms;3000,000;5000,000;0; pl=0%;80;100;0;100 rtmax=0,098ms;;;; rtmin=0,098ms;;;;"
         execution_time:
           type: number
           format: float
-          description: "duration of check"
+          description: "Check duration"
           example: 0.005618
         latency:
           type: number
           format: float
-          description: "Latency of the host"
+          description: "Host Latency"
           example: 0.117
         downtimes:
           type: array

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -3531,79 +3531,80 @@ components:
                 example: "'used'=453849088B;;;0;1927262208"
     Monitoring.Resource.Host:
       allOf:
-        - $ref: '#/components/schemas/Monitoring.ResourceMain'
+        - $ref: "#/components/schemas/Monitoring.ResourceMain"
       type: object
       properties:
         command_line:
           type: string
           nullable: true
-          description: 'Check command of the host'
-          example: '/usr/lib64/nagios/plugins/check_icmp -H 127.0.0.1 -w 3000.0,80% -c 5000.0,100% -p 1'
+          description: "Check command of the host"
+          example: "/usr/lib64/nagios/plugins/check_icmp -H 127.0.0.1 -w 3000.0,80% -c 5000.0,100% -p 1"
         poller_name:
           type: string
           nullable: true
-          description: 'Name of the monitoring server of the Host'
-          example: 'Central'
+          description: "Name of the monitoring server of the Host"
+          example: "Central"
         timezone:
           type: string
-          description: 'Timezone used by Host'
-          example: 'Europe/Paris'
+          description: "Timezone used by Host"
+          example: "Europe/Paris"
         flapping:
           type: boolean
-          description: 'Host is flapping or not'
+          description: "Host is flapping or not"
           example: false
         percent_state_change:
           type: number
           format: float
-          description: 'Percent of Host state changing'
+          description: "Percent of Host state changing"
           example: 20.10
         criticality:
           type: number
           nullable: true
           format: integer
-          description: 'Criticality level'
+          description: "Criticality level"
           example: 1
         chart_url:
           type: string
           nullable: true
-          description: 'Url of chart'
+          description: "Url of chart"
         last_notification:
           type: string
           nullable: true
           format: date-time
-          description: 'DateTime of the last notification'
-          example: '2020-02-18T00:00:00'
+          description: "DateTime of the last notification"
+          example: "2020-02-18T00:00:00"
         notification_number:
           type: number
           nullable: true
           format: integer
-          description: 'Number of notifications'
+          description: "Number of notifications"
           example: 3
         next_check:
           type: string
           nullable: true
           format: date-time
-          description: 'next planned check'
-          example: '2020-11-23T10:26:19+01:00'
+          description: "next planned check"
+          example: "2020-11-23T10:26:19+01:00"
         perofrmance_data:
           type: string
-          description: 'Details of performances'
-          example: 'rta=0,098ms;3000,000;5000,000;0; pl=0%;80;100;0;100 rtmax=0,098ms;;;; rtmin=0,098ms;;;;'
+          description: "Details of performances"
+          example: "rta=0,098ms;3000,000;5000,000;0; pl=0%;80;100;0;100 rtmax=0,098ms;;;; rtmin=0,098ms;;;;"
         execution_time:
           type: number
           format: float
-          description: 'duration of check'
+          description: "duration of check"
           example: 0.005618
         latency:
           type: number
           format: float
-          description: 'Latency of the host'
+          description: "Latency of the host"
+          example: 0.117
         downtimes:
           type: array
           items:
-            $ref: '#/components/schemas/Downtime.Host'
+            $ref: "#/components/schemas/Downtime.Host"
         acknowledgement:
-          $ref: '#/components/schemas/Acknowledgement.Host'
+          $ref: "#/components/schemas/Acknowledgement.Host"
     Monitoring.Resource.Disacknowledge.Host:
       type: object
       properties:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -524,6 +524,21 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /monitoring/resources/hosts/{host_id}:
+    get:
+      tags:
+        - Resource
+      summary: "Get a host resources informations"
+      description: "Return a single host with full details of its resources status."
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitoring.Resource.Host'
   /monitoring/hosts:
     get:
       tags:
@@ -3510,6 +3525,81 @@ components:
                 nullable: true
                 description: "Performance data result of the check sent"
                 example: "'used'=453849088B;;;0;1927262208"
+    Monitoring.Resource.Host:
+      allOf:
+        - $ref: '#/components/schemas/Monitoring.ResourceMain'
+      type: object
+      properties:
+        command_line:
+          type: string
+          nullable: true
+          description: 'Check command of the host'
+          example: '/usr/lib64/nagios/plugins/check_icmp -H 127.0.0.1 -w 3000.0,80% -c 5000.0,100% -p 1'
+        poller_name:
+          type: string
+          nullable: true
+          description: 'Name of the monitoring server of the Host'
+          example: 'Central'
+        timezone:
+          type: string
+          description: 'Timezone used by Host'
+          example: 'Europe/Paris'
+        flapping:
+          type: boolean
+          description: 'Host is flapping or not'
+          example: false
+        percent_state_change:
+          type: number
+          format: float
+          description: 'Percent of Host state changing'
+          example: 20.10
+        criticality:
+          type: number
+          nullable: true
+          format: integer
+          description: 'Criticality level'
+          example: 1
+        chart_url:
+          type: string
+          nullable: true
+          description: 'Url of chart'
+        last_notification:
+          type: string
+          nullable: true
+          format: date-time
+          description: 'DateTime of the last notification'
+          example: '2020-02-18T00:00:00'
+        notification_number:
+          type: number
+          nullable: true
+          format: integer
+          description: 'Number of notifications'
+          example: 3
+        next_check:
+          type: string
+          nullable: true
+          format: date-time
+          description: 'next planned check'
+          example: '2020-11-23T10:26:19+01:00'
+        perofrmance_data:
+          type: string
+          description: 'Details of performances'
+          example: 'rta=0,098ms;3000,000;5000,000;0; pl=0%;80;100;0;100 rtmax=0,098ms;;;; rtmin=0,098ms;;;;'
+        execution_time:
+          type: number
+          format: float
+          description: 'duration of check'
+          example: 0.005618
+        latency:
+          type: number
+          format: float
+          description: 'Latency of the host'
+        downtimes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Downtime.Host'
+        acknowledgement:
+          $ref: '#/components/schemas/Acknowledgement.Host'
     Monitoring.Resource.Disacknowledge.Host:
       type: object
       properties:
@@ -3578,11 +3668,6 @@ components:
           type: object
           nullable: true
           properties:
-            id:
-              type: integer
-              format: int32
-              description: "ID of the image"
-              example: 12
             name:
               type: string
               description: "Name of the icon"
@@ -3785,19 +3870,19 @@ components:
               nullable: true
               description: "current resource downtimes endpoint"
               example: "/centreon/api/beta/monitoring/hosts/11/downtimes?search=%7B%22%24and%22:%5B%7B%22start_time%22:%7B%22%24lt%22:1599655905%7D,%22end_time%22:%7B%22%24gt%22:1599655905%7D,%220%22:%7B%22%24or%22:%7B%22is_cancelled%22:%7B%22%24neq%22:1%7D,%22deletion_time%22:%7B%22%24gt%22:1599655905%7D%7D%7D%7D%5D%7D"
-          externals:
-              type: object
-              properties:
-                action_url:
-                  type: string
-                  nullable: true
-                  description: "URL that can be used to provide more actions to be performed on the resource"
-                  example: "http://mediawiki/resource/name"
-                notes_url:
-                  type: string
-                  nullable: true
-                  description: "URL that can be used to provide more information on the resource"
-                  example: "http://mediawiki/resource/name"
+        externals:
+            type: object
+            properties:
+              action_url:
+                type: string
+                nullable: true
+                description: "URL that can be used to provide more actions to be performed on the resource"
+                example: "http://mediawiki/resource/name"
+              notes_url:
+                type: string
+                nullable: true
+                description: "URL that can be used to provide more information on the resource"
+                example: "http://mediawiki/resource/name"
     Monitoring.ResourceStatus:
       type: object
       properties:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -546,8 +546,8 @@ paths:
     get:
       tags:
         - Resource
-      summary: "Get information on service resources"
-      description: "Return a single service with full details of its resources status."
+      summary: "Get information on service resource"
+      description: "Return a single service with full details as resource."
       parameters:
         - $ref: '#/components/parameters/HostId'
         - $ref: '#/components/parameters/ServiceId'

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -539,6 +539,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Monitoring.Resource.Host'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /monitoring/hosts:
     get:
       tags:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -537,7 +537,27 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Monitoring.Resource.Host'
+                $ref: '#/components/schemas/Monitoring.ResourceFull'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /monitoring/resources/hosts/{host_id}/services/{service_id}:
+    get:
+      tags:
+        - Resource
+      summary: "Get information on service resources"
+      description: "Return a single service with full details of its resources status."
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitoring.ResourceFull'
         '403':
           $ref: '#/components/responses/Forbidden'
         '500':
@@ -3528,7 +3548,7 @@ components:
                 nullable: true
                 description: "Performance data result of the check sent"
                 example: "'used'=453849088B;;;0;1927262208"
-    Monitoring.Resource.Host:
+    Monitoring.ResourceFull:
       allOf:
         - $ref: "#/components/schemas/Monitoring.ResourceMain"
       type: object


### PR DESCRIPTION
## Description

Add Missing documentation for endpoint /monitoring/resources/hosts/<hostId>/services/<serviceId>.  Also rename the schema Monitoring.Resource.Host in Monitoring.ResourceFull as its inherit from ResourceMain and add additional properties used by multiples resources (host and service).

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
