### PR TITLE
enh(api): allow user to retrieve only resources with graphs

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.ResourceFilter.yml
+++ b/config/packages/serializer/Centreon/Monitoring.ResourceFilter.yml
@@ -10,3 +10,5 @@ Centreon\Domain\Monitoring\ResourceFilter:
             type: array<int>
         servicegroupIds:
             type: array<int>
+        onlyWithPerformanceData:
+            type: boolean

--- a/config/packages/validator/validation.yaml
+++ b/config/packages/validator/validation.yaml
@@ -238,6 +238,10 @@ Centreon\Domain\Monitoring\ResourceFilter:
                 - Type:
                     type: int
                     groups: [Default]
+        onlyWithPerformanceData:
+            - Type:
+                type: boolean
+                groups: [Default]
 
 # Used to validate the Resource Entity
 Centreon\Domain\Monitoring\Resource:

--- a/doc/API/centreon-api-v2.1.yaml
+++ b/doc/API/centreon-api-v2.1.yaml
@@ -551,6 +551,7 @@ paths:
         - $ref: '#/components/parameters/ResourceFilterStatus'
         - $ref: '#/components/parameters/ResourceFilterHostgroupId'
         - $ref: '#/components/parameters/ResourceFilterServicegroupId'
+        - $ref: '#/components/parameters/ResourceFilterOnlyWithPerformanceData'
       responses:
         '200':
           description: "OK"
@@ -2713,6 +2714,15 @@ components:
           type: string
           enum: [service, host]
         example: '["host"]'
+    ResourceFilterOnlyWithPerformanceData:
+      in: query
+      name: only_with_performance_data
+      required: false
+      description: "Filter the resources to retrieve the ones with available performance data"
+      schema:
+        type: boolean
+        default: false
+        example: true
     ResourceFilterState:
       in: query
       name: states

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -544,6 +544,7 @@ paths:
         - $ref: '#/components/parameters/ResourceFilterStatus'
         - $ref: '#/components/parameters/ResourceFilterHostgroupId'
         - $ref: '#/components/parameters/ResourceFilterServicegroupId'
+        - $ref: '#/components/parameters/ResourceFilterOnlyWithPerformanceData'
       responses:
         '200':
           description: "OK"
@@ -2913,6 +2914,15 @@ components:
           type: string
           enum: [service, host]
         example: '["host"]'
+    ResourceFilterOnlyWithPerformanceData:
+      in: query
+      name: only_with_performance_data
+      required: false
+      description: "Filter the resources to retrieve the ones with available performance data"
+      schema:
+        type: boolean
+        default: false
+        example: true
     ResourceFilterState:
       in: query
       name: states

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -68,6 +68,8 @@ class MonitoringResourceController extends AbstractController
         'servicegroup_ids',
     ];
 
+    public const FILTER_RESOURCES_ON_PERFORMANCE_DATA_AVAILABILITY = 'only_with_performance_data';
+
     private const HOST_CONFIGURATION_URI = '/main.php?p=60101&o=c&host_id={resource_id}';
     private const SERVICE_CONFIGURATION_URI = '/main.php?p=60201&o=c&service_id={resource_id}';
     private const HOST_LOGS_URI = '/main.php?p=20301&h={resource_id}';
@@ -181,6 +183,8 @@ class MonitoringResourceController extends AbstractController
         foreach (static::EXTRA_PARAMETERS_LIST as $param) {
             $filterData[$param] = [];
         }
+
+        $filterData[static::FILTER_RESOURCES_ON_PERFORMANCE_DATA_AVAILABILITY] = false;
 
         // load filter data with the query parameters
         foreach ($request->query->all() as $param => $data) {

--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -318,7 +318,6 @@ class ResourceFilter
     /**
      * @param boolean $onlyWithPerformanceData
      * @return \Centreon\Domain\Monitoring\ResourceFilter
-     * @throws \InvalidArgumentException
      */
     public function setOnlyWithPerformanceData(bool $onlyWithPerformanceData): self
     {

--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -322,12 +322,6 @@ class ResourceFilter
      */
     public function setOnlyWithPerformanceData(bool $onlyWithPerformanceData): self
     {
-        if (!is_bool($onlyWithPerformanceData)) {
-            throw new \InvalidArgumentException(
-                'Search parameter on resources that has performance data available should be a boolean'
-            );
-        }
-
         $this->onlyWithPerformanceData = $onlyWithPerformanceData;
 
         return $this;

--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -322,7 +322,6 @@ class ResourceFilter
     public function setOnlyWithPerformanceData(bool $onlyWithPerformanceData): self
     {
         $this->onlyWithPerformanceData = $onlyWithPerformanceData;
-
         return $this;
     }
 

--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -117,6 +117,11 @@ class ResourceFilter
     private $serviceIds = [];
 
     /**
+     * @var boolean
+     */
+    private $onlyWithPerformanceData = false;
+
+    /**
      * Transform result by map
      *
      * @param array $list
@@ -308,5 +313,31 @@ class ResourceFilter
         $this->serviceIds = $serviceIds;
 
         return $this;
+    }
+
+    /**
+     * @param boolean $onlyWithPerformanceData
+     * @return \Centreon\Domain\Monitoring\ResourceFilter
+     * @throws \InvalidArgumentException
+     */
+    public function setOnlyWithPerformanceData(bool $onlyWithPerformanceData): self
+    {
+        if (!is_bool($onlyWithPerformanceData)) {
+            throw new \InvalidArgumentException(
+                'Search parameter on resources that has performance data available should be a boolean'
+            );
+        }
+
+        $this->onlyWithPerformanceData = $onlyWithPerformanceData;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getOnlyWithPerformanceData(): bool
+    {
+        return $this->onlyWithPerformanceData;
     }
 }

--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -253,6 +253,16 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             . ' LEFT JOIN `:dbstg`.`hosts_hostgroups` AS hhg ON hhg.host_id = resource.host_id'
             . ' LEFT JOIN `:dbstg`.`hostgroups` AS hg ON hg.hostgroup_id = hhg.hostgroup_id';
 
+        /**
+         * If we specify that user only wants resources with available performance datas.
+         * Then only resources with existing metrics referencing index_data services will be returned.
+         */
+        if ($filter->getOnlyWithPerformanceData() === true) {
+            $request .= ' INNER JOIN (SELECT host_id, service_id FROM `:dbstg`.metrics AS m, `:dbstg`.index_data AS i '
+                . 'WHERE i.id = m.index_id AND m.hidden = "0" GROUP BY host_id, service_id) AS gdata '
+                . 'ON gdata.host_id = resource.parent_id AND gdata.service_id = resource.id';
+        }
+
         $request = $this->translateDbName($request);
 
         // Search


### PR DESCRIPTION
This PR intends to add the possibility to return ONLY resources that has performance data available when calling `/monitoring/resources` endpoint.

Example

`http://[IP]/centreon/api/beta/monitoring/resources?page=1&limit=30&sort_by={"status_severity_code":"asc"}&types=["service"]&statuses=["OK"]&**only_with_performance_data=true**`


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

See JIRA issue for this

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
