### PR TITLE
feat(api): add endpoints to API to add comment on resources

### DIFF
--- a/config/json_validator/latest/Centreon/Comment/Comment.json
+++ b/config/json_validator/latest/Centreon/Comment/Comment.json
@@ -12,7 +12,8 @@
             "type": [
                 "string",
                 "null"
-            ]
+            ],
+            "format": "date-time"
         }
     }
 }

--- a/config/json_validator/latest/Centreon/Comment/Comment.json
+++ b/config/json_validator/latest/Centreon/Comment/Comment.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Submit result to a host or service",
+    "title": "Add comment to a host or a service",
     "type": "object",
     "required": ["comment"],
     "additionalProperties": false,

--- a/config/json_validator/latest/Centreon/Comment/Comment.json
+++ b/config/json_validator/latest/Centreon/Comment/Comment.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Submit result to a host or service",
+    "type": "object",
+    "required": ["comment"],
+    "additionalProperties": false,
+    "properties": {
+        "comment": {
+            "type": "string"
+        },
+        "date": {
+            "type": [
+                "string",
+                "null"
+            ]
+        }
+    }
+}

--- a/config/json_validator/latest/Centreon/Comment/CommentResources.json
+++ b/config/json_validator/latest/Centreon/Comment/CommentResources.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Schedule checks on resources",
+    "type": "object",
+    "required": ["resources"],
+    "additionalProperties": false,
+    "properties": {
+        "resources": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "id",
+                    "parent",
+                    "comment"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "service",
+                            "host"
+                        ]
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "parent": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "comment": {
+                        "type": "string"
+                    },
+                    "date": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/config/json_validator/latest/Centreon/Comment/CommentResources.json
+++ b/config/json_validator/latest/Centreon/Comment/CommentResources.json
@@ -45,7 +45,8 @@
                         "type": [
                             "string",
                             "null"
-                        ]
+                        ],
+                        "format": "date-time"
                     }
                 }
             }

--- a/config/json_validator/latest/Centreon/Comment/CommentResources.json
+++ b/config/json_validator/latest/Centreon/Comment/CommentResources.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Schedule checks on resources",
+    "title": "Add comment on multiple resources",
     "type": "object",
     "required": ["resources"],
     "additionalProperties": false,

--- a/config/packages/validator/validation.yaml
+++ b/config/packages/validator/validation.yaml
@@ -41,6 +41,19 @@ Centreon\Domain\Acknowledgement\Acknowledgement:
                 type: boolean
                 groups: [add_host_acks, add_host_ack, ack_resource]
 
+# Used to validate the Comment entity
+Centreon\Domain\Monitoring\Comment:
+    properties:
+        date:
+            - Type:
+                type: DateTime
+                groups: [add_host_comment, add_service_comment]
+        comment:
+            - Type:
+                type: string
+                groups: [add_host_comment, add_service_comment]
+            - NotNull: ~
+
 # Used to validate the Downtime entity
 Centreon\Domain\Downtime\Downtime:
     properties:

--- a/config/routes/Centreon/monitoring/comments.yaml
+++ b/config/routes/Centreon/monitoring/comments.yaml
@@ -1,0 +1,22 @@
+centreon_application_monitoring_commentresource:
+    methods: POST
+    path: /monitoring/resources/comments
+    controller: 'Centreon\Application\Controller\Monitoring\CommentController::addResourcesComment'
+    condition: "request.attributes.get('version') >= 2.0"
+
+centreon_application_monitoring_commenthost:
+    methods: POST
+    path: /monitoring/hosts/{hostId}/comments
+    requirements:
+        hostId: '\d+'
+    controller: 'Centreon\Application\Controller\Monitoring\CommentController::addHostComment'
+    condition: "request.attributes.get('version') >= 2.0"
+
+centreon_application_monitoring_commentservice:
+    methods: POST
+    path: /monitoring/hosts/{hostId}/services/{serviceId}/comments
+    requirements:
+        hostId: '\d+'
+        serviceId: '\d+'
+    controller: 'Centreon\Application\Controller\Monitoring\CommentController::addServiceComment'
+    condition: "request.attributes.get('version') >= 2.0"

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -3756,7 +3756,6 @@ components:
             $ref: "#/components/schemas/Downtime.Host"
         acknowledgement:
           $ref: "#/components/schemas/Acknowledgement.Host"
-=======
     Comment.Host:
       type: object
       required: [comment]
@@ -3819,7 +3818,6 @@ components:
                 type: string
                 description: "Comment to add to the monitored resource"
                 example: "Resource is not-OK but it is expected"
->>>>>>> feat(api): add endpoints to API to add comment on resources
     Monitoring.Resource.Disacknowledge.Host:
       type: object
       properties:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -1751,7 +1751,7 @@ paths:
       tags:
         - Comment
       summary: "Add comment to resources"
-      description: "And comment(s) to a single or multiple resources"
+      description: "Add at least one comment to a single or to multiple resources"
       requestBody:
         required: true
         content:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -1699,6 +1699,74 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /monitoring/hosts/{host_id}/comments:
+    post:
+      tags:
+        - Comment
+      summary: "Add a comment to a single host"
+      description: "Add a comment to a monitored host"
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Comment.Host'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: 'Host not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /monitoring/hosts/{host_id}/services/{service_id}/comments:
+    post:
+      tags:
+        - Comment
+      summary: "Add a comment to a single service"
+      description: "Add a comment to a monitored service"
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Comment.Service'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /monitoring/resources/comments:
+    post:
+      tags:
+        - Comment
+      summary: "Add comment to resources"
+      description: "And comment(s) to a single or multiple resources"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Comment.Resources'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /monitoring/hosts/{host_id}/services/{service_id}/metrics/start/{start}/end/{end}:
     get:
       tags:
@@ -3688,6 +3756,70 @@ components:
             $ref: "#/components/schemas/Downtime.Host"
         acknowledgement:
           $ref: "#/components/schemas/Acknowledgement.Host"
+=======
+    Comment.Host:
+      type: object
+      required: [comment]
+      properties:
+        date:
+          type: string
+          format: date-time
+          nullable: true
+          description: "Date of the comment (ISO8601)"
+        comment:
+          type: string
+          description: "Comment to add to the monitored host"
+          example: "HOST is down because it has been powered off"
+    Comment.Service:
+      type: object
+      required: [comment]
+      properties:
+        date:
+          type: string
+          format: date-time
+          nullable: true
+          description: "Date of the comment (ISO8601)"
+        comment:
+          type: string
+          description: "Comment to add to the monitored service"
+          example: "SERVICE is critical because ntpd service if stopped"
+    Comment.Resources:
+      type: object
+      required: [resources]
+      properties:
+        resources:
+          type: array
+          items:
+            type: object
+            required: [comment,id]
+            properties:
+              type:
+                type: string
+                enum: [host, service]
+                description: "Type of resource"
+                example: "service"
+              id:
+                type: integer
+                description: "Resource ID"
+                example: 10
+              parent:
+                type: object
+                nullable: true
+                properties:
+                  id:
+                    type: integer
+                    description: "Parent resource ID"
+                    example: 17
+              date:
+                type: string
+                format: date-time
+                nullable: true
+                description: "Date of the comment (ISO8601)"
+              comment:
+                type: string
+                description: "Comment to add to the monitored resource"
+                example: "Resource is not-OK but it is expected"
+>>>>>>> feat(api): add endpoints to API to add comment on resources
     Monitoring.Resource.Disacknowledge.Host:
       type: object
       properties:

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15857,3 +15857,9 @@ msgstr "[%s] La valeur \"%s\" est trop longue, elle ne devrait pas avoir plus de
 
 msgid "[%s] The value \"%s\" is too short, it should have at least %d characters, but only has %d characters"
 msgstr "[%s] La valeur \"%s\" est trop courte, elle devrait avoir au moins %d caractères, mais n'a que %d caractères"
+
+msgid "Error when searching for services"
+msgstr "Erreur lors de la recherche des services"
+
+msgid "Error when searching for hosts"
+msgstr "Erreur lors de la recherche des hôtes"

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -335,7 +335,7 @@ class CommentController extends AbstractController
             }
             $service->setHost($host);
 
-            $date = ($results['date'] !== null) ? new \DateTime($results['date']) : new \DateTime('now');
+            $date = ($results['date'] !== null) ? new \DateTime($results['date']) : new \DateTime();
 
             $result = (new Comment($serviceId, $results['comment']))
                 ->setDate($date)

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -184,7 +184,7 @@ class CommentController extends AbstractController
 
         $now = new \DateTime();
 
-        foreach ($receivedData['resources'] as $index => $commentResource) {
+        foreach ($receivedData['resources'] as $commentResource) {
             $date = ($commentResource['date'] !== null) ? new \DateTime($commentResource['date']) : $now;
             $comments[$commentResource['id']] = (new Comment($commentResource['id'], $commentResource['comment']))
                 ->setDate($date)

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -179,7 +179,7 @@ class CommentController extends AbstractController
         $serviceIds = [];
         $comments = [];
 
-        $now = new \DateTime('now');
+        $now = new \DateTime();
 
         foreach ($results['resources'] as $index => $commentResource) {
             $date = ($commentResource['date'] !== null) ? new \DateTime($commentResource['date']) : $now;

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -252,7 +252,10 @@ class CommentController extends AbstractController
              * At this point we made sure that the mapping will work since we validate
              * the JSON sent with the JSON validator.
              */
-            $host = $this->monitoringService->findOneHost($hostId);
+            $host = $this->monitoringService
+                ->filterByContact($contact)
+                ->findOneHost($hostId);
+
             if (is_null($host)) {
                 throw new EntityNotFoundException(
                     sprintf(
@@ -312,7 +315,10 @@ class CommentController extends AbstractController
              * At this point we made sure that the mapping will work since we validate
              * the JSON sent with the JSON validator.
              */
-            $host = $this->monitoringService->findOneHost($hostId);
+            $host = $this->monitoringService
+                ->filterByContact($contact)
+                ->findOneHost($hostId);
+
             if (is_null($host)) {
                 throw new EntityNotFoundException(
                     sprintf(
@@ -322,7 +328,10 @@ class CommentController extends AbstractController
                 );
             }
 
-            $service = $this->monitoringService->findOneService($hostId, $serviceId);
+            $service = $this->monitoringService
+                ->filterByContact($contact)
+                ->findOneService($hostId, $serviceId);
+
             if (is_null($service)) {
                 throw new EntityNotFoundException(
                     sprintf(

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -239,8 +239,7 @@ class CommentController extends AbstractController
 
         if (!empty($receivedData)) {
             /**
-             * At this point we made sure that the mapping will work since we validate
-             * the JSON sent with the JSON validator.
+             * At this point we validate the JSON sent with the JSON validator.
              */
             $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
             $comment = (new Comment($hostId, $receivedData['comment']))
@@ -286,8 +285,7 @@ class CommentController extends AbstractController
 
         if (!empty($receivedData)) {
             /**
-             * At this point we made sure that the mapping will work since we validate
-             * the JSON sent with the JSON validator.
+             * At this point we validate the JSON sent with the JSON validator.
              */
             $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
             $comment = (new Comment($serviceId, $receivedData['comment']))

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -156,10 +156,12 @@ class CommentController extends AbstractController
             return $this->view(null, Response::HTTP_UNAUTHORIZED);
         }
 
+        $now = new \DateTime('now');
+
         foreach ($results['resources'] as $commentResource) {
-            $date = $commentResource['date'] ?? 'now';
+            $date = ($commentResource['date'] !== null) ? new \DateTime($commentResource['date']) : $now;
             $result = (new Comment($commentResource['id'], $commentResource['comment']))
-                ->setDate(new \DateTime($date))
+                ->setDate($date)
                 ->setParentResourceId($commentResource['parent']['id']);
             if ($commentResource['type'] === ResourceEntity::TYPE_SERVICE) {
                 $this->commentService

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -109,6 +109,13 @@ class CommentController extends AbstractController
         $hasHostRights = $contact->hasRole(Contact::ROLE_HOST_ADD_COMMENT);
         $hasServiceRights = $contact->hasRole(Contact::ROLE_SERVICE_ADD_COMMENT);
 
+        /**
+         * If the user has no rights at all, do not go further
+         */
+        if (!$hasHostRights && !$hasServiceRights) {
+            return false;
+        }
+
         foreach ($resources as $resource) {
             if (
                 ($resource['type'] === ResourceEntity::TYPE_HOST && $hasHostRights)

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -237,17 +237,15 @@ class CommentController extends AbstractController
             'config/json_validator/latest/Centreon/Comment/Comment.json'
         );
 
-        if (!empty($receivedData)) {
-            /**
-             * At this point we validate the JSON sent with the JSON validator.
-             */
-            $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
-            $comment = (new Comment($hostId, $receivedData['comment']))
-                ->setDate($date);
-            $host = new Host();
-            $host->setId($hostId);
-            $this->commentService->addHostComment($comment, $host);
-        }
+        /**
+         * At this point we validate the JSON sent with the JSON validator.
+         */
+        $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
+        $comment = (new Comment($hostId, $receivedData['comment']))
+            ->setDate($date);
+        $host = new Host();
+        $host->setId($hostId);
+        $this->commentService->addHostComment($comment, $host);
 
         return $this->view(null, Response::HTTP_NO_CONTENT);
     }
@@ -283,23 +281,21 @@ class CommentController extends AbstractController
             'config/json_validator/latest/Centreon/Comment/Comment.json'
         );
 
-        if (!empty($receivedData)) {
-            /**
-             * At this point we validate the JSON sent with the JSON validator.
-             */
-            $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
-            $comment = (new Comment($serviceId, $receivedData['comment']))
-                ->setDate($date)
-                ->setParentResourceId($hostId);
+        /**
+         * At this point we validate the JSON sent with the JSON validator.
+         */
+        $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
+        $comment = (new Comment($serviceId, $receivedData['comment']))
+            ->setDate($date)
+            ->setParentResourceId($hostId);
 
-            $service = new Service();
-            $host = new Host();
+        $service = new Service();
+        $host = new Host();
 
-            $host->setId($hostId);
-            $service->setId($serviceId)->setHost($host);
+        $host->setId($hostId);
+        $service->setId($serviceId)->setHost($host);
 
-            $this->commentService->addServiceComment($comment, $service);
-        }
+        $this->commentService->addServiceComment($comment, $service);
 
         return $this->view(null, Response::HTTP_NO_CONTENT);
     }

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -161,16 +161,12 @@ class CommentController extends AbstractController
             $result = (new Comment($commentResource['id'], $commentResource['comment']))
                 ->setDate(new \DateTime($date))
                 ->setParentResourceId($commentResource['parent']['id']);
-            try {
-                if ($commentResource['type'] === ResourceEntity::TYPE_SERVICE) {
-                    $this->commentService
-                        ->addServiceComment($result);
-                } elseif ($commentResource['type'] === ResourceEntity::TYPE_HOST) {
-                    $this->commentService
-                        ->addHostComment($result);
-                }
-            } catch (EntityNotFoundException $e) {
-                throw $e;
+            if ($commentResource['type'] === ResourceEntity::TYPE_SERVICE) {
+                $this->commentService
+                    ->addServiceComment($result);
+            } elseif ($commentResource['type'] === ResourceEntity::TYPE_HOST) {
+                $this->commentService
+                    ->addHostComment($result);
             }
         }
 

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -45,12 +45,14 @@ class CommentController extends AbstractController
      * @var CommentServiceInterface
      */
     private $commentService;
+
     /**
-     * Monitoring 
+     * Monitoring
      *
      * @var MonitoringServiceInterface
      */
     private $monitoringService;
+
     public function __construct(
         CommentServiceInterface $commentService,
         MonitoringServiceInterface $monitoringService

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -263,7 +263,7 @@ class CommentController extends AbstractController
                     )
                 );
             }
-            $date = ($results['date'] !== null) ? new \DateTime($results['date']) : new \DateTime('now');
+            $date = ($results['date'] !== null) ? new \DateTime($results['date']) : new \DateTime();
             $result = (new Comment($hostId, $results['comment']))
                 ->setDate($date);
 

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -1,0 +1,282 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Application\Controller\Monitoring;
+
+use Exception;
+use JsonSchema\Validator;
+use FOS\RestBundle\View\View;
+use Centreon\Domain\Contact\Contact;
+use JsonSchema\Constraints\Constraint;
+use Symfony\Component\HttpFoundation\Request;
+use Centreon\Domain\Monitoring\ResourceStatus;
+use Symfony\Component\HttpFoundation\Response;
+use Centreon\Domain\Monitoring\Comment\Comment;
+use Centreon\Domain\Exception\EntityNotFoundException;
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Monitoring\Resource as ResourceEntity;
+use Centreon\Domain\Monitoring\Comment\Interfaces\CommentServiceInterface;
+
+class CommentController extends AbstractController
+{
+    /**
+     * comment
+     *
+     * @var CommentServiceInterface
+     */
+    private $commentService;
+
+    public function __construct(CommentServiceInterface $commentService)
+    {
+        $this->commentService = $commentService;
+    }
+
+    /**
+     * This function will ensure that the POST data is valid
+     * regarding validation constraints defined and will return
+     * the decoded JSON content
+     *
+     * @param Request $request
+     * @param string $jsonValidatorFile
+     * @return array $results
+     * @throws InvalidArgumentException
+     */
+    private function validateAndRetrievePostData(Request $request, string $jsonValidatorFile): array
+    {
+        $results = json_decode((string) $request->getContent(), true);
+        if (!is_array($results)) {
+            throw new \InvalidArgumentException(_('Error when decoding sent data'));
+        }
+
+        /*
+        * Validate the content of the POST request against the JSON schema validator
+        */
+        $validator = new Validator();
+        $bodyContent = json_decode((string) $request->getContent());
+        $file = 'file://' . __DIR__ . '/../../../../../' . $jsonValidatorFile;
+        $validator->validate(
+            $bodyContent,
+            (object) ['$ref' => $file],
+            Constraint::CHECK_MODE_VALIDATE_SCHEMA
+        );
+
+        if (!$validator->isValid()) {
+            $message = '';
+            foreach ($validator->getErrors() as $error) {
+                $message .= sprintf("[%s] %s\n", $error['property'], $error['message']);
+            }
+            throw new \InvalidArgumentException($message);
+        }
+
+        return $results;
+    }
+
+    /**
+     * This function will verify that the contact is authorized to add a comment
+     * on the selected resources
+     *
+     * @param Contact $contact
+     * @param array $resources
+     * @return boolean
+     */
+    private function hasCommentRightsForResources(Contact $contact, array $resources): bool
+    {
+        if ($contact->isAdmin()) {
+            return true;
+        }
+        /**
+         * Retrieving the current rights of the user for adding comments
+         */
+        $hasHostRights = $contact->hasRole(Contact::ROLE_HOST_ADD_COMMENT);
+        $hasServiceRights = $contact->hasRole(Contact::ROLE_SERVICE_ADD_COMMENT);
+
+        foreach ($resources as $resource) {
+            if (
+                ($resource['type'] === ResourceEntity::TYPE_HOST && $hasHostRights)
+                || ($resource['type'] === ResourceEntity::TYPE_SERVICE && $hasServiceRights)
+            ) {
+                continue;
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Entry point to add comments to multiple resources
+     *
+     * @param Request $request
+     * @return View
+     * @throws \Exception
+     * @throws \InvalidArgumentException
+     */
+    public function addResourcesComment(
+        Request $request
+    ): View {
+        $this->denyAccessUnlessGrantedForApiRealtime();
+        /**
+        * @var Contact $contact
+        */
+        $contact = $this->getUser();
+        $this->commentService->filterByContact($contact);
+
+       /*
+        * Validate the content of the POST request against the JSON schema validator
+        */
+        $results = $this->validateAndRetrievePostData(
+            $request,
+            'config/json_validator/latest/Centreon/Comment/CommentResources.json'
+        );
+
+        /**
+         * If user has no rights to submit result for host and/or service
+         * return view with unauthorized HTTP header response
+         */
+        if (!$this->hasCommentRightsForResources($contact, $results['resources'])) {
+            return $this->view(null, Response::HTTP_UNAUTHORIZED);
+        }
+
+        foreach ($results['resources'] as $commentResource) {
+            $date = $commentResource['date'] ?? 'now';
+            $result = (new Comment($commentResource['id'], $commentResource['comment']))
+                ->setDate(new \DateTime($date))
+                ->setParentResourceId($commentResource['parent']['id']);
+            try {
+                if ($commentResource['type'] === ResourceEntity::TYPE_SERVICE) {
+                    $this->commentService
+                        ->addServiceComment($result);
+                } elseif ($commentResource['type'] === ResourceEntity::TYPE_HOST) {
+                    $this->commentService
+                        ->addHostComment($result);
+                }
+            } catch (EntityNotFoundException $e) {
+                throw $e;
+            }
+        }
+
+        return $this->view(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Entry point to add a comment on a host resource
+     *
+     * @param Request $request
+     * @param int $hostId ID of the host
+     * @return View
+     * @throws \Exception
+     * @throws \InvalidArgumentException
+     */
+    public function addHostComment(
+        Request $request,
+        int $hostId
+    ): View {
+        $this->denyAccessUnlessGrantedForApiRealtime();
+        /**
+         * @var Contact $contact
+         */
+        $contact = $this->getUser();
+
+        /**
+         * Checking that user is allowed to add a comment for a host resource
+         */
+        if (!$contact->isAdmin() && !$contact->hasRole(Contact::ROLE_HOST_ADD_COMMENT)) {
+            return $this->view(null, Response::HTTP_UNAUTHORIZED);
+        }
+
+        $results = $this->validateAndRetrievePostData(
+            $request,
+            'config/json_validator/latest/Centreon/Comment/Comment.json'
+        );
+
+        if (!empty($results)) {
+            /**
+             * At this point we made sure that the mapping will work since we validate
+             * the JSON sent with the JSON validator.
+             */
+            $date = $commentResource['date'] ?? 'now';
+            $result = (new Comment($hostId, $results['comment']))
+                ->setDate(new \DateTime($date));
+
+            try {
+                $this->commentService
+                    ->filterByContact($contact)
+                    ->addHostComment($result);
+            } catch (EntityNotFoundException $e) {
+                throw $e;
+            }
+        }
+
+        return $this->view(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Entry point to add a comment on a service
+     *
+     * @param Request $request
+     * @param int $hostId ID of service parent (host)
+     * @param int $serviceId ID of the service
+     * @return View
+     * @throws \Exception
+     * @throws \InvalidArgumentException
+     */
+    public function addServiceComment(
+        Request $request,
+        int $hostId,
+        int $serviceId
+    ): View {
+        $this->denyAccessUnlessGrantedForApiRealtime();
+
+        /**
+         * @var Contact $contact
+         */
+        $contact = $this->getUser();
+        if (!$contact->isAdmin() && !$contact->hasRole(Contact::ROLE_SERVICE_ADD_COMMENT)) {
+            return $this->view(null, Response::HTTP_UNAUTHORIZED);
+        }
+
+        $results = $this->validateAndRetrievePostData(
+            $request,
+            'config/json_validator/latest/Centreon/Comment/Comment.json'
+        );
+
+        if (!empty($results)) {
+            /**
+             * At this point we made sure that the mapping will work since we validate
+             * the JSON sent with the JSON validator.
+             */
+            $date = $commentResource['date'] ?? 'now';
+            $result = (new Comment($serviceId, $results['comment']))
+                ->setDate(new \DateTime($date))
+                ->setParentResourceId($hostId);
+            try {
+                $this->commentService
+                    ->filterByContact($contact)
+                    ->addServiceComment($result);
+            } catch (EntityNotFoundException $e) {
+                    throw $e;
+            }
+        }
+
+        return $this->view(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -203,16 +203,12 @@ class CommentController extends AbstractController
         $hosts = $this->monitoringService->findMultipleHosts($hostIds);
         $services = $this->monitoringService->findMultipleServices($serviceIds);
 
-        if (!empty($hosts)) {
-            foreach ($hosts as $key => $host) {
-                $this->commentService->addHostComment($comments[$key], $host);
-            }
+        foreach ($hosts as $key => $host) {
+            $this->commentService->addHostComment($comments[$key], $host);
         }
 
-        if (!empty($services)) {
-            foreach ($services as $key => $service) {
-                $this->commentService->addServiceComment($comments[$key], $service);
-            }
+        foreach ($services as $key => $service) {
+            $this->commentService->addServiceComment($comments[$key], $service);
         }
 
         return $this->view(null, Response::HTTP_NO_CONTENT);

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -161,7 +161,7 @@ class CommentController extends AbstractController
         $this->commentService->filterByContact($contact);
 
        /*
-        * Validate the content of the POST request against the JSON schema validator
+        * Validate the content of the request against the JSON schema validator
         */
         $receivedData = $this->validateAndRetrievePostData(
             $request,

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -45,7 +45,12 @@ class CommentController extends AbstractController
      * @var CommentServiceInterface
      */
     private $commentService;
-
+    /**
+     * Monitoring 
+     *
+     * @var MonitoringServiceInterface
+     */
+    private $monitoringService;
     public function __construct(
         CommentServiceInterface $commentService,
         MonitoringServiceInterface $monitoringService

--- a/src/Centreon/Application/Controller/Monitoring/CommentController.php
+++ b/src/Centreon/Application/Controller/Monitoring/CommentController.php
@@ -68,13 +68,13 @@ class CommentController extends AbstractController
      *
      * @param Request $request
      * @param string $jsonValidatorFile
-     * @return array $results
+     * @return array $receivedData
      * @throws InvalidArgumentException
      */
     private function validateAndRetrievePostData(Request $request, string $jsonValidatorFile): array
     {
-        $results = json_decode((string) $request->getContent(), true);
-        if (!is_array($results)) {
+        $receivedData = json_decode((string) $request->getContent(), true);
+        if (!is_array($receivedData)) {
             throw new \InvalidArgumentException(_('Error when decoding sent data'));
         }
 
@@ -98,7 +98,7 @@ class CommentController extends AbstractController
             throw new \InvalidArgumentException($message);
         }
 
-        return $results;
+        return $receivedData;
     }
 
     /**
@@ -161,7 +161,7 @@ class CommentController extends AbstractController
        /*
         * Validate the content of the POST request against the JSON schema validator
         */
-        $results = $this->validateAndRetrievePostData(
+        $receivedData = $this->validateAndRetrievePostData(
             $request,
             'config/json_validator/latest/Centreon/Comment/CommentResources.json'
         );
@@ -170,7 +170,7 @@ class CommentController extends AbstractController
          * If user has no rights to add a comment for host and/or service
          * return view with unauthorized HTTP header response
          */
-        if (!$this->hasCommentRightsForResources($contact, $results['resources'])) {
+        if (!$this->hasCommentRightsForResources($contact, $receivedData['resources'])) {
             return $this->view(null, Response::HTTP_UNAUTHORIZED);
         }
 
@@ -183,7 +183,7 @@ class CommentController extends AbstractController
 
         $now = new \DateTime();
 
-        foreach ($results['resources'] as $index => $commentResource) {
+        foreach ($receivedData['resources'] as $index => $commentResource) {
             $date = ($commentResource['date'] !== null) ? new \DateTime($commentResource['date']) : $now;
             $comments[$index] = (new Comment($commentResource['id'], $commentResource['comment']))
                 ->setDate($date)
@@ -242,12 +242,12 @@ class CommentController extends AbstractController
             return $this->view(null, Response::HTTP_UNAUTHORIZED);
         }
 
-        $results = $this->validateAndRetrievePostData(
+        $receivedData = $this->validateAndRetrievePostData(
             $request,
             'config/json_validator/latest/Centreon/Comment/Comment.json'
         );
 
-        if (!empty($results)) {
+        if (!empty($receivedData)) {
             /**
              * At this point we made sure that the mapping will work since we validate
              * the JSON sent with the JSON validator.
@@ -264,8 +264,8 @@ class CommentController extends AbstractController
                     )
                 );
             }
-            $date = ($results['date'] !== null) ? new \DateTime($results['date']) : new \DateTime();
-            $result = (new Comment($hostId, $results['comment']))
+            $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
+            $result = (new Comment($hostId, $receivedData['comment']))
                 ->setDate($date);
 
             try {
@@ -305,12 +305,12 @@ class CommentController extends AbstractController
             return $this->view(null, Response::HTTP_UNAUTHORIZED);
         }
 
-        $results = $this->validateAndRetrievePostData(
+        $receivedData = $this->validateAndRetrievePostData(
             $request,
             'config/json_validator/latest/Centreon/Comment/Comment.json'
         );
 
-        if (!empty($results)) {
+        if (!empty($receivedData)) {
             /**
              * At this point we made sure that the mapping will work since we validate
              * the JSON sent with the JSON validator.
@@ -342,9 +342,9 @@ class CommentController extends AbstractController
             }
             $service->setHost($host);
 
-            $date = ($results['date'] !== null) ? new \DateTime($results['date']) : new \DateTime();
+            $date = ($receivedData['date'] !== null) ? new \DateTime($receivedData['date']) : new \DateTime();
 
-            $result = (new Comment($serviceId, $results['comment']))
+            $result = (new Comment($serviceId, $receivedData['comment']))
                 ->setDate($date)
                 ->setParentResourceId($hostId);
 

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -48,6 +48,7 @@ class UserController extends AbstractController
                 'disacknowledgement' => $this->getAuthorizationForRole(Contact::ROLE_HOST_DISACKNOWLEDGEMENT),
                 'downtime' => $this->getAuthorizationForRole(Contact::ROLE_ADD_HOST_DOWNTIME),
                 'submit_status' => $this->getAuthorizationForRole(Contact::ROLE_HOST_SUBMIT_RESULT),
+                'comment' => $this->getAuthorizationForRole(Contact::ROLE_HOST_ADD_COMMENT),
             ],
             'service' => [
                 'check' => $this->getAuthorizationForRole(Contact::ROLE_SERVICE_CHECK),
@@ -55,6 +56,7 @@ class UserController extends AbstractController
                 'disacknowledgement' => $this->getAuthorizationForRole(Contact::ROLE_SERVICE_DISACKNOWLEDGEMENT),
                 'downtime' => $this->getAuthorizationForRole(Contact::ROLE_ADD_SERVICE_DOWNTIME),
                 'submit_status' => $this->getAuthorizationForRole(Contact::ROLE_SERVICE_SUBMIT_RESULT),
+                'comment' => $this->getAuthorizationForRole(Contact::ROLE_SERVICE_ADD_COMMENT),
             ],
         ];
 

--- a/src/Centreon/Domain/Contact/Contact.php
+++ b/src/Centreon/Domain/Contact/Contact.php
@@ -45,6 +45,8 @@ class Contact implements UserInterface, ContactInterface
     public const ROLE_ADD_SERVICE_DOWNTIME = 'ROLE_ADD_SERVICE_DOWNTIME';
     public const ROLE_SERVICE_SUBMIT_RESULT = 'ROLE_SERVICE_SUBMIT_RESULT';
     public const ROLE_HOST_SUBMIT_RESULT = 'ROLE_HOST_SUBMIT_RESULT';
+    public const ROLE_HOST_ADD_COMMENT = 'ROLE_HOST_ADD_COMMENT';
+    public const ROLE_SERVICE_ADD_COMMENT = 'ROLE_SERVICE_ADD_COMMENT';
 
     // user pages access
     public const ROLE_CONFIGURATION_HOSTS_WRITE = 'ROLE_CONFIGURATION_HOSTS_HOSTS_RW';

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -570,10 +570,12 @@ class EngineService extends AbstractCentreonService implements
             throw new EngineException(_('The contact alias is empty'));
         }
         if ($host == null) {
-            throw new EngineException(_('Host of comment not found'));
+            throw new EngineException(_('Host not found'));
         }
         if (empty($host->getName())) {
-            throw new EngineException(_('Host name can not be empty'));
+            throw new EngineException(
+                sprintf(_('Host name can not be empty for host (id: %d)'), $host->getId())
+            );
         }
 
         $preCommand = sprintf(

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -105,7 +105,7 @@ class EngineService extends AbstractCentreonService implements
             $acknowledgement->getComment()
         );
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-        $commandFull = $this->createCommandHeader($host->getPollerId(), null) . $commandToSend;
+        $commandFull = $this->createCommandHeader($host->getPollerId()) . $commandToSend;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -132,7 +132,7 @@ class EngineService extends AbstractCentreonService implements
             $acknowledgement->getComment()
         );
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId(), null) . $commandToSend;
+        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId()) . $commandToSend;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -149,7 +149,7 @@ class EngineService extends AbstractCentreonService implements
             $host->getName()
         );
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-        $commandFull = $this->createCommandHeader($host->getPollerId(), null) . $commandToSend;
+        $commandFull = $this->createCommandHeader($host->getPollerId()) . $commandToSend;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -169,7 +169,7 @@ class EngineService extends AbstractCentreonService implements
         );
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
 
-        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId(), null) . $commandToSend;
+        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId()) . $commandToSend;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -219,7 +219,7 @@ class EngineService extends AbstractCentreonService implements
                 $downtime->getComment()
             );
             $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-            $commands[] = $this->createCommandHeader($host->getPollerId(), null) . $commandToSend;
+            $commands[] = $this->createCommandHeader($host->getPollerId()) . $commandToSend;
         }
         $this->engineRepository->sendExternalCommands($commands);
     }
@@ -271,7 +271,7 @@ class EngineService extends AbstractCentreonService implements
             $downtime->getComment()
         );
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-        $command = $this->createCommandHeader($service->getHost()->getPollerId(), null) . $commandToSend;
+        $command = $this->createCommandHeader($service->getHost()->getPollerId()) . $commandToSend;
 
         $this->engineRepository->sendExternalCommand($command);
     }
@@ -327,7 +327,7 @@ class EngineService extends AbstractCentreonService implements
         );
 
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-        $commandFull = $this->createCommandHeader($host->getPollerId(), null) . $commandToSend;
+        $commandFull = $this->createCommandHeader($host->getPollerId()) . $commandToSend;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -346,7 +346,7 @@ class EngineService extends AbstractCentreonService implements
         $suffix = ($downtime->getServiceId() === null) ? 'HOST' : 'SVC';
         $preCommand = sprintf('DEL_%s_DOWNTIME;%d', $suffix, $downtime->getInternalId());
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-        $commandFull = $this->createCommandHeader($host->getPollerId(), null) . $commandToSend;
+        $commandFull = $this->createCommandHeader($host->getPollerId()) . $commandToSend;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -384,7 +384,7 @@ class EngineService extends AbstractCentreonService implements
                 $check->getCheckTime()->getTimestamp()
             );
             $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
-            $commands[] = $this->createCommandHeader($host->getPollerId(), null) . $commandToSend;
+            $commands[] = $this->createCommandHeader($host->getPollerId()) . $commandToSend;
         }
         $this->engineRepository->sendExternalCommands($commands);
     }
@@ -423,7 +423,7 @@ class EngineService extends AbstractCentreonService implements
             $check->getCheckTime()->getTimestamp()
         );
 
-        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId(), null) . $command;
+        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId()) . $command;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -458,7 +458,7 @@ class EngineService extends AbstractCentreonService implements
             $result->getPerformanceData()
         );
 
-        $commandFull = $this->createCommandHeader($host->getPollerId(), null) . $command;
+        $commandFull = $this->createCommandHeader($host->getPollerId()) . $command;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -498,7 +498,7 @@ class EngineService extends AbstractCentreonService implements
             $result->getPerformanceData()
         );
 
-        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId(), null) . $command;
+        $commandFull = $this->createCommandHeader($service->getHost()->getPollerId()) . $command;
         $this->engineRepository->sendExternalCommand($commandFull);
     }
 
@@ -569,9 +569,7 @@ class EngineService extends AbstractCentreonService implements
         if (empty($this->contact->getAlias())) {
             throw new EngineException(_('The contact alias is empty'));
         }
-        if ($host == null) {
-            throw new EngineException(_('Host not found'));
-        }
+
         if (empty($host->getName())) {
             throw new EngineException(
                 sprintf(_('Host name can not be empty for host (id: %d)'), $host->getId())
@@ -597,7 +595,7 @@ class EngineService extends AbstractCentreonService implements
      * @return string Returns the new generated command header
      * @throws \Exception
      */
-    private function createCommandHeader(int $pollerId, ?\DateTime $date): string
+    private function createCommandHeader(int $pollerId, \DateTime $date = null): string
     {
         return sprintf(
             "%s:%d:[%d] ",

--- a/src/Centreon/Domain/Engine/Interfaces/EngineServiceInterface.php
+++ b/src/Centreon/Domain/Engine/Interfaces/EngineServiceInterface.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Monitoring\Host;
 use Centreon\Domain\Downtime\Downtime;
 use Centreon\Domain\Monitoring\Service;
 use Centreon\Domain\Engine\EngineException;
+use Centreon\Domain\Monitoring\Comment\Comment;
 use Centreon\Domain\Acknowledgement\Acknowledgement;
 use JMS\Serializer\Exception\ValidationFailedException;
 use Centreon\Domain\Monitoring\SubmitResult\SubmitResult;
@@ -145,4 +146,22 @@ interface EngineServiceInterface extends ContactFilterInterface
      * @throws \Exception
      */
     public function submitServiceResult(SubmitResult $result, Service $service): void;
+
+    /**
+     * Add a comment to a monitored service
+     *
+     * @param Comment $comment
+     * @param Service $service
+     * @throws \Exception
+     */
+    public function addServiceComment(Comment $comment, Service $service): void;
+
+    /**
+     * Add a comment to a monitored host
+     *
+     * @param Comment $comment
+     * @param Host $host
+     * @throws \Exception
+     */
+    public function addHostComment(Comment $comment, Host $host): void;
 }

--- a/src/Centreon/Domain/Monitoring/Comment/Comment.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Comment.php
@@ -120,7 +120,7 @@ class Comment
      *
      * @return \DateTime
      */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->date;
     }
@@ -128,10 +128,10 @@ class Comment
     /**
      * Set date of the comment
      *
-     * @param \DateTime|null $date Date of the comment
+     * @param \DateTime $date Date of the comment
      * @return Comment
      */
-    public function setDate(?\DateTime $date)
+    public function setDate(\DateTime $date)
     {
         $this->date = is_null($date) ? new \DateTime() : $date;
         return $this;

--- a/src/Centreon/Domain/Monitoring/Comment/Comment.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Comment.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Comment;
+
+class Comment
+{
+    /**
+     * @var int Resource ID
+     */
+    public $resourceId;
+
+    /**
+     * @var int|null Parent Resource ID
+     */
+    private $parentResourceId;
+
+    /**
+     * @var string added comment
+     */
+    public $comment;
+
+    /**
+     * Date of the comment
+     *
+     * @var \DateTime|null
+     */
+    public $date;
+
+    public function __construct(int $resourceId, string $comment)
+    {
+        $this->resourceId = $resourceId;
+        $this->setComment($comment);
+    }
+
+    /**
+     * @return int
+     */
+    public function getResourceId(): int
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * @param int $resourceId
+     * @return Comment
+     */
+    public function setResourceId(int $resourceId): Comment
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getParentResourceId(): ?int
+    {
+        return $this->parentResourceId;
+    }
+
+    /**
+     * @param int|null $parentResourceId
+     * @return Comment
+     */
+    public function setParentResourceId(?int $parentResourceId): Comment
+    {
+        $this->parentResourceId = $parentResourceId;
+        return $this;
+    }
+
+    /**
+     * Get added comment
+     *
+     * @return string
+     */
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+
+    /**
+     * Set added comment
+     *
+     * @param string $comment added comment
+     * @return Comment
+     */
+    public function setComment(string $comment): Comment
+    {
+        $this->comment = $comment;
+        return $this;
+    }
+
+    /**
+     * Get date of the comment
+     *
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * Set date of the comment
+     *
+     * @param \DateTime|null $date Date of the comment
+     * @return Comment
+     */
+    public function setDate(?\DateTime $date)
+    {
+        $this->date = $date;
+        return $this;
+    }
+}

--- a/src/Centreon/Domain/Monitoring/Comment/Comment.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Comment.php
@@ -71,7 +71,7 @@ class Comment
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getParentResourceId(): ?int
     {
@@ -106,6 +106,11 @@ class Comment
      */
     public function setComment(string $comment): Comment
     {
+        if (empty($comment)) {
+            throw new \InvalidArgumentException(
+                "Comment can not be empty"
+            );
+        }
         $this->comment = $comment;
         return $this;
     }
@@ -128,7 +133,7 @@ class Comment
      */
     public function setDate(?\DateTime $date)
     {
-        $this->date = $date;
+        $this->date = is_null($date) ? new \DateTime() : $date;
         return $this;
     }
 }

--- a/src/Centreon/Domain/Monitoring/Comment/Comment.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Comment.php
@@ -133,7 +133,7 @@ class Comment
      */
     public function setDate(\DateTime $date)
     {
-        $this->date = is_null($date) ? new \DateTime() : $date;
+        $this->date = $date;
         return $this;
     }
 }

--- a/src/Centreon/Domain/Monitoring/Comment/Comment.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Comment.php
@@ -118,9 +118,9 @@ class Comment
     /**
      * Get date of the comment
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
-    public function getDate(): \DateTime
+    public function getDate(): ?\DateTime
     {
         return $this->date;
     }

--- a/src/Centreon/Domain/Monitoring/Comment/CommentException.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Comment;
+
+class CommentException extends \RuntimeException
+{
+}

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -118,7 +118,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
      */
     public function addServiceComment(Comment $comment, Service $service): void
     {
-        // We validate the check instance
+        // We validate the comment entity sent
         $errors = $this->validator->validate(
             $comment,
             null,
@@ -164,7 +164,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
      */
     public function addHostComment(Comment $comment, Host $host): void
     {
-        // We validate the SubmitResult instance instance
+        // We validate the comment entity sent
         $errors = $this->validator->validate(
             $comment,
             null,

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -106,7 +106,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
     /**
      * @inheritDoc
      */
-    public function addServiceComment(Comment $comment): void
+    public function addServiceComment(Comment $comment, Service $service): void
     {
         // We validate the check instance
         $errors = $this->validator->validate(
@@ -119,37 +119,13 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
             throw new ValidationFailedException($errors);
         }
 
-        $host = $this->monitoringRepository->findOneHost($comment->getParentResourceId());
-        if (is_null($host)) {
-            throw new EntityNotFoundException(
-                sprintf(
-                    _('Host %d not found'),
-                    $comment->getParentResourceId()
-                )
-            );
-        }
-
-        $service = $this->monitoringRepository->findOneService(
-            $comment->getParentResourceId(),
-            $comment->getResourceId()
-        );
-        if (is_null($service)) {
-            throw new EntityNotFoundException(
-                sprintf(
-                    _('Service %d not found'),
-                    $comment->getResourceId()
-                )
-            );
-        }
-        $service->setHost($host);
-
         $this->engineService->addServiceComment($comment, $service);
     }
 
     /**
      * @inheritDoc
      */
-    public function addHostComment(Comment $comment): void
+    public function addHostComment(Comment $comment, Host $host): void
     {
         // We validate the SubmitResult instance instance
         $errors = $this->validator->validate(
@@ -160,16 +136,6 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
 
         if ($errors->count() > 0) {
             throw new ValidationFailedException($errors);
-        }
-
-        $host = $this->monitoringRepository->findOneHost($comment->getResourceId());
-        if (is_null($host)) {
-            throw new EntityNotFoundException(
-                sprintf(
-                    _('Host %d not found'),
-                    $comment->getResourceId()
-                )
-            );
         }
 
         $this->engineService->addHostComment($comment, $host);

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -196,31 +196,49 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
      */
     public function addResourcesComment(array $comments, array $resourceIds): void
     {
+        $hosts = [];
+        $services = [];
         /**
          * Retrieving at this point all the host and services entities linked to
          * the resource ids provided
          */
         if ($this->contact->isAdmin()) {
             if (!empty($resourceIds['host'])) {
-                $hosts = $this->monitoringRepository->findHostsByIdsForAdminUser($resourceIds['host']);
+                try {
+                    $hosts = $this->monitoringRepository->findHostsByIdsForAdminUser($resourceIds['host']);
+                } catch (\Throwable $ex) {
+                    throw new \Exception(_('Error when searching for hosts'));
+                }
             }
 
             if (!empty($resourceIds['service'])) {
-                $services = $this->monitoringRepository->findServicesByIdsForAdminUser($resourceIds['service']);
+                try {
+                    $services = $this->monitoringRepository->findServicesByIdsForAdminUser($resourceIds['service']);
+                } catch (\Throwable $ex) {
+                    throw new \Exception(_('Error when searching for services'));
+                }
             }
         } else {
             $accessGroups = $this->accessGroupRepository->findByContact($this->contact);
 
             if (!empty($resourcesId['host'])) {
-                $hosts = $this->monitoringRepository
-                    ->filterByAccessGroups($accessGroups)
-                    ->findHostsByIdsForNonAdminUser($resourceIds['host']);
+                try {
+                    $hosts = $this->monitoringRepository
+                        ->filterByAccessGroups($accessGroups)
+                        ->findHostsByIdsForNonAdminUser($resourceIds['host']);
+                } catch (\Throwable $ex) {
+                    throw new \Exception(_('Error when searching for hosts'));
+                }
             }
 
             if (!empty($resourcesIds['service'])) {
-                $services = $this->monitoringRepository
-                    ->filterByAccessGroups($accessGroups)
-                    ->findServicesByIdsForNonAdminUser($resourceIds['service']);
+                try {
+                    $services = $this->monitoringRepository
+                        ->filterByAccessGroups($accessGroups)
+                        ->findServicesByIdsForNonAdminUser($resourceIds['service']);
+                } catch (\Throwable $ex) {
+                    throw new \Exception(_('Error when searching for services'));
+                }
             }
         }
 

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -205,7 +205,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
                 $hosts = $this->monitoringRepository->findHostsByIdsForAdminUser($resourceIds['host']);
             }
 
-            if (!empty($resourceIds['services'])) {
+            if (!empty($resourceIds['service'])) {
                 $services = $this->monitoringRepository->findServicesByIdsForAdminUser($resourceIds['service']);
             }
         } else {

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -201,18 +201,27 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
          * the resource ids provided
          */
         if ($this->contact->isAdmin()) {
-            $hosts = $this->monitoringRepository->findHostsByIdsForAdminUser($resourceIds['host']);
-            $services = $this->monitoringRepository->findServicesByIdsForAdminUser($resourceIds['service']);
+            if (!empty($resourceIds['host'])) {
+                $hosts = $this->monitoringRepository->findHostsByIdsForAdminUser($resourceIds['host']);
+            }
+
+            if (!empty($resourceIds['services'])) {
+                $services = $this->monitoringRepository->findServicesByIdsForAdminUser($resourceIds['service']);
+            }
         } else {
             $accessGroups = $this->accessGroupRepository->findByContact($this->contact);
 
-            $hosts = $this->monitoringRepository
-                ->filterByAccessGroups($accessGroups)
-                ->findHostsByIdsForNonAdminUser($resourceIds['host']);
+            if (!empty($resourcesId['host'])) {
+                $hosts = $this->monitoringRepository
+                    ->filterByAccessGroups($accessGroups)
+                    ->findHostsByIdsForNonAdminUser($resourceIds['host']);
+            }
 
-            $services = $this->monitoringRepository
-                ->filterByAccessGroups($accessGroups)
-                ->findServicesByIdsForNonAdminUser($resourceIds['service']);
+            if (!empty($resourcesIds['service'])) {
+                $services = $this->monitoringRepository
+                    ->filterByAccessGroups($accessGroups)
+                    ->findServicesByIdsForNonAdminUser($resourceIds['service']);
+            }
         }
 
         foreach ($hosts as $key => $host) {

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Comment;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Monitoring\Host;
+use Centreon\Domain\Monitoring\Service;
+use Centreon\Domain\Entity\EntityValidator;
+use Centreon\Domain\Service\AbstractCentreonService;
+use Centreon\Domain\Exception\EntityNotFoundException;
+use JMS\Serializer\Exception\ValidationFailedException;
+use Centreon\Domain\Engine\Interfaces\EngineServiceInterface;
+use Centreon\Domain\Security\Interfaces\AccessGroupRepositoryInterface;
+use Centreon\Domain\Monitoring\Interfaces\MonitoringRepositoryInterface;
+use Centreon\Domain\Monitoring\Comment\Interfaces\CommentServiceInterface;
+
+/**
+ * Monitoring class used to manage result submitting to services, hosts and resources
+ *
+ * @package Centreon\Domain\Monitoring\SubmitResult
+ */
+class CommentService extends AbstractCentreonService implements CommentServiceInterface
+{
+    public const VALIDATION_GROUPS_HOST_ADD_COMMENT = ['add_host_comment'];
+    public const VALIDATION_GROUPS_SERVICE_ADD_COMMENT = ['add_service_comment'];
+
+    /**
+     * @var EngineServiceInterface Used to send external commands to engine.
+     */
+    private $engineService;
+
+    /**
+     * @var EntityValidator
+     */
+    private $validator;
+
+    /**
+     * @var MonitoringRepositoryInterface
+     */
+    private $monitoringRepository;
+
+    /**
+     * @var AccessGroupRepositoryInterface
+     */
+    private $accessGroupRepository;
+
+    /**
+     * SubmitResultService constructor.
+     *
+     * @param AccessGroupRepositoryInterface $accessGroupRepository
+     * @param MonitoringRepositoryInterface $monitoringRepository
+     * @param EngineServiceInterface $engineService
+     * @param EntityValidator $validator
+     */
+    public function __construct(
+        AccessGroupRepositoryInterface $accessGroupRepository,
+        MonitoringRepositoryInterface $monitoringRepository,
+        EngineServiceInterface $engineService,
+        EntityValidator $validator
+    ) {
+        $this->accessGroupRepository = $accessGroupRepository;
+        $this->monitoringRepository = $monitoringRepository;
+        $this->engineService = $engineService;
+        $this->validator = $validator;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param Contact $contact
+     * @return CommentServiceInterface
+     */
+    public function filterByContact($contact): CommentServiceInterface
+    {
+        parent::filterByContact($contact);
+        $this->engineService->filterByContact($contact);
+
+        $accessGroups = $this->accessGroupRepository->findByContact($contact);
+
+        $this->monitoringRepository
+            ->setContact($contact)
+            ->filterByAccessGroups($accessGroups);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addServiceComment(Comment $comment): void
+    {
+        // We validate the check instance
+        $errors = $this->validator->validate(
+            $comment,
+            null,
+            self::VALIDATION_GROUPS_SERVICE_ADD_COMMENT
+        );
+
+        if ($errors->count() > 0) {
+            throw new ValidationFailedException($errors);
+        }
+
+        $host = $this->monitoringRepository->findOneHost($comment->getParentResourceId());
+        if (is_null($host)) {
+            throw new EntityNotFoundException(
+                sprintf(
+                    _('Host %d not found'),
+                    $comment->getParentResourceId()
+                )
+            );
+        }
+
+        $service = $this->monitoringRepository->findOneService(
+            $comment->getParentResourceId(),
+            $comment->getResourceId()
+        );
+        if (is_null($service)) {
+            throw new EntityNotFoundException(
+                sprintf(
+                    _('Service %d not found'),
+                    $comment->getResourceId()
+                )
+            );
+        }
+        $service->setHost($host);
+
+        $this->engineService->addServiceComment($comment, $service);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addHostComment(Comment $comment): void
+    {
+        // We validate the SubmitResult instance instance
+        $errors = $this->validator->validate(
+            $comment,
+            null,
+            self::VALIDATION_GROUPS_HOST_ADD_COMMENT
+        );
+
+        if ($errors->count() > 0) {
+            throw new ValidationFailedException($errors);
+        }
+
+        $host = $this->monitoringRepository->findOneHost($comment->getResourceId());
+        if (is_null($host)) {
+            throw new EntityNotFoundException(
+                sprintf(
+                    _('Host %d not found'),
+                    $comment->getResourceId()
+                )
+            );
+        }
+
+        $this->engineService->addHostComment($comment, $host);
+    }
+}

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -26,15 +26,16 @@ use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Monitoring\Host;
 use Centreon\Domain\Monitoring\Service;
 use Centreon\Domain\Entity\EntityValidator;
+use Centreon\Domain\Monitoring\MonitoringService;
 use Centreon\Domain\Service\AbstractCentreonService;
 use Centreon\Domain\Exception\EntityNotFoundException;
 use JMS\Serializer\Exception\ValidationFailedException;
+use Centreon\Domain\Monitoring\Comment\CommentException;
 use Centreon\Domain\Engine\Interfaces\EngineServiceInterface;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringServiceInterface;
 use Centreon\Domain\Security\Interfaces\AccessGroupRepositoryInterface;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringRepositoryInterface;
 use Centreon\Domain\Monitoring\Comment\Interfaces\CommentServiceInterface;
-use Centreon\Domain\Monitoring\MonitoringService;
 
 /**
  * Monitoring class used to manage result submitting to services, hosts and resources
@@ -207,7 +208,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
                 try {
                     $hosts = $this->monitoringRepository->findHostsByIdsForAdminUser($resourceIds['host']);
                 } catch (\Throwable $ex) {
-                    throw new \Exception(_('Error when searching for hosts'));
+                    throw new CommentException(_('Error when searching for hosts'), 0, $ex);
                 }
             }
 
@@ -215,7 +216,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
                 try {
                     $services = $this->monitoringRepository->findServicesByIdsForAdminUser($resourceIds['service']);
                 } catch (\Throwable $ex) {
-                    throw new \Exception(_('Error when searching for services'));
+                    throw new CommentException(_('Error when searching for services'), 0, $ex);
                 }
             }
         } else {
@@ -227,7 +228,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
                         ->filterByAccessGroups($accessGroups)
                         ->findHostsByIdsForNonAdminUser($resourceIds['host']);
                 } catch (\Throwable $ex) {
-                    throw new \Exception(_('Error when searching for hosts'));
+                    throw new CommentException(_('Error when searching for hosts'), 0, $ex);
                 }
             }
 
@@ -237,7 +238,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
                         ->filterByAccessGroups($accessGroups)
                         ->findServicesByIdsForNonAdminUser($resourceIds['service']);
                 } catch (\Throwable $ex) {
-                    throw new \Exception(_('Error when searching for services'));
+                    throw new CommentException(_('Error when searching for services'), 0, $ex);
                 }
             }
         }

--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -243,11 +243,11 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
             }
         }
 
-        foreach ($hosts as $key => $host) {
+        foreach ($hosts as $host) {
             $this->addHostComment($comments[$host->getId()], $host);
         }
 
-        foreach ($services as $key => $service) {
+        foreach ($services as $service) {
             $this->addServiceComment($comments[$service->getId()], $service);
         }
     }

--- a/src/Centreon/Domain/Monitoring/Comment/Interfaces/CommentServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Interfaces/CommentServiceInterface.php
@@ -32,16 +32,17 @@ interface CommentServiceInterface extends ContactFilterInterface
     /**
      * Function allowing contact to add a comment to a service
      *
-     * @param  Comment $comment
-     * @return void
+     * @param  Comment $comment Comment to add to the service
+     * @param Service $service Service that will receive the comment
      */
-    public function addServiceComment(Comment $comment): void;
+    public function addServiceComment(Comment $comment, Service $service): void;
 
     /**
      * Function allowing contact to add a comment to a host
      *
-     * @param  Comment $comment
+     * @param  Comment $comment Comment to add to the host
+     * @param Host $host Host that will receive the comment
      * @return void
      */
-    public function addHostComment(Comment $comment): void;
+    public function addHostComment(Comment $comment, Host $host): void;
 }

--- a/src/Centreon/Domain/Monitoring/Comment/Interfaces/CommentServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Interfaces/CommentServiceInterface.php
@@ -45,4 +45,13 @@ interface CommentServiceInterface extends ContactFilterInterface
      * @return void
      */
     public function addHostComment(Comment $comment, Host $host): void;
+
+    /**
+     * Function allowing contact to add multiple comments to multiple resources
+     *
+     * @param Comment[] $comments Comments added for each resources
+     * @param array $resourceIds IDs of the resources
+     * @return void
+     */
+    public function addResourcesComment(array $comments, array $resourceIds): void;
 }

--- a/src/Centreon/Domain/Monitoring/Comment/Interfaces/CommentServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Interfaces/CommentServiceInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Comment\Interfaces;
+
+use Centreon\Domain\Monitoring\Host;
+use Centreon\Domain\Monitoring\Service;
+use Centreon\Domain\Monitoring\Comment\Comment;
+use Centreon\Domain\Contact\Interfaces\ContactFilterInterface;
+
+interface CommentServiceInterface extends ContactFilterInterface
+{
+    /**
+     * Function allowing contact to add a comment to a service
+     *
+     * @param  Comment $comment
+     * @return void
+     */
+    public function addServiceComment(Comment $comment): void;
+
+    /**
+     * Function allowing contact to add a comment to a host
+     *
+     * @param  Comment $comment
+     * @return void
+     */
+    public function addHostComment(Comment $comment): void;
+}

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -90,7 +90,7 @@ interface MonitoringRepositoryInterface
      * @param array $hostIds
      * @return Host[]
      */
-    public function findHostsByIdsForNonAdminUser(array $hostIds): ?array;
+    public function findHostsByIdsForNonAdminUser(array $hostIds): array;
 
     /**
      * Find all hosts from an array of hostIds for an admin user
@@ -98,7 +98,7 @@ interface MonitoringRepositoryInterface
      * @param array $hostIds
      * @return Host[]
      */
-    public function findHostsByIdsForAdminUser(array $hostIds): ?array;
+    public function findHostsByIdsForAdminUser(array $hostIds): array;
 
     /**
      * Find one service based on its id and according to ACL.

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -85,12 +85,20 @@ interface MonitoringRepositoryInterface
     public function findOneHost(int $hostId): ?Host;
 
     /**
-     * Find all hosts from an array of hostIds
+     * Find all hosts from an array of hostIds for a non admin user
      *
      * @param array $hostIds
      * @return Host[]
      */
-    public function findMultipleHosts(array $hostIds): ?array;
+    public function findHostsByIdsForNonAdminUser(array $hostIds): ?array;
+
+    /**
+     * Find all hosts from an array of hostIds for an admin user
+     *
+     * @param array $hostIds
+     * @return Host[]
+     */
+    public function findHostsByIdsForAdminUser(array $hostIds): ?array;
 
     /**
      * Find one service based on its id and according to ACL.
@@ -103,12 +111,20 @@ interface MonitoringRepositoryInterface
     public function findOneService(int $hostId, int $serviceId): ?Service;
 
     /**
-     * Find all services from an array of serviceIds
+     * Find all services from an array of serviceIds for a non admin user
      *
      * @param array $serviceIds
      * @return Services[]
      */
-    public function findMultipleServices(array $serviceIds): array;
+    public function findServicesByIdsForNonAdminUser(array $serviceIds): array;
+
+    /**
+     * Find all services from an array of serviceIds for an admin user
+     *
+     * @param array $serviceIds
+     * @return Services[]
+     */
+    public function findServicesByIdsForAdminUser(array $serviceIds): array;
 
     /**
      * Find all services grouped by service groups

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -85,6 +85,14 @@ interface MonitoringRepositoryInterface
     public function findOneHost(int $hostId): ?Host;
 
     /**
+     * Find all hosts from an array of hostIds
+     *
+     * @param array $hostIds
+     * @return Host[]
+     */
+    public function findMultipleHosts(array $hostIds): ?array;
+
+    /**
      * Find one service based on its id and according to ACL.
      *
      * @param int $hostId Host id of the service
@@ -93,6 +101,14 @@ interface MonitoringRepositoryInterface
      * @throws \Exception
      */
     public function findOneService(int $hostId, int $serviceId): ?Service;
+
+    /**
+     * Find all services from an array of serviceIds
+     *
+     * @param array $serviceIds
+     * @return Services[]
+     */
+    public function findMultipleServices(array $serviceIds): array;
 
     /**
      * Find all services grouped by service groups

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringServiceInterface.php
@@ -65,14 +65,6 @@ interface MonitoringServiceInterface extends ContactFilterInterface
     public function findOneHost(int $hostId): ?Host;
 
     /**
-     * Find all hosts from an array of hostIds
-     *
-     * @param array $hostIds
-     * @return Host[]
-     */
-    public function findMultipleHosts(array $hostIds): array;
-
-    /**
      * Find a service based on his ID and a host ID.
      *
      * @param int $hostId Host ID for which the service belongs
@@ -81,23 +73,6 @@ interface MonitoringServiceInterface extends ContactFilterInterface
      * @throws \Exception
      */
     public function findOneService(int $hostId, int $serviceId): ?Service;
-
-    /**
-     * Find a services based on a list of ids
-     *
-     * @param array $serviceIds Services to find
-     * Expected
-     * [
-     *   [0] => [
-     *      'host_id' => int,
-     *      'service_id' => int
-     *   ],
-     *   ...
-     * ]
-     * @return Service[]
-     * @throws \Exception
-     */
-    public function findMultipleServices(array $serviceIds): array;
 
     /**
      * Find all service groups.

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringServiceInterface.php
@@ -22,15 +22,15 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Monitoring\Interfaces;
 
+use Centreon\Domain\Monitoring\Host;
+use Centreon\Domain\Monitoring\Service;
+use Centreon\Domain\Monitoring\HostGroup;
+use Centreon\Domain\Monitoring\ServiceGroup;
+use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Domain\Contact\Interfaces\ContactFilterInterface;
+use Centreon\Domain\MonitoringServer\MonitoringServerException;
 use Centreon\Domain\HostConfiguration\HostConfigurationException;
 use Centreon\Domain\Monitoring\Exception\MonitoringServiceException;
-use Centreon\Domain\Monitoring\Host;
-use Centreon\Domain\Monitoring\HostGroup;
-use Centreon\Domain\Monitoring\Service;
-use Centreon\Domain\Monitoring\ServiceGroup;
-use Centreon\Domain\MonitoringServer\MonitoringServerException;
-use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Domain\ServiceConfiguration\ServiceConfigurationException;
 
 interface MonitoringServiceInterface extends ContactFilterInterface
@@ -65,6 +65,14 @@ interface MonitoringServiceInterface extends ContactFilterInterface
     public function findOneHost(int $hostId): ?Host;
 
     /**
+     * Find all hosts from an array of hostIds
+     *
+     * @param array $hostIds
+     * @return Host[]
+     */
+    public function findMultipleHosts(array $hostIds): array;
+
+    /**
      * Find a service based on his ID and a host ID.
      *
      * @param int $hostId Host ID for which the service belongs
@@ -73,6 +81,23 @@ interface MonitoringServiceInterface extends ContactFilterInterface
      * @throws \Exception
      */
     public function findOneService(int $hostId, int $serviceId): ?Service;
+
+    /**
+     * Find a services based on a list of ids
+     *
+     * @param array $serviceIds Services to find
+     * Expected
+     * [
+     *   [0] => [
+     *      'host_id' => int,
+     *      'service_id' => int
+     *   ],
+     *   ...
+     * ]
+     * @return Service[]
+     * @throws \Exception
+     */
+    public function findMultipleServices(array $serviceIds): array;
 
     /**
      * Find all service groups.

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -201,9 +201,24 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
     /**
      * @inheritDoc
      */
+    public function findMultipleHosts(array $hostIds): array
+    {
+        return $this->monitoringRepository->findMultipleHosts($hostIds);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findOneService(int $hostId, int $serviceId): ?Service
     {
         return $this->monitoringRepository->findOneService($hostId, $serviceId);
+    }
+    /**
+     * @inheritDoc
+     */
+    public function findMultipleServices(array $serviceIds): array
+    {
+        return $this->monitoringRepository->findMultipleServices($serviceIds);
     }
 
     /**

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -201,24 +201,9 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
     /**
      * @inheritDoc
      */
-    public function findMultipleHosts(array $hostIds): array
-    {
-        return $this->monitoringRepository->findMultipleHosts($hostIds);
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function findOneService(int $hostId, int $serviceId): ?Service
     {
         return $this->monitoringRepository->findOneService($hostId, $serviceId);
-    }
-    /**
-     * @inheritDoc
-     */
-    public function findMultipleServices(array $serviceIds): array
-    {
-        return $this->monitoringRepository->findMultipleServices($serviceIds);
     }
 
     /**

--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -374,6 +374,12 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             case 'host_submit_result':
                 $contact->addRole(Contact::ROLE_HOST_SUBMIT_RESULT);
                 break;
+            case 'host_comment':
+                $contact->addRole(Contact::ROLE_HOST_ADD_COMMENT);
+                break;
+            case 'service_comment':
+                $contact->addRole(Contact::ROLE_SERVICE_ADD_COMMENT);
+                break;
         }
     }
 

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -578,21 +578,18 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               WHERE srv.enabled = \'1\'
               AND h.enabled = \'1\'';
 
-
-        if (is_array($serviceIds)) {
-            $idsListKey = [];
-            foreach ($serviceIds as $index => $hostServiceIds) {
-                $hostKey = ":host_id{$index}";
-                $hostIdsListKey[] = $hostKey;
-                $serviceKey = ":service_id{$index}";
-                $serviceIdsListKey[] = $serviceKey;
-                $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
-                $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
-                unset($index, $hostServiceIds);
-            }
-            $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
-            $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';
+        $idsListKey = [];
+        foreach ($serviceIds as $index => $hostServiceIds) {
+            $hostKey = ":host_id{$index}";
+            $hostIdsListKey[] = $hostKey;
+            $serviceKey = ":service_id{$index}";
+            $serviceIdsListKey[] = $serviceKey;
+            $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
+            $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
+            unset($index, $hostServiceIds);
         }
+        $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
+        $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';
 
         $request .= ' GROUP BY srv.service_id';
 
@@ -639,16 +636,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               AND h.enabled = \'1\'
               AND h.name NOT LIKE \'_Module_BAM%\'';
 
-        if (is_array($hostIds)) {
-            $idsListKey = [];
-            foreach ($hostIds as $index => $id) {
-                $key = ":id{$index}";
-                $idsListKey[] = $key;
-                $collector->addValue($key, $id, \PDO::PARAM_INT);
-                unset($index, $id);
-            }
-            $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
+        $idsListKey = [];
+        foreach ($hostIds as $index => $id) {
+            $key = ":id{$index}";
+            $idsListKey[] = $key;
+            $collector->addValue($key, $id, \PDO::PARAM_INT);
+            unset($index, $id);
         }
+        $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
 
         $request = $this->translateDbName($request);
 
@@ -657,11 +652,10 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-            $host = EntityCreator::createEntityByArray(
+            $host[] = EntityCreator::createEntityByArray(
                 Host::class,
                 $row
             );
-            $hosts[] = $host;
         }
 
         return $hosts;
@@ -670,7 +664,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
-    public function findHostsByIdsForNonAdminUser(array $hostIds): ?array
+    public function findHostsByIdsForNonAdminUser(array $hostIds): array
     {
         $hosts = [];
 
@@ -701,17 +695,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               AND h.name NOT LIKE \'_Module_BAM%\''
             . $accessGroupFilter;
 
-        if (is_array($hostIds)) {
-            $idsListKey = [];
-            foreach ($hostIds as $index => $id) {
-                $key = ":id{$index}";
-                $idsListKey[] = $key;
-                $collector->addValue($key, $id, \PDO::PARAM_INT);
-                unset($index, $id);
-            }
-            $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
+        $idsListKey = [];
+        foreach ($hostIds as $index => $id) {
+            $key = ":id{$index}";
+            $idsListKey[] = $key;
+            $collector->addValue($key, $id, \PDO::PARAM_INT);
         }
 
+        $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
         $request = $this->translateDbName($request);
 
         $statement = $this->db->prepare($request);
@@ -719,11 +710,10 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-            $host = EntityCreator::createEntityByArray(
+            $host[] = EntityCreator::createEntityByArray(
                 Host::class,
                 $row
             );
-            $hosts[] = $host;
         }
 
         return $hosts;
@@ -865,21 +855,18 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             . ' WHERE srv.enabled = \'1\'
               AND h.enabled = \'1\'';
 
-
-        if (is_array($serviceIds)) {
-            $idsListKey = [];
-            foreach ($serviceIds as $index => $hostServiceIds) {
-                $hostKey = ":host_id{$index}";
-                $hostIdsListKey[] = $hostKey;
-                $serviceKey = ":service_id{$index}";
-                $serviceIdsListKey[] = $serviceKey;
-                $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
-                $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
-                unset($index, $hostServiceIds);
-            }
-            $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
-            $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';
+        $idsListKey = [];
+        foreach ($serviceIds as $index => $hostServiceIds) {
+            $hostKey = ":host_id{$index}";
+            $hostIdsListKey[] = $hostKey;
+            $serviceKey = ":service_id{$index}";
+            $serviceIdsListKey[] = $serviceKey;
+            $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
+            $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
+            unset($index, $hostServiceIds);
         }
+        $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
+        $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';
 
         $request .= ' GROUP BY srv.service_id';
 

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -600,22 +600,18 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
+        $statement->execute();
 
-        if ($statement->execute() !== false) {
-            while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-                $service = EntityCreator::createEntityByArray(
-                    Service::class,
-                    $row
-                );
-                $service->setHost(
-                    EntityCreator::createEntityByArray(Host::class, $row, 'host_')
-                );
-                $services[] = $service;
-            }
-        } else {
-            throw new \Exception(_('Failed to find services'));
+        while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $service = EntityCreator::createEntityByArray(
+                Service::class,
+                $row
+            );
+            $service->setHost(
+                EntityCreator::createEntityByArray(Host::class, $row, 'host_')
+            );
+            $services[] = $service;
         }
-
         return $services;
     }
 
@@ -658,17 +654,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
+        $statement->execute();
 
-        if ($statement->execute() !== false) {
-            while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-                $host = EntityCreator::createEntityByArray(
-                    Host::class,
-                    $row
-                );
-                $hosts[] = $host;
-            }
-        } else {
-            throw new \Exception(_('Failed to find hosts'));
+        while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $host = EntityCreator::createEntityByArray(
+                Host::class,
+                $row
+            );
+            $hosts[] = $host;
         }
 
         return $hosts;
@@ -723,17 +716,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
+        $statement->execute();
 
-        if ($statement->execute() !== false) {
-            while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-                $host = EntityCreator::createEntityByArray(
-                    Host::class,
-                    $row
-                );
-                $hosts[] = $host;
-            }
-        } else {
-            throw new \Exception(_('Failed to find hosts'));
+        while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $host = EntityCreator::createEntityByArray(
+                Host::class,
+                $row
+            );
+            $hosts[] = $host;
         }
 
         return $hosts;
@@ -897,20 +887,17 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
+        $statement->execute();
 
-        if ($statement->execute() !== false) {
-            while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-                $service = EntityCreator::createEntityByArray(
-                    Service::class,
-                    $row
-                );
-                $service->setHost(
-                    EntityCreator::createEntityByArray(Host::class, $row, 'host_')
-                );
-                $services[] = $service;
-            }
-        } else {
-            throw new \Exception(_('Failed to find services'));
+        while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $service = EntityCreator::createEntityByArray(
+                Service::class,
+                $row
+            );
+            $service->setHost(
+                EntityCreator::createEntityByArray(Host::class, $row, 'host_')
+            );
+            $services[] = $service;
         }
 
         return $services;

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -687,15 +687,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $collector = new StatementCollector();
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id IS NULL
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter =
+            ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id IS NULL
+            INNER JOIN `:db`.`acl_groups` acg
+                ON acg.acl_group_id = acl.group_id
+                AND acg.acl_group_activate = \'1\'
+                AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
         $request =
             'SELECT h.*,
@@ -842,15 +841,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $services;
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter =
+            ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = srv.service_id
+            INNER JOIN `:db`.`acl_groups` acg
+                ON acg.acl_group_id = acl.group_id
+                AND acg.acl_group_activate = \'1\'
+                AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
         $request =
             'SELECT DISTINCT srv.*,

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -551,6 +551,11 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $hosts = [];
+
+        if (empty($hostIds)) {
+            return $hosts;
+        }
+
         $collector = new StatementCollector();
 
         $accessGroupFilter = $this->isAdmin()
@@ -706,6 +711,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $collector = new StatementCollector();
 
+        $services = [];
+
+        if (empty($serviceIds)) {
+            return $services;
+        }
+
         $accessGroupFilter = $this->isAdmin()
             ? ' '
             : ' INNER JOIN `:dbstg`.`centreon_acl` acl
@@ -763,8 +774,6 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
-
-        $services = [];
 
         if ($statement->execute()) {
             while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -586,7 +586,6 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             $serviceIdsListKey[] = $serviceKey;
             $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
             $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
-            unset($index, $hostServiceIds);
         }
         $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
         $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';
@@ -641,7 +640,6 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             $key = ":id{$index}";
             $idsListKey[] = $key;
             $collector->addValue($key, $id, \PDO::PARAM_INT);
-            unset($index, $id);
         }
         $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
 
@@ -652,7 +650,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-            $host[] = EntityCreator::createEntityByArray(
+            $hosts[] = EntityCreator::createEntityByArray(
                 Host::class,
                 $row
             );
@@ -863,7 +861,6 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             $serviceIdsListKey[] = $serviceKey;
             $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
             $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
-            unset($index, $hostServiceIds);
         }
         $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
         $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -35,6 +35,7 @@ use Centreon\Domain\Monitoring\Host;
 use Centreon\Domain\Monitoring\Service;
 use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringRepositoryInterface;
+use Centreon\Infrastructure\CentreonLegacyDB\StatementCollector;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 
@@ -543,6 +544,71 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
+    public function findMultipleHosts(array $hostIds): ?array
+    {
+        if ($this->hasNotEnoughRightsToContinue()) {
+            return null;
+        }
+
+        $hosts = [];
+        $collector = new StatementCollector();
+
+        $accessGroupFilter = $this->isAdmin()
+            ? ' '
+            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                  ON acl.host_id = h.host_id
+                  AND acl.service_id IS NULL
+                INNER JOIN `:db`.`acl_groups` acg
+                  ON acg.acl_group_id = acl.group_id
+                  AND acg.acl_group_activate = \'1\'
+                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+
+        $request =
+            'SELECT h.*,
+            i.name AS poller_name,
+              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS state
+            FROM `:dbstg`.`instances` i
+            INNER JOIN `:dbstg`.`hosts` h
+              ON h.instance_id = i.instance_id
+              AND h.enabled = \'1\'
+              AND h.name NOT LIKE \'_Module_BAM%\''
+            . $accessGroupFilter;
+
+        if (is_array($hostIds)) {
+            $idsListKey = [];
+            foreach ($hostIds as $x => $id) {
+                $key = ":id{$x}";
+                $idsListKey[] = $key;
+                $collector->addValue($key, $id, \PDO::PARAM_INT);
+                unset($x, $id);
+            }
+            $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
+        }
+
+        $request = $this->translateDbName($request);
+
+        $statement = $this->db->prepare($request);
+        $collector->bind($statement);
+
+        if ($statement->execute()) {
+            while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
+                $host = EntityCreator::createEntityByArray(
+                    Host::class,
+                    $row
+                );
+                $hosts[] = $host;
+            }
+        } else {
+            throw new \Exception(_('Bad SQL request'));
+        }
+
+        return $hosts;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findOneService(int $hostId, int $serviceId): ?Service
     {
         if ($this->hasNotEnoughRightsToContinue()) {
@@ -627,6 +693,95 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         return $service;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findMultipleServices(array $serviceIds): array
+    {
+        if ($this->hasNotEnoughRightsToContinue()) {
+            return null;
+        }
+
+        $collector = new StatementCollector();
+
+        $accessGroupFilter = $this->isAdmin()
+            ? ' '
+            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                  ON acl.host_id = h.host_id
+                  AND acl.service_id = srv.service_id
+                INNER JOIN `:db`.`acl_groups` acg
+                  ON acg.acl_group_id = acl.group_id
+                  AND acg.acl_group_activate = \'1\'
+                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+
+        $request =
+            'SELECT DISTINCT srv.*,
+              h.host_id AS `host_host_id`, h.name AS `host_name`, h.alias AS `host_alias`, h.instance_id AS `host_poller_id`,
+              srv.state AS `status_code`,
+              CASE
+                WHEN srv.state = 0 THEN "' . ResourceStatus::STATUS_NAME_OK . '"
+                WHEN srv.state = 1 THEN "' . ResourceStatus::STATUS_NAME_WARNING . '"
+                WHEN srv.state = 2 THEN "' . ResourceStatus::STATUS_NAME_CRITICAL . '"
+                WHEN srv.state = 3 THEN "' . ResourceStatus::STATUS_NAME_UNKNOWN . '"
+                WHEN srv.state = 4 THEN "' . ResourceStatus::STATUS_NAME_PENDING . '"
+              END AS `status_name`,
+              CASE
+                WHEN srv.state = 0 THEN ' . ResourceStatus::SEVERITY_OK . '
+                WHEN srv.state = 1 THEN ' . ResourceStatus::SEVERITY_MEDIUM . '
+                WHEN srv.state = 2 THEN ' . ResourceStatus::SEVERITY_HIGH . '
+                WHEN srv.state = 3 THEN ' . ResourceStatus::SEVERITY_LOW . '
+                WHEN srv.state = 4 THEN ' . ResourceStatus::SEVERITY_PENDING . '
+              END AS `status_severity_code`
+            FROM `:dbstg`.services srv
+            LEFT JOIN `:dbstg`.hosts h
+              ON h.host_id = srv.host_id'
+            . $accessGroupFilter
+            . ' WHERE srv.enabled = \'1\'
+              AND h.enabled = \'1\'';
+
+
+        if (is_array($serviceIds)) {
+            $idsListKey = [];
+            foreach ($serviceIds as $x => $hostServiceIds) {
+                $hostKey = ":host_id{$x}";
+                $hostIdsListKey[] = $hostKey;
+                $serviceKey = ":service_id{$x}";
+                $serviceIdsListKey[] = $serviceKey;
+                $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
+                $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
+                unset($x, $hostServiceIds);
+            }
+            $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
+            $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';
+        }
+
+        $request .= ' GROUP BY srv.service_id';
+
+        $request = $this->translateDbName($request);
+
+        $statement = $this->db->prepare($request);
+        $collector->bind($statement);
+
+        $services = [];
+
+        if ($statement->execute()) {
+            while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
+                $service = EntityCreator::createEntityByArray(
+                    Service::class,
+                    $row
+                );
+                $service->setHost(
+                    EntityCreator::createEntityByArray(Host::class, $row, 'host_')
+                );
+                $services[] = $service;
+            }
+        } else {
+            throw new \Exception(_('Bad SQL request'));
+        }
+
+        return $services;
     }
 
     /**

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -718,8 +718,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         $request =
             'SELECT DISTINCT srv.*,
-              h.host_id AS `host_host_id`, h.name AS `host_name`, h.alias AS `host_alias`, h.instance_id AS `host_poller_id`,
-              srv.state AS `status_code`,
+              h.host_id AS `host_host_id`, h.name AS `host_name`, h.alias AS `host_alias`,
+              h.instance_id AS `host_poller_id`, srv.state AS `status_code`,
               CASE
                 WHEN srv.state = 0 THEN "' . ResourceStatus::STATUS_NAME_OK . '"
                 WHEN srv.state = 1 THEN "' . ResourceStatus::STATUS_NAME_WARNING . '"

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -577,11 +577,11 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         if (is_array($hostIds)) {
             $idsListKey = [];
-            foreach ($hostIds as $x => $id) {
-                $key = ":id{$x}";
+            foreach ($hostIds as $index => $id) {
+                $key = ":id{$index}";
                 $idsListKey[] = $key;
                 $collector->addValue($key, $id, \PDO::PARAM_INT);
-                unset($x, $id);
+                unset($index, $id);
             }
             $request .= ' WHERE h.host_id IN (' . implode(',', $idsListKey) . ')';
         }
@@ -744,14 +744,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
 
         if (is_array($serviceIds)) {
             $idsListKey = [];
-            foreach ($serviceIds as $x => $hostServiceIds) {
-                $hostKey = ":host_id{$x}";
+            foreach ($serviceIds as $index => $hostServiceIds) {
+                $hostKey = ":host_id{$index}";
                 $hostIdsListKey[] = $hostKey;
-                $serviceKey = ":service_id{$x}";
+                $serviceKey = ":service_id{$index}";
                 $serviceIdsListKey[] = $serviceKey;
                 $collector->addValue($serviceKey, $hostServiceIds['service_id'], \PDO::PARAM_INT);
                 $collector->addValue($hostKey, $hostServiceIds['host_id'], \PDO::PARAM_INT);
-                unset($x, $hostServiceIds);
+                unset($index, $hostServiceIds);
             }
             $request .= ' AND srv.service_id IN (' . implode(',', $serviceIdsListKey) . ')';
             $request .= ' AND srv.host_id IN (' . implode(',', $hostIdsListKey) . ')';

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -574,8 +574,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               END AS `status_severity_code`
             FROM `:dbstg`.services srv
             LEFT JOIN `:dbstg`.hosts h
-              ON h.host_id = srv.host_id'
-            . ' WHERE srv.enabled = \'1\'
+              ON h.host_id = srv.host_id
+              WHERE srv.enabled = \'1\'
               AND h.enabled = \'1\'';
 
 
@@ -601,7 +601,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
 
-        if ($statement->execute()) {
+        if ($statement->execute() !== false) {
             while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
                 $service = EntityCreator::createEntityByArray(
                     Service::class,
@@ -613,7 +613,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 $services[] = $service;
             }
         } else {
-            throw new \Exception(_('Bad SQL request'));
+            throw new \Exception(_('Failed to find services'));
         }
 
         return $services;
@@ -659,7 +659,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
 
-        if ($statement->execute()) {
+        if ($statement->execute() !== false) {
             while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
                 $host = EntityCreator::createEntityByArray(
                     Host::class,
@@ -668,7 +668,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 $hosts[] = $host;
             }
         } else {
-            throw new \Exception(_('Bad SQL request'));
+            throw new \Exception(_('Failed to find hosts'));
         }
 
         return $hosts;
@@ -724,7 +724,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
 
-        if ($statement->execute()) {
+        if ($statement->execute() !== false) {
             while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
                 $host = EntityCreator::createEntityByArray(
                     Host::class,
@@ -733,7 +733,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 $hosts[] = $host;
             }
         } else {
-            throw new \Exception(_('Bad SQL request'));
+            throw new \Exception(_('Failed to find hosts'));
         }
 
         return $hosts;
@@ -898,7 +898,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement = $this->db->prepare($request);
         $collector->bind($statement);
 
-        if ($statement->execute()) {
+        if ($statement->execute() !== false) {
             while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
                 $service = EntityCreator::createEntityByArray(
                     Service::class,
@@ -910,7 +910,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 $services[] = $service;
             }
         } else {
-            throw new \Exception(_('Bad SQL request'));
+            throw new \Exception(_('Failed to find services'));
         }
 
         return $services;

--- a/tests/api/Context/CommentContext.php
+++ b/tests/api/Context/CommentContext.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+namespace Centreon\Test\Api\Context;
+
+use Centreon\Test\Behat\Api\Context\ApiContext;
+
+class CommentContext extends ApiContext
+{
+}

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -35,7 +35,7 @@ default:
     comment:
       paths: [ "%paths.base%/features/Comment.feature" ]
       contexts:
-        - Centreon\Test\Api\Context\CommentContextt
+        - Centreon\Test\Api\Context\CommentContext
     acknowledgement:
       paths: [ "%paths.base%/features/Acknowledgement.feature" ]
       contexts:

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -32,6 +32,10 @@ default:
       paths: [ "%paths.base%/features/SubmitResult.feature" ]
       contexts:
         - Centreon\Test\Api\Context\SubmitResultContext
+    comment:
+      paths: [ "%paths.base%/features/Comment.feature" ]
+      contexts:
+        - Centreon\Test\Api\Context\CommentContextt
     acknowledgement:
       paths: [ "%paths.base%/features/Acknowledgement.feature" ]
       contexts:

--- a/tests/api/features/Comment.feature
+++ b/tests/api/features/Comment.feature
@@ -1,0 +1,51 @@
+Feature:
+  In order to identify issues on resources
+  As a user
+  I want to add a comment on those resources
+
+  Background:
+    Given a running instance of Centreon Web API
+    And the endpoints are described in Centreon Web API documentation
+
+  Scenario: Add comment to resources
+    Given I am logged in
+    And the following CLAPI import data:
+    """
+    HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
+    SERVICE;ADD;test;test_service_1;Ping-LAN;
+    """
+    And the configuration is generated and exported
+    And I wait until service "test_service_1" from host "test" is monitored
+    And I send a GET request to '/beta/monitoring/services?search={"$and":[{"host.name":"test"},{"service.description":"test_service_1"}]}'
+    And I store response values in:
+      | name      | path              |
+      | hostId    | result[0].host.id |
+      | serviceId | result[0].id      |
+
+    When I send a POST request to '/beta/monitoring/resources/comments' with body:
+    """
+    {
+      "resources": [
+        {
+          "type": "host",
+          "id": <hostId>,
+          "parent": null,
+          "comment": "This happened because wire has been unplugged",
+          "date": null
+        },
+        {
+          "type": "service",
+          "id": <serviceId>,
+          "parent": {
+            "id": <hostId>
+          },
+          "comment": "This happened because the ntpd service is stopped",
+          "date": null
+        }
+      ]
+    }
+    """
+
+    Then the response code should be 204
+    And the content of file "/var/log/centreon-engine/centengine.log" should match "/ADD_HOST_COMMENT;Test host"
+    And the content of file "/var/log/centreon-engine/centengine.log" should match "/ADD_SVC_COMMENT;test;test_service_1/" (tries: 3)

--- a/tests/api/features/Comment.feature
+++ b/tests/api/features/Comment.feature
@@ -47,5 +47,5 @@ Feature:
     """
 
     Then the response code should be 204
-    And the content of file "/var/log/centreon-engine/centengine.log" should match "/ADD_HOST_COMMENT;Test host"
+    And the content of file "/var/log/centreon-engine/centengine.log" should match "/ADD_HOST_COMMENT;test/"
     And the content of file "/var/log/centreon-engine/centengine.log" should match "/ADD_SVC_COMMENT;test;test_service_1/" (tries: 3)

--- a/tests/php/Centreon/Application/Controller/Monitoring/CommentControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/Monitoring/CommentControllerTest.php
@@ -1,0 +1,314 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+namespace Tests\Centreon\Application\Controller\Monitoring;
+
+use FOS\RestBundle\View\View;
+use PHPUnit\Framework\TestCase;
+use Centreon\Domain\Contact\Contact;
+use Psr\Container\ContainerInterface;
+use Centreon\Domain\Monitoring\Resource;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Centreon\Domain\Monitoring\Comment\CommentService;
+use Centreon\Application\Controller\Monitoring\CommentController;
+use Centreon\Test\Api\Context\CommentContext;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class CommentControllerTest extends TestCase
+{
+    protected $adminContact;
+    protected $hostResource;
+    protected $serviceResource;
+    protected $correctJsonComment;
+    protected $wrongJsonComment;
+    protected $hostCommentJson;
+    protected $serviceCommentJson;
+    protected $serviceResult;
+    protected $commentService;
+
+    protected $container;
+
+    protected $request;
+
+    protected function setUp()
+    {
+        $timezone = new \DateTimeZone('Europe/Paris');
+        $dateTime = new \DateTime('now');
+        $date = $dateTime->format('Y-m-d\TH:i:s.u');
+
+        $this->adminContact = (new Contact())
+            ->setId(1)
+            ->setName('admin')
+            ->setAdmin(true)
+            ->setTimezone($timezone);
+
+        $correctJsonComment = [
+            'resources' => [
+                [
+                    'type' => 'host',
+                    'id' => 1,
+                    'parent' => null,
+                    'comment' => 'simple comment on a host resource',
+                    'date' => null
+                ],
+                [
+                    'type' => 'service',
+                    'id' => 1,
+                    'parent' => [
+                        'id' => 1,
+                    ],
+                    'comment' => 'simple comment on a service resource',
+                    'date' => $date
+                ],
+            ],
+        ];
+
+        $hostCommentJson = [
+            'comment' => 'single comment on a service',
+            'date' => $date
+        ];
+
+        $serviceCommentJson = [
+            'comment' => 'single comment on a host',
+            'date' => $date
+        ];
+
+        $this->hostResource = (new Resource())
+            ->setType($correctJsonComment['resources'][0]['type'])
+            ->setId($correctJsonComment['resources'][0]['id']);
+        $this->serviceResource = (new Resource())
+            ->setType($correctJsonComment['resources'][1]['type'])
+            ->setId($correctJsonComment['resources'][1]['id'])
+            ->setParent($this->hostResource);
+
+        $this->correctJsonComment = json_encode($correctJsonComment);
+        $this->serviceCommentJson = json_encode($serviceCommentJson);
+        $this->hostCommentJson = json_encode($hostCommentJson);
+
+        $this->wrongJsonComment = json_encode([
+            'unknown_property' => 'unknown',
+        ]);
+
+        $this->commentService = $this->createMock(CommentService::class);
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->willReturn(true);
+        $token = $this->createMock(TokenInterface::class);
+        $token->expects($this->any())
+            ->method('getUser')
+            ->willReturn($this->adminContact);
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token);
+
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->container->expects($this->any())
+            ->method('has')
+            ->willReturn(true);
+        $this->container->expects($this->any())
+            ->method('get')
+            ->withConsecutive(
+                [$this->equalTo('security.authorization_checker')],
+                [$this->equalTo('security.token_storage')],
+                [$this->equalTo('parameter_bag')]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $authorizationChecker,
+                $tokenStorage,
+                new class () {
+                    public function get()
+                    {
+                        return __DIR__ . '/../../../../../';
+                    }
+                }
+            );
+
+        $this->request = $this->createMock(Request::class);
+    }
+
+    /**
+     * Testing wrongly formatted JSON POST data for addResourcesComment
+     */
+    public function testaddResourcesCommentBadJsonFormat()
+    {
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->once())
+            ->method('getContent')
+            ->willReturn('[}');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Error when decoding sent data');
+        $commentController->addResourcesComment($this->request);
+    }
+
+    /**
+     * Testing with wrong property added to the POST JSON for addResourcesComment
+     */
+    public function testCommentResourcesBadJsonProperties()
+    {
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->any())
+            ->method('getContent')
+            ->willReturn($this->wrongJsonComment);
+        $this->expectException(\InvalidArgumentException::class);
+        $commentController->addResourcesComment($this->request);
+    }
+
+    /**
+     * Testing with a correct JSON POST data and successful add a comment to a resource
+     */
+    public function testAddResourcesCommentSuccess()
+    {
+        $this->commentService->expects($this->any())
+            ->method('filterByContact')
+            ->willReturn($this->commentService);
+
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->any())
+            ->method('getContent')
+            ->willReturn($this->correctJsonComment);
+        $view = $commentController->addResourcesComment($this->request);
+
+        $this->assertEquals($view, View::create(null, Response::HTTP_NO_CONTENT));
+    }
+
+    /**
+     * Tesring with wrongly formatted JSON POST data for addHostComment
+     */
+    public function testAddHostCommentBadJsonFormat()
+    {
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->once())
+            ->method('getContent')
+            ->willReturn('[}');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Error when decoding sent data');
+        $commentController->addHostComment($this->request, $this->hostResource->getId());
+    }
+    /**
+     * Testing with wrong property added to the POST JSON for addHostComment
+     */
+    public function testAddHostCommentBadJsonProperties()
+    {
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->any())
+            ->method('getContent')
+            ->willReturn($this->wrongJsonComment);
+        $this->expectException(\InvalidArgumentException::class);
+        $commentController->addHostComment($this->request, $this->hostResource->getId());
+    }
+    /**
+     * Testing with a correct JSON POST data and successful add a comment for a host resource
+     */
+    public function testAddHostCommentSuccess()
+    {
+        $this->commentService->expects($this->any())
+        ->method('filterByContact')
+        ->willReturn($this->commentService);
+
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->any())
+            ->method('getContent')
+            ->willReturn($this->hostCommentJson);
+        $view = $commentController->addHostComment($this->request, $this->hostResource->getId());
+
+        $this->assertEquals($view, View::create(null, Response::HTTP_NO_CONTENT));
+    }
+
+    /**
+     * Tesring with wrongly formatted JSON POST data for addServiceComment
+     */
+    public function testAddServiceCommentBadJsonFormat()
+    {
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->once())
+            ->method('getContent')
+            ->willReturn('[}');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Error when decoding sent data');
+        $commentController->addServiceComment(
+            $this->request,
+            $this->serviceResource->getParent()->getId(),
+            $this->serviceResource->getId()
+        );
+    }
+    /**
+     * Testing with wrong property added to the POST JSON for addServiceComment
+     */
+    public function testAddServiceCommentBadJsonProperties()
+    {
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->any())
+            ->method('getContent')
+            ->willReturn($this->wrongJsonComment);
+        $this->expectException(\InvalidArgumentException::class);
+        $commentController->addServiceComment(
+            $this->request,
+            $this->serviceResource->getParent()->getId(),
+            $this->serviceResource->getId()
+        );
+    }
+    /**
+     * Testing with a correct JSON POST data and successful add comment for a service resource
+     */
+    public function testAddServiceCommentSuccess()
+    {
+        $this->commentService->expects($this->any())
+        ->method('filterByContact')
+        ->willReturn($this->commentService);
+
+        $commentController = new CommentController($this->commentService);
+        $commentController->setContainer($this->container);
+
+        $this->request->expects($this->any())
+            ->method('getContent')
+            ->willReturn($this->serviceCommentJson);
+
+        $view = $commentController->addServiceComment(
+            $this->request,
+            $this->serviceResource->getParent()->getId(),
+            $this->serviceResource->getId()
+        );
+
+        $this->assertEquals($view, View::create(null, Response::HTTP_NO_CONTENT));
+    }
+}

--- a/tests/php/Centreon/Application/Controller/Monitoring/CommentControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/Monitoring/CommentControllerTest.php
@@ -185,7 +185,7 @@ class CommentControllerTest extends TestCase
     }
 
     /**
-     * Testing with a correct JSON POST data and successful add a comment to a resource
+     * Testing with a correct JSON POST data and successfully adding a comment to a resource
      */
     public function testAddResourcesCommentSuccess()
     {
@@ -205,7 +205,7 @@ class CommentControllerTest extends TestCase
     }
 
     /**
-     * Tesring with wrongly formatted JSON POST data for addHostComment
+     * Testing with wrongly formatted JSON POST data for addHostComment
      */
     public function testAddHostCommentBadJsonFormat()
     {
@@ -234,7 +234,7 @@ class CommentControllerTest extends TestCase
         $commentController->addHostComment($this->request, $this->hostResource->getId());
     }
     /**
-     * Testing with a correct JSON POST data and successful add a comment for a host resource
+     * Testing with a correct JSON POST data and successfully adding a comment for a host resource
      */
     public function testAddHostCommentSuccess()
     {
@@ -259,7 +259,7 @@ class CommentControllerTest extends TestCase
     }
 
     /**
-     * Tesring with wrongly formatted JSON POST data for addServiceComment
+     * Testing with wrongly formatted JSON POST data for addServiceComment
      */
     public function testAddServiceCommentBadJsonFormat()
     {
@@ -296,7 +296,7 @@ class CommentControllerTest extends TestCase
         );
     }
     /**
-     * Testing with a correct JSON POST data and successful add comment for a service resource
+     * Testing with a correct JSON POST data and successfully adding comment for a service resource
      */
     public function testAddServiceCommentSuccess()
     {

--- a/tests/php/Centreon/Domain/Engine/EngineServiceTest.php
+++ b/tests/php/Centreon/Domain/Engine/EngineServiceTest.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Monitoring\Host;
 use Centreon\Domain\Monitoring\Service;
 use Centreon\Domain\Engine\EngineService;
 use Centreon\Domain\Entity\EntityValidator;
+use Centreon\Domain\Monitoring\Comment\Comment;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Centreon\Domain\Monitoring\SubmitResult\SubmitResult;
 use Centreon\Domain\Engine\Interfaces\EngineServiceInterface;
@@ -47,13 +48,16 @@ class EngineServiceTest extends TestCase
     protected $commandHeaderRegex;
     protected $monitoringRepository;
     protected $engineConfigurationService;
+    protected $hostComment;
+    protected $serviceComment;
 
     protected function setUp()
     {
         $this->adminContact = (new Contact())
             ->setId(1)
             ->setName('admin')
-            ->setAdmin(true);
+            ->setAdmin(true)
+            ->setAlias('adminAlias');
 
         $this->host = (new Host())
             ->setId(1)
@@ -73,6 +77,12 @@ class EngineServiceTest extends TestCase
             ->setParentResourceId($this->service->getHost()->getId())
             ->setOutput('Service went critical')
             ->setPerformanceData('ping: 0');
+
+        $this->hostComment = (new Comment($this->host->getID(), 'Simple host comment'))
+            ->setDate(new \DateTime('now'));
+
+        $this->serviceComment = (new Comment($this->service->getID(), 'Simple service comment'))
+            ->setDate(new \DateTime('now'));
         /**
          * commandHeader should look like 'EXTERNALCMD:<pollerid>:[timestamp] '
          */
@@ -85,6 +95,85 @@ class EngineServiceTest extends TestCase
         $this->entityValidator = $this->createMock(EntityValidator::class);
         $this->monitoringRepository = $this->createMock(MonitoringRepositoryInterface::class);
     }
+
+    /**
+     * Testing the addHostComment EngineService function in a nominal case.
+     */
+    public function testAddHostComment()
+    {
+        $this->entityValidator->expects($this->once())
+            ->method('validate')
+            ->willReturn(new ConstraintViolationList());
+
+        /**
+         * Creating the command to check that the code
+         * will send the same to the sendExternalCommand
+         * repository function
+         */
+        $command = sprintf(
+            'ADD_HOST_COMMENT;%s;1;%s;%s',
+            $this->host->getName(),
+            $this->adminContact->getAlias(),
+            $this->hostComment->getComment()
+        );
+
+        $this->engineRepository->expects($this->once())
+            ->method('sendExternalCommand')
+            ->with(
+                $this->matchesRegularExpression(
+                    '/^' . $this->commandHeaderRegex . str_replace('|', '\|', $command) . '$/'
+                )
+            );
+
+        $engineService = new EngineService(
+            $this->engineRepository,
+            $this->engineConfigurationService,
+            $this->entityValidator
+        );
+
+        $engineService->filterByContact($this->adminContact);
+        $this->assertNull($engineService->addHostComment($this->hostComment, $this->host));
+    }
+
+    /**
+    * Testing the addServiceComment EngineService function in a nominal case.
+    */
+   public function testServiceComment()
+   {
+       $this->entityValidator->expects($this->once())
+           ->method('validate')
+           ->willReturn(new ConstraintViolationList());
+
+       /**
+        * Creating the command to check that the code
+        * will send the same to the sendExternalCommand
+        * repository function
+        */
+       $command = sprintf(
+            'ADD_SVC_COMMENT;%s;%s;1;%s;%s',
+            $this->host->getName(),
+            $this->service->getDescription(),
+            $this->adminContact->getAlias(),
+            $this->serviceComment->getComment()
+       );
+
+       $this->engineRepository->expects($this->once())
+           ->method('sendExternalCommand')
+           ->with(
+               $this->matchesRegularExpression(
+                   '/^' . $this->commandHeaderRegex . str_replace('|', '\|', $command) . '$/'
+               )
+           );
+
+       $engineService = new EngineService(
+           $this->engineRepository,
+           $this->engineConfigurationService,
+           $this->entityValidator
+       );
+
+       $engineService->filterByContact($this->adminContact);
+       $this->assertNull($engineService->addServiceComment($this->serviceComment, $this->service));
+   }
 
     /**
      * Testing the submitHostResult EngineService function in a nominal case.

--- a/tests/php/Centreon/Domain/Engine/EngineServiceTest.php
+++ b/tests/php/Centreon/Domain/Engine/EngineServiceTest.php
@@ -138,26 +138,26 @@ class EngineServiceTest extends TestCase
     /**
     * Testing the addServiceComment EngineService function in a nominal case.
     */
-   public function testServiceComment()
-   {
-       $this->entityValidator->expects($this->once())
+    public function testServiceComment()
+    {
+        $this->entityValidator->expects($this->once())
            ->method('validate')
            ->willReturn(new ConstraintViolationList());
 
-       /**
-        * Creating the command to check that the code
-        * will send the same to the sendExternalCommand
-        * repository function
-        */
-       $command = sprintf(
+        /**
+         * Creating the command to check that the code
+         * will send the same to the sendExternalCommand
+         * repository function
+         */
+        $command = sprintf(
             'ADD_SVC_COMMENT;%s;%s;1;%s;%s',
             $this->host->getName(),
             $this->service->getDescription(),
             $this->adminContact->getAlias(),
             $this->serviceComment->getComment()
-       );
+        );
 
-       $this->engineRepository->expects($this->once())
+        $this->engineRepository->expects($this->once())
            ->method('sendExternalCommand')
            ->with(
                $this->matchesRegularExpression(
@@ -165,15 +165,15 @@ class EngineServiceTest extends TestCase
                )
            );
 
-       $engineService = new EngineService(
-           $this->engineRepository,
-           $this->engineConfigurationService,
-           $this->entityValidator
-       );
+        $engineService = new EngineService(
+            $this->engineRepository,
+            $this->engineConfigurationService,
+            $this->entityValidator
+        );
 
-       $engineService->filterByContact($this->adminContact);
-       $this->assertNull($engineService->addServiceComment($this->serviceComment, $this->service));
-   }
+        $engineService->filterByContact($this->adminContact);
+        $this->assertNull($engineService->addServiceComment($this->serviceComment, $this->service));
+    }
 
     /**
      * Testing the submitHostResult EngineService function in a nominal case.


### PR DESCRIPTION
## Description

This PR intends to add 3 new endpoints related to comments.
- POST `/monitoring/resources/comments`
- POST `/monitoring/hosts/{host_id}/comments`
- POST `/monitoring/hosts/{host_id}/services/{service_id}/comments`

Example of call that can be made on several resources

![comment](https://user-images.githubusercontent.com/31647811/100251925-9b4ea600-2f3f-11eb-9b42-22d89a573c04.png)


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

This will be tested thanks to the ability to add a comment through the graphs

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
