### PR TITLE
enh(api): add groups property to resources details endpoints

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -161,3 +161,7 @@ Centreon\Domain\Monitoring\Resource:
             type: Centreon\Domain\Acknowledgement\Acknowledgement
             groups:
                 - 'resource_details'
+        groups:
+            type: array<Centreon\Domain\Monitoring\ResourceGroup>
+            groups:
+                - 'resource_details'

--- a/config/packages/serializer/Centreon/Monitoring.ResourceGroup.yml
+++ b/config/packages/serializer/Centreon/Monitoring.ResourceGroup.yml
@@ -1,0 +1,10 @@
+Centreon\Domain\Monitoring\ResourceGroup:
+    properties:
+        id:
+            type: integer
+            groups:
+                - 'Default'
+        name:
+            type: string
+            groups:
+                - 'Default'

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -4004,6 +4004,10 @@ components:
               example: "127.0.0.1"
             links:
               $ref: '#/components/schemas/Monitoring.ResourceLinks'
+            groups:
+              type: array
+              items:
+                $ref: '#/components/schemas/Monitoring.ResourceGroup'
             status:
               type: object
               properties:
@@ -4175,6 +4179,17 @@ components:
                 nullable: true
                 description: "URL that can be used to provide more information on the resource"
                 example: "http://mediawiki/resource/name"
+    Monitoring.ResourceGroup:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: "ID of the group to which belongs the resource"
+          example: 1
+        name:
+          type: string
+          description: "Name of the group to which belongs the resource"
+          example: "ESX-France|Cpus"
     Monitoring.ResourceStatus:
       type: object
       properties:

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15911,4 +15911,4 @@ msgid "Parent of service resource type cannot be null"
 msgstr "Le parent de la resource de type service ne peut être null"
 
 msgid "One of the elements provided is not a ResourceGroup type"
-msgstr Un des éléments fourni n'est pas de type ResourceGroup"
+msgstr "Un des éléments fourni n'est pas de type ResourceGroup"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15906,3 +15906,9 @@ msgstr "[%s] La valeur est vide, mais une valeur non vide était attendue"
 
 msgid "[%s] The value is null, but non null value was expected"
 msgstr "[%] La valeur est nulle, mais une valeur non nulle était attendue"
+
+msgid "Parent of service resource type cannot be null"
+msgstr "Le parent de la resource de type service ne peut être null"
+
+msgid "One of the elements provided is not a ResourceGroup type"
+msgstr Un des éléments fourni n'est pas de type ResourceGroup"

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -125,6 +125,7 @@ interface ResourceServiceInterface
      * Enrich resource object with specific service data
      *
      * @param ResourceEntity $resource
+     * @throws \ResourceException
      */
     public function enrichServiceWithDetails(ResourceEntity $resource): void;
 

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -24,6 +24,7 @@ namespace Centreon\Domain\Monitoring\Interfaces;
 
 use Centreon\Domain\Monitoring\ResourceFilter;
 use Centreon\Domain\Monitoring\Resource as ResourceEntity;
+use Centreon\Domain\Monitoring\Exception\ResourceException;
 
 interface ResourceServiceInterface
 {
@@ -125,7 +126,7 @@ interface ResourceServiceInterface
      * Enrich resource object with specific service data
      *
      * @param ResourceEntity $resource
-     * @throws \ResourceException
+     * @throws ResourceException
      */
     public function enrichServiceWithDetails(ResourceEntity $resource): void;
 

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -22,14 +22,15 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Monitoring;
 
-use Centreon\Domain\Monitoring\Icon;
-use Centreon\Domain\Monitoring\ResourceStatus;
-use Centreon\Domain\Monitoring\ResourceSeverity;
-use Centreon\Domain\Monitoring\ResourceLinks;
-use Centreon\Domain\Downtime\Downtime;
-use Centreon\Domain\Acknowledgement\Acknowledgement;
 use DateTime;
 use CentreonDuration;
+use Centreon\Domain\Monitoring\Icon;
+use Centreon\Domain\Downtime\Downtime;
+use Centreon\Domain\Monitoring\ResourceGroup;
+use Centreon\Domain\Monitoring\ResourceLinks;
+use Centreon\Domain\Monitoring\ResourceStatus;
+use Centreon\Domain\Monitoring\ResourceSeverity;
+use Centreon\Domain\Acknowledgement\Acknowledgement;
 
 /**
  * Class representing a record of a resource in the repository.
@@ -219,6 +220,13 @@ class Resource
      * @var Acknowledgement|null
      */
     private $acknowledgement;
+
+    /**
+     * Groups to which belongs the resource
+     *
+     * @var ResourceGroup[]
+     */
+    private $groups = [];
 
     /**
      * Resource constructor.
@@ -902,6 +910,30 @@ class Resource
     public function setAcknowledgement(?Acknowledgement $acknowledgement): self
     {
         $this->acknowledgement = $acknowledgement;
+        return $this;
+    }
+
+
+    /**
+     * Get groups to which belongs the resource.
+     *
+     * @return ResourceGroup[]
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+
+    /**
+     * Set groups to which belongs the resource
+     *
+     * @param ResourceGroup[] $groups
+     * @return Resource
+     */
+    public function setGroups(array $groups): self
+    {
+        $this->groups = $groups;
+
         return $this;
     }
 }

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -913,6 +913,11 @@ class Resource
      */
     public function setGroups(array $groups): self
     {
+        foreach ($groups as $group) {
+            if (!($group instanceof ResourceGroup)) {
+                throw new \InvalidArgumentException(_('One of the elements provided is not a ResourceGroup type'));
+            }
+        }
         $this->groups = $groups;
 
         return $this;

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -909,6 +909,7 @@ class Resource
      * Set groups to which belongs the resource
      *
      * @param ResourceGroup[] $groups
+     * @throws \InvalidArgumentException
      * @return self
      */
     public function setGroups(array $groups): self

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -657,25 +657,6 @@ class Resource
     /**
      * @return string|null
      */
-    public function getActionUrl(): ?string
-    {
-        return $this->actionUrl;
-    }
-
-    /**
-     * @param string|null $actionUrl
-     * @return \Centreon\Domain\Monitoring\Resource
-     */
-    public function setActionUrl(?string $actionUrl): self
-    {
-        $this->actionUrl = $actionUrl ?: null;
-
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
     public function getChartUrl(): ?string
     {
         return $this->chartUrl;
@@ -928,7 +909,7 @@ class Resource
      * Set groups to which belongs the resource
      *
      * @param ResourceGroup[] $groups
-     * @return Resource
+     * @return self
      */
     public function setGroups(array $groups): self
     {

--- a/src/Centreon/Domain/Monitoring/ResourceGroup.php
+++ b/src/Centreon/Domain/Monitoring/ResourceGroup.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring;
+
+/**
+ * Resource group model for resource repository
+ *
+ * @package Centreon\Domain\Monitoring
+ */
+class ResourceGroup
+{
+    /**
+     * Id of the resource group
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * Name of the resource group
+     *
+     * @var string
+     */
+    private $name;
+
+
+    /**
+     * Get resource group id.
+     *
+     * @return integer
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * ResourceGroup constructor
+     */
+    public function __construct(int $resourceGroupId, string $resourceGroupName)
+    {
+        $this->id = $resourceGroupId;
+        $this->name = $resourceGroupName;
+    }
+
+    /**
+     * Get the resource group name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the resource group id.
+     *
+     * @param integer $resourceGroupId
+     * @return ResourceGroup
+     */
+    public function setId(int $resourceGroupId): self
+    {
+        $this->id = $resourceGroupId;
+
+        return $this;
+    }
+
+    /**
+     * Set the resource group name.
+     *
+     * @param string $resourceGroupName
+     * @return ResourceGroup
+     */
+    public function setName(string $resourceGroupName): self
+    {
+        $this->name = $resourceGroupName;
+
+        return $this;
+    }
+}

--- a/src/Centreon/Domain/Monitoring/ResourceGroup.php
+++ b/src/Centreon/Domain/Monitoring/ResourceGroup.php
@@ -30,6 +30,18 @@ namespace Centreon\Domain\Monitoring;
 class ResourceGroup
 {
     /**
+     * Contructor for ResourceGroup entity
+     *
+     * @param integer $resourceGroupId
+     * @param string $resourceGroupName
+     */
+    public function __construct(int $resourceGroupId, string $resourceGroupName)
+    {
+        $this->id = $resourceGroupId;
+        $this->name = $resourceGroupName;
+    }
+
+    /**
      * Id of the resource group
      *
      * @var int
@@ -52,15 +64,6 @@ class ResourceGroup
     public function getId(): int
     {
         return $this->id;
-    }
-
-    /**
-     * ResourceGroup constructor
-     */
-    public function __construct(int $resourceGroupId, string $resourceGroupName)
-    {
-        $this->id = $resourceGroupId;
-        $this->name = $resourceGroupName;
     }
 
     /**

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -73,9 +73,7 @@ class ResourceService extends AbstractCentreonService implements ResourceService
     }
 
     /**
-     * {@inheritDoc}
-     * @param Contact $contact
-     * @return self
+     * @inheritDoc
      */
     public function filterByContact($contact): self
     {
@@ -224,8 +222,8 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      * Validates input for resource based on groups
      * @param EntityValidator $validator
      * @param ResourceEntity $resource
-     * @param array $contextGroups
-     * @return ConstraintViolationListInterface
+     * @param array<string, mixed> $contextGroups
+     * @return ConstraintViolationListInterface<mixed>
      */
     public static function validateResource(
         EntityValidator $validator,

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -167,6 +167,10 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      */
     public function enrichServiceWithDetails(ResourceEntity $resource): void
     {
+        if ($resource->getParent() === null) {
+            throw new ResourceException(_('Parent of resource type service cannot be null'));
+        }
+
         $downtimes = $this->monitoringRepository->findDowntimes(
             $resource->getParent()->getId(),
             $resource->getId()


### PR DESCRIPTION
This PR aims to add a new property to the endpoint resource detail.

The groups property relates to
- Hostgroups for the host resources
- Servicegroups for the service resources

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add a host to one or several hostgroups
- Add a service to one or several servicegroups

- Check that when calling endpoints` /monitoring/resources/hosts/<hostId>` and `/monitoring/resources/hosts/<hostId>/services/<serviceId>` you get the groups property.


## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
