### PR TITLE
enh(resource-status/Graph): Enhance comment in performance graphs

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Graph/AddCommentForm/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/AddCommentForm/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { isEmpty, isNil } from 'ramda';
+import { isEmpty, isNil, pipe, trim } from 'ramda';
 
 import { Grid, Typography } from '@material-ui/core';
 
@@ -69,9 +69,19 @@ const AddCommentForm = ({
     });
   };
 
-  const error = isEmpty(comment) ? t(labelRequired) : undefined;
+  const getError = (): string | undefined => {
+    if (isNil(comment)) {
+      return undefined;
+    }
 
-  const canConfirm = isNil(error) && !isNil(comment) && !sending;
+    const normalizedComment = comment || '';
+
+    return pipe(trim, isEmpty)(normalizedComment)
+      ? t(labelRequired)
+      : undefined;
+  };
+
+  const canConfirm = isNil(getError()) && !isNil(comment) && !sending;
 
   return (
     <Dialog
@@ -91,7 +101,7 @@ const AddCommentForm = ({
         <Grid item>
           <TextField
             autoFocus
-            error={error}
+            error={getError()}
             label={t(labelComment)}
             ariaLabel={t(labelComment)}
             value={comment}

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -24,6 +24,7 @@ import {
   makeStyles,
   Paper,
   Typography,
+  Theme,
 } from '@material-ui/core';
 import { grey } from '@material-ui/core/colors';
 
@@ -69,12 +70,26 @@ const MemoizedAnnotations = React.memo(Annotations, propsAreEqual);
 
 const margin = { top: 30, right: 45, bottom: 30, left: 45 };
 
-const useStyles = makeStyles((theme) => ({
+interface Props {
+  width: number;
+  height: number;
+  timeSeries: Array<TimeValue>;
+  base: number;
+  lines: Array<LineModel>;
+  xAxisTickFormat: string;
+  timeline?: Array<TimelineEvent>;
+  resource: Resource | ResourceDetails;
+  onAddComment?: (commentParameters: CommentParameters) => void;
+  eventAnnotationsActive: boolean;
+}
+
+const useStyles = makeStyles<Theme, Pick<Props, 'onAddComment'>>((theme) => ({
   container: {
     position: 'relative',
   },
   overlay: {
-    cursor: 'crosshair',
+    cursor: ({ onAddComment }): string =>
+      isNil(onAddComment) ? 'normal' : 'crosshair',
   },
   tooltip: {
     opacity: 0.8,
@@ -92,19 +107,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 10,
   },
 }));
-
-interface Props {
-  width: number;
-  height: number;
-  timeSeries: Array<TimeValue>;
-  base: number;
-  lines: Array<LineModel>;
-  xAxisTickFormat: string;
-  timeline?: Array<TimelineEvent>;
-  resource: Resource | ResourceDetails;
-  onAddComment: (commentParameters: CommentParameters) => void;
-  eventAnnotationsActive: boolean;
-}
 
 const getScale = ({
   values,
@@ -136,7 +138,7 @@ const Graph = ({
   eventAnnotationsActive,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
-  const classes = useStyles();
+  const classes = useStyles({ onAddComment });
   const { format } = useLocaleDateTimeFormat();
 
   const [addingComment, setAddingComment] = React.useState(false);
@@ -284,7 +286,7 @@ const Graph = ({
   );
 
   const displayAddCommentTooltip = (event): void => {
-    if (!canComment([resource])) {
+    if (!canComment([resource]) || isNil(onAddComment)) {
       return;
     }
 
@@ -308,7 +310,7 @@ const Graph = ({
 
   const confirmAddComment = (comment): void => {
     setAddingComment(false);
-    onAddComment(comment);
+    onAddComment?.(comment);
   };
 
   const tooltipLineLeft = (tooltipLeft as number) - margin.left;

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -70,6 +70,8 @@ const MemoizedAnnotations = React.memo(Annotations, propsAreEqual);
 
 const margin = { top: 30, right: 45, bottom: 30, left: 45 };
 
+const commentTooltipWidth = 165;
+
 interface Props {
   width: number;
   height: number;
@@ -297,8 +299,10 @@ const Graph = ({
 
     setCommentDate(date);
 
+    const displayLeft = width - x < commentTooltipWidth;
+
     showAddCommentTooltip({
-      tooltipLeft: x,
+      tooltipLeft: displayLeft ? x - commentTooltipWidth : x,
       tooltipTop: y,
     });
   };
@@ -396,6 +400,7 @@ const Graph = ({
             style={{
               left: addCommentTooltipLeft,
               top: addCommentTooltipTop,
+              width: commentTooltipWidth,
             }}
           >
             <Typography variant="caption">

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -28,7 +28,7 @@ interface Props {
   eventAnnotationsActive?: boolean;
   resource: Resource | ResourceDetails;
   timeline?: Array<TimelineEvent>;
-  onAddComment: (commentParameters: CommentParameters) => void;
+  onAddComment?: (commentParameters: CommentParameters) => void;
 }
 
 const useStyles = makeStyles<Theme, Pick<Props, 'graphHeight'>>((theme) => ({

--- a/www/front_src/src/Resources/Listing/columns/Graph/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph/index.tsx
@@ -59,7 +59,6 @@ const GraphColumn = ({
             graphHeight={150}
             resource={row}
             timeline={[]}
-            onAddComment={(): void => undefined}
           />
         </Paper>
       </HoverChip>


### PR DESCRIPTION
## Description
This performs a few enhancements on the graph comment insertion:
- If the tooltip to add a comment is too closed to the edge, it will be displayed to the left of the pointer instead of the right
- The tooltip won't open on the listing graph tooltip
- We now prevent the insertion of comment if the trimmed comment is empty

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x (master)
