### PR TITLE
fix(test): remove phpunit warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,7 @@ try {
         recordIssues(
           enabledForFailure: true,
           aggregatingResults: true,
+          ignoreFailedBuilds: false,
           qualityGates: [[threshold: 1, type: 'NEW', unstable: false]],
           tools: [
             checkStyle(pattern: 'codestyle-be.xml'),
@@ -96,6 +97,7 @@ try {
         recordIssues(
           enabledForFailure: true,
           failOnError: true,
+          ignoreFailedBuilds: false,
           qualityGates: [[threshold: 1, type: 'NEW', unstable: false]],
           tools: [esLint(pattern: 'codestyle-fe.xml')],
           referenceJobName: 'centreon-web/master'

--- a/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
@@ -290,10 +290,6 @@ class PlatformTopologyControllerTest extends TestCase
 
     public function testDeletePlatformTopologySuccess(): void
     {
-        $this->platformTopologyService
-            ->expects($this->once())
-            ->method('deletePlatform')
-            ->willReturn(null);
         $platformTopologyController = new PlatformTopologyController($this->platformTopologyService);
         $platformTopologyController->setContainer($this->container);
 

--- a/tests/php/Centreon/Domain/PlatformTopology/PlatformTopologyServiceTest.php
+++ b/tests/php/Centreon/Domain/PlatformTopology/PlatformTopologyServiceTest.php
@@ -457,11 +457,6 @@ class PlatformTopologyServiceTest extends TestCase
             ->method('findPlatform')
             ->willReturn($this->platform);
 
-        $this->platformTopologyRepository
-            ->expects($this->once())
-            ->method('deletePlatform')
-            ->willReturn(null);
-
         $platformTopologyService = new PlatformTopologyService(
             $this->platformTopologyRepository,
             $this->platformInformationService,


### PR DESCRIPTION
## Description

* remove phpunit warnings : 
```
There were 2 warnings:

1) Tests\Centreon\Application\Controller\PlatformTopologyControllerTest::testDeletePlatformTopologySuccess
Trying to configure method "deletePlatform" which cannot be configured because it does not exist, has not been specified, is final, or is static

2) Tests\Centreon\Domain\PlatformTopology\PlatformTopologyServiceTest::testDeletePlatformTopologySuccess
Method deletePlatform may not return value of type NULL, its return declaration is ": void"
```
* take into account failed builds for quality gate : to be able to reset it

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)