### PR TITLE
fix(clapi): Fix incorrect error messages for contact group and contact template

### DIFF
--- a/www/class/centreon-clapi/centreonLDAP.class.php
+++ b/www/class/centreon-clapi/centreonLDAP.class.php
@@ -344,10 +344,13 @@ class CentreonLDAP extends CentreonObject
             );
         } elseif (isset($this->baseParams[strtolower($params[1])])) {
             if (strtolower($params[1]) == 'ldap_contact_tmpl') {
+                if (empty($params[2])) {
+                    throw new CentreonClapiException(self::MISSINGPARAMETER);
+                }
                 $contactObj = new CentreonContact($this->dependencyInjector);
                 $params[2] = $contactObj->getContactID($params[2]);
             }
-            if (strtolower($params[1]) === 'ldap_default_cg') {
+            if (strtolower($params[1]) === 'ldap_default_cg' && !empty($params[2])) {
                 $contactGroupObj = new CentreonContactGroup($this->dependencyInjector);
                 $params[2] = $contactGroupObj->getContactGroupID($params[2]);
             }


### PR DESCRIPTION
## Description

This PR fix an issue where an invalid message was thrown when contact group or contact template were empty 

**Fixes** # MON-4451

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

**Contact Template:**

`[root@central2104 ~]# /usr/share/centreon/bin/centreon -u admin -p centreon -o LDAP -a SETPARAM -v "<LDAPCONFNAME>;ldap_contact_tmpl;;"
Missing parameters
`


**Contact Group (CG is unlinked and no message thrown):**

`[root@central2104 ~]# /usr/share/centreon/bin/centreon -u admin -p centreon -o LDAP -a SETPARAM -v "<LDAPCONFNAME>;ldap_default_cg;;"
`

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
