### PR TITLE
Filter for fullName on the inner select

### DIFF
--- a/www/api/class/centreon_performance_service.class.php
+++ b/www/api/class/centreon_performance_service.class.php
@@ -104,7 +104,8 @@ class CentreonPerformanceService extends CentreonConfigurationObjects
             'WHERE i.id = m.index_id ' .
             'AND s.enabled = 1 ' .
             'AND i.service_id = s.service_id ' .
-            'AND i.host_name NOT LIKE "_Module_%" ';
+            'AND i.host_name NOT LIKE "_Module_%" ' .
+            'AND CONCAT(i.host_name, " - ", i.service_description) LIKE :fullName ';
 
         if (!$isAdmin) {
             $query .= 'AND acl.host_id = i.host_id ' .


### PR DESCRIPTION
## Description

When filtering for charts on the Performance Graphs page, if there are too many graphs on the database, the queries take too long to complete.

In our case for each search, it was taking around 12 seconds per search and since more than 3 characters will trigger a search we were getting a lot of slowness, we have around 66k services.

This fix will filter the inner query to optimize the search on the database.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to: Monitoring > Performances > Graphs
2. Type in the "Chart" search box
3. If there are many services you can see that the search gets slow

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
