### PR TITLE
enh(topCounter): services from host acked, in downtime not displayed

### DIFF
--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -557,7 +557,7 @@ class CentreonTopCounter extends CentreonWebService
             throw new \RestUnauthorizedException("You're not authorized to access resource datas");
         }
 
-        if (isset($_SESSION['topCounterHostStatus']) && 
+        if (isset($_SESSION['topCounterHostStatus']) &&
             (time() - $this->refreshTime) < $_SESSION['topCounterHostStatus']['time']) {
             return $_SESSION['topCounterHostStatus'];
         }
@@ -634,11 +634,14 @@ class CentreonTopCounter extends CentreonWebService
             COALESCE(SUM(CASE WHEN s.state = 2 THEN 1 ELSE 0 END), 0) AS critical_total,
             COALESCE(SUM(CASE WHEN s.state = 3 THEN 1 ELSE 0 END), 0) AS unknown_total,
             COALESCE(SUM(CASE WHEN s.state = 4 THEN 1 ELSE 0 END), 0) AS pending_total,
-            COALESCE(SUM(CASE WHEN s.state = 1 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
+            COALESCE(SUM(CASE WHEN s.state = 1 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0
+                AND s.state_type = 1 AND s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
                 THEN 1 ELSE 0 END), 0) AS warning_unhandled,
-            COALESCE(SUM(CASE WHEN s.state = 2 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
+            COALESCE(SUM(CASE WHEN s.state = 2 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0
+                AND s.state_type = 1 AND s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
                 THEN 1 ELSE 0 END), 0) AS critical_unhandled,
-            COALESCE(SUM(CASE WHEN s.state = 3 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
+            COALESCE(SUM(CASE WHEN s.state = 3 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0
+                AND s.state_type = 1 AND s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
                 THEN 1 ELSE 0 END), 0) AS unknown_unhandled
             FROM hosts h, services s, instances i';
         $query .= ' WHERE i.deleted = 0

--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2018 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -120,7 +121,8 @@ class CentreonTopCounter extends CentreonWebService
             $this->hasAccessToPollers = true;
         }
 
-        if (isset($this->centreon->user->access->topology[50104]) &&
+        if (
+            isset($this->centreon->user->access->topology[50104]) &&
             $this->centreon->user->access->topology[50104] === 1
         ) {
             $this->hasAccessToProfile = true;
@@ -234,7 +236,8 @@ class CentreonTopCounter extends CentreonWebService
 
         // If the autologin feature is enabled then fetch the autologin key
         // And display the shortcut if the option is enabled
-        if (isset($rowEnableAutoLogin['value'])
+        if (
+            isset($rowEnableAutoLogin['value'])
             && isset($rowEnableShortcut['value'])
             && $rowEnableAutoLogin['value'] === '1'
             && $rowEnableShortcut['value'] === '1'
@@ -244,7 +247,7 @@ class CentreonTopCounter extends CentreonWebService
                 $res = $this->pearDB->prepare(
                     'SELECT contact_autologin_key FROM contact WHERE contact_id = :userId'
                 );
-                $res->bindValue(':userId',  (int) $this->centreon->user->user_id, \PDO::PARAM_INT);
+                $res->bindValue(':userId', (int) $this->centreon->user->user_id, \PDO::PARAM_INT);
                 $res->execute();
             } catch (\Exception $e) {
                 throw new \RestInternalServerErrorException('Error getting the user.');
@@ -346,7 +349,7 @@ class CentreonTopCounter extends CentreonWebService
             foreach ($pollers as $poller) {
                 $changeStateServers[$poller['id']] = $poller['lastRestart'];
             }
-            $changeStateServers = getChangeState($changeStateServers); 
+            $changeStateServers = getChangeState($changeStateServers);
             foreach ($pollers as $poller) {
                 if ($changeStateServers[$poller['id']]) {
                     $result['pollers'][] = array(
@@ -557,8 +560,10 @@ class CentreonTopCounter extends CentreonWebService
             throw new \RestUnauthorizedException("You're not authorized to access resource datas");
         }
 
-        if (isset($_SESSION['topCounterHostStatus']) &&
-            (time() - $this->refreshTime) < $_SESSION['topCounterHostStatus']['time']) {
+        if (
+            isset($_SESSION['topCounterHostStatus']) &&
+            (time() - $this->refreshTime) < $_SESSION['topCounterHostStatus']['time']
+        ) {
             return $_SESSION['topCounterHostStatus'];
         }
 
@@ -623,8 +628,10 @@ class CentreonTopCounter extends CentreonWebService
             throw new \RestUnauthorizedException("You're not authorized to access resource datas");
         }
 
-        if (isset($_SESSION['topCounterServiceStatus']) && 
-            (time() - $this->refreshTime) < $_SESSION['topCounterServiceStatus']['time']) {
+        if (
+            isset($_SESSION['topCounterServiceStatus']) &&
+            (time() - $this->refreshTime) < $_SESSION['topCounterServiceStatus']['time']
+        ) {
             return $_SESSION['topCounterServiceStatus'];
         }
 


### PR DESCRIPTION
The objective of the PR

- Do not consider in the final result showed by the top counter the services that has host parent acknowledged.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Make sure to have a host in a non-ok state linked to services (non-ok and ok)
- acknowledge the host
- Services linked to this host should not be part of the count of services by status

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
