### PR TITLE
fix(clapi): Fix CLAPI command to list all hosts acknowledgements #9332

### DIFF
--- a/lib/Centreon/Object/Acknowledgement/RtAcknowledgement.php
+++ b/lib/Centreon/Object/Acknowledgement/RtAcknowledgement.php
@@ -77,6 +77,7 @@ class Centreon_Object_RtAcknowledgement extends Centreon_ObjectRt
                     ) AS tmp
                     ON tmp.entry_time = ack.entry_time
                     AND tmp.host_id = ack.host_id
+                    AND ack.service_id = 0
                 ORDER BY ack.entry_time, hosts.name',
                 $hostFilter
             )


### PR DESCRIPTION
**Fixes**
When displaying host acknowledgements with CLAPI, the host acknowledgement appeared as many times as the number of services on which the acknowledgement was set.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
