### PR TITLE
fix(mediawiki): manage properly mediawiki url of host templates

### DIFF
--- a/www/class/centreon-knowledge/ProceduresProxy.class.php
+++ b/www/class/centreon-knowledge/ProceduresProxy.class.php
@@ -157,6 +157,11 @@ class ProceduresProxy
     public function getHostUrl($hostName): ?string
     {
         $hostId = $this->getHostId($hostName);
+
+        if ($hostId === null) {
+            return null;
+        }
+
         $hostProperties = $this->hostObj->getInheritedValues(
             $hostId,
             [],
@@ -168,15 +173,18 @@ class ProceduresProxy
             return $this->wikiUrl . "/index.php?title=Host_:_" . $hostProperties['host_name'];
         }
 
-        $inheritedHostProperties = $this->hostObj->getInheritedValues(
-            $hostId,
-            [],
-            -1,
-            ['host_name', 'ehi_notes_url']
-        );
+        $templates = $this->hostObj->getTemplateChain($hostId);
+        foreach ($templates as $template) {
+            $inheritedHostProperties = $this->hostObj->getInheritedValues(
+                $template['id'],
+                [],
+                1,
+                ['host_name', 'ehi_notes_url']
+            );
 
-        if (isset($inheritedHostProperties['ehi_notes_url'])) {
-            return $this->wikiUrl . "/index.php?title=Host-Template_:_" . $inheritedHostProperties['host_name'];
+            if (isset($inheritedHostProperties['ehi_notes_url'])) {
+                return $this->wikiUrl . "/index.php?title=Host-Template_:_" . $inheritedHostProperties['host_name'];
+            }
         }
 
         return null;


### PR DESCRIPTION
## Description

Fix mediawiki urls to host templates

Fixes MON-6321 MON-6531

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

check mediawiki redirection when procedure is linked to a host template