### PR TITLE
fix(ldap): correctly set bind_pass value

### DIFF
--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -1153,7 +1153,7 @@ class CentreonLdapAdmin
             );
         }
         $knownParameters = $this->getLdapParameters();
-        if (isset($options["bind_pass"]) && $options["bind_pass"] === CentreonAuth::PWS_OCCULTATION && $isUpdate) {
+        if (isset($options["bind_pass"]) && $options["bind_pass"] === CentreonAuth::PWS_OCCULTATION && $isUpdate === true) {
             unset($options["bind_pass"]);
         }
         foreach ($options as $key => $value) {

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -1108,12 +1108,12 @@ class CentreonLdapAdmin
      * @param  array $options The list of options
      * @return int | auth ressource id
      */
-    public function setGeneralOptions($arId, $options)
+    public function setGeneralOptions($arId = 0, array $options)
     {
-        $isUpdate = !empty($arId);
+        $isUpdate = ((int) $arId !== 0);
 
         $gopt = $this->getGeneralOptions($arId);
-        if (isset($gopt["bind_pass"]) && $gopt["bind_pass"] === CentreonAuth::PWS_OCCULTATION && !$isUpdate) {
+        if (isset($gopt["bind_pass"]) && $gopt["bind_pass"] === CentreonAuth::PWS_OCCULTATION && $isUpdate === false) {
             unset($gopt["bind_pass"]);
         }
         if (!count($gopt)

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -1110,8 +1110,10 @@ class CentreonLdapAdmin
      */
     public function setGeneralOptions($arId, $options)
     {
+        $isUpdate = !empty($arId);
+
         $gopt = $this->getGeneralOptions($arId);
-        if (isset($gopt["bind_pass"]) && $gopt["bind_pass"] === CentreonAuth::PWS_OCCULTATION && $arId == 0) {
+        if (isset($gopt["bind_pass"]) && $gopt["bind_pass"] === CentreonAuth::PWS_OCCULTATION && !$isUpdate) {
             unset($gopt["bind_pass"]);
         }
         if (!count($gopt)
@@ -1151,7 +1153,7 @@ class CentreonLdapAdmin
             );
         }
         $knownParameters = $this->getLdapParameters();
-        if (isset($options["bind_pass"]) && $options["bind_pass"] === CentreonAuth::PWS_OCCULTATION) {
+        if (isset($options["bind_pass"]) && $options["bind_pass"] === CentreonAuth::PWS_OCCULTATION && $isUpdate) {
             unset($options["bind_pass"]);
         }
         foreach ($options as $key => $value) {


### PR DESCRIPTION
## Description

This PR fix an issue where the bind_pass value was removed from database if an LDAP configuration had a "******" password. So it becames impossible to edit further. 

**Fixes** # MON-6379

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
