### PR TITLE
fix(CLAPI) take account of encoding language

### DIFF
--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -202,10 +202,12 @@ class CentreonContact extends CentreonObject
         if (strtolower($locale) == "en_us" || strtolower($locale) == "browser") {
             return true;
         }
-        $centreonDir = realpath(__DIR__ . "/../../../");
-        $dir = $centreonDir . "/www/locale/$locale";
-        if (is_dir($dir)) {
-            return true;
+        $centreonDir = realpath(__DIR__ . "/../../../") . "/www/locale";
+        $dir = opendir($centreonDir) ;
+        while (false !== ($ssDir = readdir($dir))) {
+            if (($locale === substr($ssDir, 0, 5)) && is_dir($centreonDir . '/' . $ssDir)) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Description

CLAPI check language don't take account of encoding indicate on the language directory (ex:fr_FR.UTF-8) when a user is created.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

 centreon -u admin -p pass -o CONTACT -a ADD -v "ABC;ABC;ABC;ABC;0;1;fr_FR;local"

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
