### PR TITLE
fix(security): Correctly evaluate centreon_token

### DIFF
--- a/www/include/reporting/dashboard/template/viewHostGroupLog.ihtml
+++ b/www/include/reporting/dashboard/template/viewHostGroupLog.ihtml
@@ -23,7 +23,7 @@
 		<td style='padding:5px;vertical-align:top;'>
 			<form {$formPeriod.attributes} style="padding-bottom : 0px;">
 				<input type="radio" value="preset" name="period_choice" {if $period_choice == "preset" } checked="checked" {/if}/>
-					{$periodTitle} : {$formPeriod.period.html}{$formPeriod.hidden}{$periodORlabel}
+					{$periodTitle} : {$formPeriod.period.html}{$periodORlabel}
 				<input type="radio" name="period_choice" value="custom" {if $period_choice == "custom" } checked="checked" {/if} />
 					{$formPeriod.StartDate.label} {$formPeriod.StartDate.html}&nbsp;{$formPeriod.alternativeDateStartDate.html}
 					{$formPeriod.EndDate.label} {$formPeriod.EndDate.html} {$formPeriod.alternativeDateEndDate.html}

--- a/www/include/reporting/dashboard/template/viewHostLog.ihtml
+++ b/www/include/reporting/dashboard/template/viewHostLog.ihtml
@@ -22,7 +22,7 @@
 		<td style='padding:5px;vertical-align:top;'>
 			<form {$formPeriod.attributes} style="padding-bottom : 0px;">
 				<input type="radio" value="preset" name="period_choice" {if $period_choice == "preset" } checked="checked" {/if}/>
-					{$periodTitle} : {$formPeriod.period.html}{$formPeriod.hidden}{$periodORlabel}
+					{$periodTitle} : {$formPeriod.period.html}{$periodORlabel}
 				<input type="radio" name="period_choice" value="custom" {if $period_choice == "custom" } checked="checked" {/if} />
 					{$formPeriod.StartDate.label} {$formPeriod.StartDate.html}&nbsp;{$formPeriod.alternativeDateStartDate.html}
 					{$formPeriod.EndDate.label} {$formPeriod.EndDate.html} {$formPeriod.alternativeDateEndDate.html}

--- a/www/include/reporting/dashboard/template/viewServicesGroupLog.ihtml
+++ b/www/include/reporting/dashboard/template/viewServicesGroupLog.ihtml
@@ -25,7 +25,7 @@
 		<td style='padding:5px;vertical-align:top;'>
 			<form {$formPeriod.attributes} style="padding-bottom : 0px;">
 			<input type="radio" value="preset" name="period_choice" {if $period_choice == "preset" } checked="checked" {/if}/>
-				{$periodTitle} : {$formPeriod.period.html}{$formPeriod.hidden}{$periodORlabel}
+				{$periodTitle} : {$formPeriod.period.html}{$periodORlabel}
 				<input type="radio" name="period_choice" value="custom" {if $period_choice == "custom" } checked="checked" {/if} />
 				{$formPeriod.StartDate.label} {$formPeriod.StartDate.html}&nbsp;{$formPeriod.alternativeDateStartDate.html}
 				{$formPeriod.EndDate.label} {$formPeriod.EndDate.html} {$formPeriod.alternativeDateEndDate.html}

--- a/www/include/reporting/dashboard/template/viewServicesLog.ihtml
+++ b/www/include/reporting/dashboard/template/viewServicesLog.ihtml
@@ -25,7 +25,7 @@
 		<td style='padding:5px;vertical-align:top;'>
 			<form {$formPeriod.attributes} style="padding-bottom : 0px;">
 			<input type="radio" value="preset" name="period_choice" {if $period_choice == "preset" } checked="checked" {/if}/>
-				{$periodTitle} : {$formPeriod.period.html}{$formPeriod.hidden}{$periodORlabel}
+				{$periodTitle} : {$formPeriod.period.html}{$periodORlabel}
 				<input type="radio" name="period_choice" value="custom" {if $period_choice == "custom" } checked="checked" {/if} />
 					{$formPeriod.StartDate.label} {$formPeriod.StartDate.html}&nbsp;{$formPeriod.alternativeDateStartDate.html}
 					{$formPeriod.EndDate.label} {$formPeriod.EndDate.html} {$formPeriod.alternativeDateEndDate.html}

--- a/www/include/reporting/dashboard/viewHostGroupLog.php
+++ b/www/include/reporting/dashboard/viewHostGroupLog.php
@@ -209,4 +209,9 @@ $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('formItem', $renderer->toArray());
 
-$tpl->display("template/viewHostGroupLog.ihtml");
+if (
+    !$formPeriod->isSubmitted()
+    || ($formPeriod->isSubmitted() && $formPeriod->validate())
+) {
+    $tpl->display("template/viewHostGroupLog.ihtml");
+}

--- a/www/include/reporting/dashboard/viewHostLog.php
+++ b/www/include/reporting/dashboard/viewHostLog.php
@@ -202,4 +202,9 @@ $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $formHost->accept($renderer);
 $tpl->assign('formHost', $renderer->toArray());
 
-$tpl->display("template/viewHostLog.ihtml");
+if (
+    !$formPeriod->isSubmitted()
+    || ($formPeriod->isSubmitted() && $formPeriod->validate())
+) {
+    $tpl->display("template/viewHostLog.ihtml");
+}

--- a/www/include/reporting/dashboard/viewServicesGroupLog.php
+++ b/www/include/reporting/dashboard/viewServicesGroupLog.php
@@ -209,4 +209,9 @@ $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('formItem', $renderer->toArray());
 
-$tpl->display("template/viewServicesGroupLog.ihtml");
+if (
+    !$formPeriod->isSubmitted()
+    || ($formPeriod->isSubmitted() && $formPeriod->validate())
+) {
+    $tpl->display("template/viewServicesGroupLog.ihtml");
+}

--- a/www/include/reporting/dashboard/viewServicesLog.php
+++ b/www/include/reporting/dashboard/viewServicesLog.php
@@ -211,4 +211,9 @@ $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('formItem', $renderer->toArray());
 
-$tpl->display("template/viewServicesLog.ihtml");
+if (
+    !$formPeriod->isSubmitted()
+    || ($formPeriod->isSubmitted() && $formPeriod->validate())
+) {
+    $tpl->display("template/viewServicesLog.ihtml");
+}


### PR DESCRIPTION
## Description
This PR fix an issue where centreon_token wasn't evaluate while submitting the Dashboard's period form.

**Fixes** # MON-3201 MON-3202

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
