### PR TITLE
enh(api) remove pagination object in meta data of monitoring server API

### DIFF
--- a/src/Centreon/Application/Controller/Configuration/MonitoringServerController.php
+++ b/src/Centreon/Application/Controller/Configuration/MonitoringServerController.php
@@ -28,6 +28,7 @@ use FOS\RestBundle\Context\Context;
 use Centreon\Application\Controller\AbstractController;
 use FOS\RestBundle\View\View;
 use Centreon\Domain\MonitoringServer\MonitoringServer;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * This class is designed to manage all requests concerning pollers
@@ -54,23 +55,26 @@ class MonitoringServerController extends AbstractController
      * Entry point to find the last hosts acknowledgements.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findServer(RequestParametersInterface $requestParameters): View
+    public function findServer(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiConfiguration();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         $server = $this->monitoringServerService->findServers();
         $context = (new Context())->setGroups([
             MonitoringServer::SERIALIZER_GROUP_MAIN,
         ]);
 
-        return $this->view([
-            'result' => $server,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $server,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 }


### PR DESCRIPTION
## Description

Remove pagination object in meta data of monitoring server API response

    "meta": {
        "page": 1,
        "limit": 10,
        "search": {},
        "sort_by": {},
        "total": 2
    }

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

GET on centreon/api/beta/configuration/monitoring-servers

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
