### PR TITLE
fix(apache): update AllowOverride Rule to properly display icon

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1280,7 +1280,7 @@ Alias /centreon $INSTALL_DIR_CENTREON/www/
 
 <Directory "$INSTALL_DIR_CENTREON/www">
     Options Indexes
-    AllowOverride AuthConfig Options
+    AllowOverride All
     Order allow,deny
     Allow from all
     Require all granted
@@ -1298,7 +1298,7 @@ Alias /centreon $INSTALL_DIR_CENTREON/www/
 
 <Directory "$INSTALL_DIR_CENTREON/www">
     Options Indexes
-    AllowOverride AuthConfig Options
+    AllowOverride All
     Order allow,deny
     Allow from all
 </Directory>


### PR DESCRIPTION
## Description
Fix an issue where icon where broken on 2.8.x due to .htaccess.
Update libinstall functions to properly write the apache conf. 

**Fixes** # MON-5920

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
