### PR TITLE
enh(resource-status/Graph): Improve exported graph image timestamp in title

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Graph/exportToPng.ts
+++ b/www/front_src/src/Resources/Details/tabs/Graph/exportToPng.ts
@@ -10,7 +10,8 @@ const exportToPng = ({ element, title }: Props): Promise<void> => {
     const canvasUrl = canvas.toDataURL('image/png;base64');
 
     const downloadLink = document.createElement('a');
-    downloadLink.download = `${title}-${new Date().toISOString()}.png`;
+    const dateTime = new Date().toISOString().substring(0, 19);
+    downloadLink.download = `${title}-${dateTime}.png`;
     downloadLink.href = canvasUrl;
 
     downloadLink.click();


### PR DESCRIPTION
## Description

This removes the milliseconds and timezone in the exported graph image title. 

Before: Ping_1-performance-2021-01-04T15_44_00..585Z.png
After: Ping_1-performance-2021-01-04T15_44_00.png

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x (master)
