### PR TITLE
fix(clapi) Import fails on password type macros

### DIFF
--- a/www/install/php/Update-19.10.19.php
+++ b/www/install/php/Update-19.10.19.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+// error specific content
+$versionOfTheUpgrade = 'UPGRADE - 19.10.19 : ';
+$errorMessage = '';
+
+try {
+    $statement = $pearDB->query(
+        'SELECT COLUMN_DEFAULT
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = \'centreon\'
+          AND TABLE_NAME = \'on_demand_macro_host\'
+          AND COLUMN_NAME = \'is_password\''
+    );
+    if (($result = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+        $defaultValue = $result['COLUMN_DEFAULT'];
+        if ($defaultValue !== '0') {
+            // An update is required
+            $errorMessage = 'Impossible to alter the table on_demand_macro_host';
+            $pearDB->query('ALTER TABLE on_demand_macro_host ALTER is_password SET DEFAULT 0');
+            $errorMessage = 'Impossible to update the column on_demand_macro_host.is_password';
+            $pearDB->query('UPDATE on_demand_macro_host SET is_password = 0 WHERE is_password IS NULL');
+        }
+    }
+    $statement = $pearDB->query(
+        'SELECT COLUMN_DEFAULT
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = \'centreon\'
+          AND TABLE_NAME = \'on_demand_macro_service\'
+          AND COLUMN_NAME = \'is_password\''
+    );
+    if (($defaultValue = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+        $defaultValue = $result['COLUMN_DEFAULT'];
+        if ($defaultValue !== '0') {
+            // An update is required
+            $errorMessage = 'Impossible to alter the table on_demand_macro_service';
+            $pearDB->query('ALTER TABLE on_demand_macro_service ALTER is_password SET DEFAULT 0');
+            $errorMessage = 'Impossible to update the column on_demand_macro_service.is_password';
+            $pearDB->query('UPDATE on_demand_macro_service SET is_password = 0 WHERE is_password IS NULL');
+        }
+    }
+} catch (\Throwable $ex) {
+    require_once __DIR__ . '/../../class/centreonLog.class.php';
+    (new CentreonLog())->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage .
+        " - Code : " . $ex->getCode() .
+        " - Error : " . $ex->getMessage() .
+        " - Trace : " . $ex->getTraceAsString()
+    );
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, $ex->getCode(), $ex);
+}

--- a/www/install/php/Update-20.04.9.php
+++ b/www/install/php/Update-20.04.9.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+// error specific content
+$versionOfTheUpgrade = 'UPGRADE - 20.04.9 : ';
+$errorMessage = '';
+
+try {
+    $statement = $pearDB->query(
+        'SELECT COLUMN_DEFAULT
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = \'centreon\'
+          AND TABLE_NAME = \'on_demand_macro_host\'
+          AND COLUMN_NAME = \'is_password\''
+    );
+    if (($result = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+        $defaultValue = $result['COLUMN_DEFAULT'];
+        if ($defaultValue !== '0') {
+            // An update is required
+            $errorMessage = 'Impossible to alter the table on_demand_macro_host';
+            $pearDB->query('ALTER TABLE on_demand_macro_host ALTER is_password SET DEFAULT 0');
+            $errorMessage = 'Impossible to update the column on_demand_macro_host.is_password';
+            $pearDB->query('UPDATE on_demand_macro_host SET is_password = 0 WHERE is_password IS NULL');
+        }
+    }
+    $statement = $pearDB->query(
+        'SELECT COLUMN_DEFAULT
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = \'centreon\'
+          AND TABLE_NAME = \'on_demand_macro_service\'
+          AND COLUMN_NAME = \'is_password\''
+    );
+    if (($defaultValue = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+        $defaultValue = $result['COLUMN_DEFAULT'];
+        if ($defaultValue !== '0') {
+            // An update is required
+            $errorMessage = 'Impossible to alter the table on_demand_macro_service';
+            $pearDB->query('ALTER TABLE on_demand_macro_service ALTER is_password SET DEFAULT 0');
+            $errorMessage = 'Impossible to update the column on_demand_macro_service.is_password';
+            $pearDB->query('UPDATE on_demand_macro_service SET is_password = 0 WHERE is_password IS NULL');
+        }
+    }
+} catch (\Throwable $ex) {
+    require_once __DIR__ . '/../../class/centreonLog.class.php';
+    (new CentreonLog())->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage .
+        " - Code : " . $ex->getCode() .
+        " - Error : " . $ex->getMessage() .
+        " - Trace : " . $ex->getTraceAsString()
+    );
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, $ex->getCode(), $ex);
+}


### PR DESCRIPTION
## Description
Added missing update scripts for previous versions (missed in the main fix #9338 )

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
