### PR TITLE
enh(timeline): add filter on date

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
@@ -124,7 +124,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         $this->sqlRequestTranslator->setConcordanceArray([
             'type' => 'log.type',
             'content' => 'log.content',
-            'date' => 'log.date'
+            'date' => 'log.date',
         ]);
 
         $collector = new StatementCollector();

--- a/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
@@ -173,6 +173,12 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
 
         $request .= ') AS `log` ';
 
+        /**
+         * Here the search filter provides a date in ISO8601.
+         * But the date on which we do filter (stored as ctime) is a timestamp.
+         * Therefore we need to normalize the data provided in the search parameter
+         * and translate it into a timestamp filtering search.
+         */
         $this->sqlRequestTranslator->addNormalizer(
             'date',
             new class implements NormalizerInterface


### PR DESCRIPTION
This PR intends to add the possibility to filter events through the timeline endpoint on a specific time period. This is now possible thanks to the recent implementation of the data normalizers for the search parameters.

The events would be filtered by the date that should be included in a timeperiod.

Here is an example of a call to the endpoint that can be done.
Calling the endpoint timeline:` ../monitoring/hosts/<hostId>/services/<serviceId>/timeline?search=...` (_see the search below for more readability_)

```
{
    "$and": [
        {
            "type": {
                "$in": [
                    "event",
                    "notification",
                    "comment",
                    "acknowledgement",
                    "downtime"
                ]
            },
            "$and": [
                    {"date": {"$gt": "2020-12-01T07:00:00"}},
                    {"date": {"$lt": "2020-12-01T11:00:00"}}
            ]
        }
    ]
}
```

**Notes** The pagination will be returned and will be handled by the front-end

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Simply call the endpoint on a service/host that you know had recent events (downtimes, comments, acknowledgements) and filter on a specific timeperiod. Check that the events returned are in this period and not the other ones

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
