### PR TITLE
fix(forms): Fixed the macros on service, service template, host and host template forms

### DIFF
--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2334,7 +2334,7 @@ function getSelectOption()
         if (strpos($value, ',') !== false) {
             return explode(',', $value);
         }
-        return [];
+        return [$value];
     };
     if (isset($_GET["select"])) {
         return is_array($_GET["select"])

--- a/www/include/common/templates/cloneMacro.ihtml
+++ b/www/include/common/templates/cloneMacro.ihtml
@@ -27,6 +27,7 @@
                 </span>
             {/foreach}
             <input type='hidden' id='macroTplValue_#index#' name='macroTplValue_#index#' value="" />
+            <input type='hidden' id='macroOriginalName_#index#' name='macroOriginalName_#index#' value="" />
             <input type='hidden' id='macroTplValToDisplay_#index#' name='macroTplValToDisplay_#index#' value="0" />
             <input type='hidden' id='macroDescription_#index#' name='macroDescription_#index#' value="" />
             <input type='hidden' id='macroTpl_#index#' name='macroTpl_#index#' value="" />

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -503,13 +503,13 @@ jQuery(function() {
      * and recover its previous value when it lost focus if no new value has been defined.
      */
     jQuery('ul#macro').find('input[id^=\'macroValue_\']').on('click', function () {
-        if ($(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
+        if (jQuery(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
             // It's a password input
-            const actualValue = $(this).val();
-            $(this).val('');
-            $(this).one('focusout', function() {
-                if ($(this).val().length === 0) {
-                    $(this).val(actualValue);
+            const actualValue = jQuery(this).val();
+			jQuery(this).val('');
+			jQuery(this).one('focusout', function() {
+                if (jQuery(this).val().length === 0) {
+					jQuery(this).val(actualValue);
                 }
             });
         }

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -506,10 +506,10 @@ jQuery(function() {
         if (jQuery(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
             // It's a password input
             const actualValue = jQuery(this).val();
-			jQuery(this).val('');
-			jQuery(this).one('focusout', function() {
+            jQuery(this).val('');
+            jQuery(this).one('focusout', function() {
                 if (jQuery(this).val().length === 0) {
-					jQuery(this).val(actualValue);
+                    jQuery(this).val(actualValue);
                 }
             });
         }

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -85,6 +85,9 @@ $host = array();
 // define macros as empty array to avoid null counting
 $aMacros = array();
 
+// Used to store all macro passwords
+$macroPasswords = [];
+
 if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     $statement = $pearDB->prepare(
         'SELECT * FROM host
@@ -204,9 +207,13 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
     foreach ($aMacros as $index => $macroValues) {
         if ($macroValues['macroPassword_#index#'] === 1) {
+            $macroPasswords[$index]['old_password'] = $aMacros[$index]['macroOldValue_#index#'];
+            $macroPasswords[$index]['password'] = $aMacros[$index]['macroValue_#index#'];
             // It's a password macro
             $aMacros[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
             $aMacros[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $aMacros[$index]['macroOriginalName_#index#'] = $aMacros[$index]['macroInput_#index#'];
         }
     }
 }
@@ -1181,6 +1188,27 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($aMacros as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateHostInDB($hostObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
         foreach ($select as $hostIdToUpdate) {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -207,7 +207,6 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
     foreach ($aMacros as $index => $macroValues) {
         if ($macroValues['macroPassword_#index#'] === 1) {
-            $macroPasswords[$index]['old_password'] = $aMacros[$index]['macroOldValue_#index#'];
             $macroPasswords[$index]['password'] = $aMacros[$index]['macroValue_#index#'];
             // It's a password macro
             $aMacros[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;

--- a/www/include/configuration/configObject/host/host.php
+++ b/www/include/configuration/configObject/host/host.php
@@ -39,7 +39,7 @@ if (!isset($centreon)) {
 }
 
 $host_id = filter_var(
-    $_GET['host_id'] ?? $_POST['host_id'] ?? 0,
+    $_GET['host_id'] ?? $_POST['host_id'] ?? null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -47,6 +47,10 @@ $hTpls = isset($hTpls) ? $hTpls : [];
 #
 $host = array();
 $macroArray = array();
+
+// Used to store all macro passwords
+$macroPasswords = [];
+
 if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_id)) {
     if (isset($lockedElements[$host_id])) {
         $o = HOST_TEMPLATE_WATCH;
@@ -146,9 +150,12 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_i
     // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
     foreach ($macroArray as $index => $macroValues) {
         if ($macroValues['macroPassword_#index#'] === 1) {
+            $macroPasswords[$index]['password'] = $macroArray[$index]['macroValue_#index#'];
             // It's a password macro
             $macroArray[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
             $macroArray[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $macroArray[$index]['macroOriginalName_#index#'] = $macroArray[$index]['macroInput_#index#'];
         }
     }
 }
@@ -857,12 +864,8 @@ $assoc->setValue("0");
 $redirect = $form->addElement('hidden', 'o');
 $redirect->setValue($o);
 if (is_array($select)) {
-    $select_str = null;
-    foreach ($select as $key => $value) {
-        $select_str .= $key . ",";
-    }
     $select_pear = $form->addElement('hidden', 'select');
-    $select_pear->setValue($select_str);
+    $select_pear->setValue(implode(',', array_keys($select)));
 }
 
 #
@@ -971,9 +974,29 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($macroArray as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateHostInDB($hostObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        $select = explode(",", $select);
         foreach ($select as $key => $value) {
             if ($value) {
                 updateHostInDB($value, true);

--- a/www/include/configuration/configObject/host_template_model/hostTemplateModel.php
+++ b/www/include/configuration/configObject/host_template_model/hostTemplateModel.php
@@ -38,7 +38,7 @@ if (!isset($centreon)) {
     exit();
 }
 $host_id = filter_var(
-    $_GET['host_id'] ?? $_POST['host_id'] ?? 0,
+    $_GET['host_id'] ?? $_POST['host_id'] ?? null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/configuration/configObject/service/serviceByHost.php
+++ b/www/include/configuration/configObject/service/serviceByHost.php
@@ -42,7 +42,7 @@ global $form_service_type;
 $form_service_type = "BYHOST";
 
 $service_id = filter_var(
-    $_GET['service_id'] ?? $_POST['service_id'] ?? 0,
+    $_GET['service_id'] ?? $_POST['service_id'] ?? null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/configuration/configObject/service/serviceByHostGroup.php
+++ b/www/include/configuration/configObject/service/serviceByHostGroup.php
@@ -42,7 +42,7 @@ global $form_service_type;
 $form_service_type = "BYHOSTGROUP";
 
 $service_id = filter_var(
-    $_GET['service_id'] ?? $_POST['service_id'] ?? 0,
+    $_GET['service_id'] ?? $_POST['service_id'] ?? null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -56,6 +56,10 @@ $cmdId = 0;
 $serviceTplId = null;
 $service = array();
 $serviceObj = new CentreonService($pearDB);
+
+// Used to store all macro passwords
+$macroPasswords = [];
+
 if (($o == SERVICE_TEMPLATE_MODIFY || $o == SERVICE_TEMPLATE_WATCH) && isset($service_id)) {
     if (isset($lockedElements[$service_id])) {
         $o = SERVICE_TEMPLATE_WATCH;
@@ -156,9 +160,12 @@ if (($o == SERVICE_TEMPLATE_MODIFY || $o == SERVICE_TEMPLATE_WATCH) && isset($se
     // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
     foreach ($aMacros as $index => $macroValues) {
         if ($macroValues['macroPassword_#index#'] === 1) {
+            $macroPasswords[$index]['password'] = $aMacros[$index]['macroValue_#index#'];
             // It's a password macro
             $aMacros[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
             $aMacros[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $aMacros[$index]['macroOriginalName_#index#'] = $aMacros[$index]['macroInput_#index#'];
         }
     }
 }
@@ -910,12 +917,8 @@ $service_register = 0;
 $redirect = $form->addElement('hidden', 'o');
 $redirect->setValue($o);
 if (is_array($select)) {
-    $select_str = null;
-    foreach ($select as $key => $value) {
-        $select_str .= $key . ",";
-    }
     $select_pear = $form->addElement('hidden', 'select');
-    $select_pear->setValue($select_str);
+    $select_pear->setValue(implode(',', array_keys($select)));
 }
 
 $form->applyFilter('__ALL__', 'myTrim');
@@ -1015,10 +1018,30 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $serviceObj->setValue(insertServiceInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($aMacros as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateServiceInDB($serviceObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        $select = explode(",", $select);
-        foreach ($select as $key => $value) {
+        foreach ($select as $value) {
             if ($value) {
                 updateServiceInDB($value, true);
             }

--- a/www/include/configuration/configObject/service_template_model/serviceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/serviceTemplateModel.php
@@ -39,7 +39,7 @@ if (!isset($centreon)) {
 }
 
 $service_id = filter_var(
-    $_GET['service_id'] ?? $_POST['service_id'] ?? 0,
+    $_GET['service_id'] ?? $_POST['service_id'] ?? null,
     FILTER_VALIDATE_INT
 );
 


### PR DESCRIPTION
## Description

Fixed the password of macros on service, service template, host, and host template forms when changing the name of password type macros.

**Fixes** MON-5851

When changing the password of a password type macro, the password was replaced by the widcard replacing the actual password.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
