### PR TITLE
fix(remoteserver): configuration failed when poller linked to multipl…

### DIFF
--- a/www/class/config-generate-remote/Generate.php
+++ b/www/class/config-generate-remote/Generate.php
@@ -53,6 +53,7 @@ require_once __DIR__ . '/HostCategory.php';
 require_once __DIR__ . '/Curves.php';
 require_once __DIR__ . '/Trap.php';
 require_once __DIR__ . '/PlatformTopology.php';
+require_once __DIR__ . '/Relations/BrokerInfo.php';
 require_once __DIR__ . '/Relations/ViewImgDirRelation.php';
 require_once __DIR__ . '/Relations/ViewImageDir.php';
 require_once __DIR__ . '/Relations/ExtendedServiceInformation.php';
@@ -211,6 +212,7 @@ class Generate
             $this->backendInstance->setUserName($username);
             $this->backendInstance->initPath($remoteServerId);
             $this->backendInstance->setPollerId($remoteServerId);
+            Manifest::getInstance($this->dependencyInjector)->clean();
             Manifest::getInstance($this->dependencyInjector)->addRemoteServer($remoteServerId);
 
             $this->getPollerFromId($remoteServerId);
@@ -351,6 +353,7 @@ class Generate
         TimePeriod::getInstance($this->dependencyInjector)->reset();
         Trap::getInstance($this->dependencyInjector)->reset();
         PlatformTopology::getInstance($this->dependencyInjector)->reset();
+        Relations\BrokerInfo::getInstance($this->dependencyInjector)->reset();
         Relations\CfgResourceInstanceRelation::getInstance($this->dependencyInjector)->reset();
         Relations\ContactGroupHostRelation::getInstance($this->dependencyInjector)->reset();
         Relations\ContactGroupServiceRelation::getInstance($this->dependencyInjector)->reset();

--- a/www/class/config-generate-remote/Manifest.php
+++ b/www/class/config-generate-remote/Manifest.php
@@ -115,4 +115,16 @@ class Manifest extends AbstractObject
             'columns' => $columns
         ];
     }
+
+    /**
+     * clean
+     *
+     * @return void
+     */
+    public function clean()
+    {
+        $this->manifest['date'] = date('l jS \of F Y h:i:s A');
+        $this->manifest['import']['data'] = [];
+        $this->manifest['pollers'] = [];
+    }
 }


### PR DESCRIPTION
…e remote server

## Description

Need to fix backend call processQueue twice in parrallel (and so the import is called also twice in same remote-server).

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

-

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
