### PR TITLE
fix(clapi): Correction of RTACKNOWLEDGEMENT cancellation for services

### DIFF
--- a/www/class/centreon-clapi/centreonRtAcknowledgement.class.php
+++ b/www/class/centreon-clapi/centreonRtAcknowledgement.class.php
@@ -500,7 +500,7 @@ class CentreonRtAcknowledgement extends CentreonObject
             list($hostName, $serviceName) = explode(',', $acknowledgement);
 
             if ($serviceName) {
-                $serviceId = $this->serviceObject->getObjectId($serviceName);
+                $serviceId = $this->serviceObject->getObjectId($hostName . ";" . $serviceName);
                 if ($this->object->svcIsAcknowledged($serviceId)) {
                     $this->externalCmdObj->deleteAcknowledgement(
                         'SVC',


### PR DESCRIPTION
**Fixes**
Cancel RTACKNOWLEDGEMENT generates an error while an acknowledgement exists on the service.
> Object not found OR not acknowledged : <host>,<service>

The command may not find a service because if there are two services with the same name, only the id of the first service will be returned while the acknowledgement may be on the second service.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
