### PR TITLE
fix(API): Register Children Pollers while converting a central to remote

### DIFF
--- a/bin/registerServerTopology.sh
+++ b/bin/registerServerTopology.sh
@@ -384,10 +384,6 @@ function convert_to_remote() {
   else
     PEER_VALIDATION='"peerValidation": true'
   fi
-  # get token of Remote API
-  get_api_token "$CURRENT_NODE_ADDRESS" "$API_CURRENT_NODE_USERNAME" "$API_CURRENT_NODE_PASSWORD" "$API_CURRENT_NODE_CENTREON_FOLDER"
-  # send request to update informations and convert remote
-  request_to_remote
 }
 #========= end of convert_to_remote()
 
@@ -511,7 +507,12 @@ fi
 
 # Get the API TARGET Token
 get_api_token "$TARGET_NODE_ADDRESS" "$API_USERNAME" "$API_TARGET_PASSWORD" "$ROOT_CENTREON_FOLDER"
-
 # Send cURL to POST Register
 register_server
+
+# get token of Remote API
+get_api_token "$CURRENT_NODE_ADDRESS" "$API_CURRENT_NODE_USERNAME" "$API_CURRENT_NODE_PASSWORD" "$API_CURRENT_NODE_CENTREON_FOLDER"
+# send request to update informations and convert remote
+request_to_remote
+
 exit 0

--- a/bin/registerServerTopology.sh
+++ b/bin/registerServerTopology.sh
@@ -366,8 +366,8 @@ function set_variable_from_template() {
 #========= end of set_variable_from_template()
 
 
-#========= begin of convert_to_remote()
-function convert_to_remote() {
+#========= begin of prepare_remote_payload()
+function prepare_remote_payload() {
   # set default variables
   API_CURRENT_NODE_PROTOCOL="http"
   API_CURRENT_NODE_PORT="80"
@@ -385,7 +385,8 @@ function convert_to_remote() {
     PEER_VALIDATION='"peerValidation": true'
   fi
 }
-#========= end of convert_to_remote()
+#========= end of prepare_remote_payload()
+
 
 #========= begin of request_to_remote()
 function request_to_remote() {
@@ -415,7 +416,7 @@ function request_to_remote() {
 
   if [[ $HTTP_CODE == "204" ]];
   then
-    log "INFO" "The CURRENT NODE ${CURRENT_NODE_TYPE}: '${CURRENT_NODE_NAME}@${CURRENT_NODE_ADDRESS}' has been converted successfully."
+    log "INFO" "The CURRENT NODE ${CURRENT_NODE_TYPE}: '${CURRENT_NODE_NAME}@${CURRENT_NODE_ADDRESS}' has been converted and registered successfully."
   elif [[ $RESPONSE_MESSAGE != "" ]];
   then
     log "ERROR" "${RESPONSE_MESSAGE}"
@@ -425,7 +426,10 @@ function request_to_remote() {
     exit 1
   fi
 }
+#========= end of request_to_remote()
 
+
+#========= begin of set_remote_parameters_manually()
 function set_remote_parameters_manually() {
     # ask information to connect to Remote API
     echo "A few more information are required to convert your platform into Remote : "
@@ -473,7 +477,7 @@ function set_remote_parameters_manually() {
       fi
     fi
 }
-#========= end of convert_to_remote()
+#========= end of set_remote_parameters_manually()
 ###########################################################
 #                                                         #
 #                    SCRIPT EXECUTION                     #
@@ -502,17 +506,16 @@ then
 fi
 
 if [[ $CURRENT_NODE_TYPE == 'remote' ]]; then
-  convert_to_remote
+  prepare_remote_payload
+  # get token of Remote API
+  get_api_token "$CURRENT_NODE_ADDRESS" "$API_CURRENT_NODE_USERNAME" "$API_CURRENT_NODE_PASSWORD" "$API_CURRENT_NODE_CENTREON_FOLDER"
+  # send request to update informations and convert remote
+  request_to_remote
+else
+  # Get the API TARGET Token
+  get_api_token "$TARGET_NODE_ADDRESS" "$API_USERNAME" "$API_TARGET_PASSWORD" "$ROOT_CENTREON_FOLDER"
+  # Send cURL to POST Register
+  register_server
 fi
-
-# Get the API TARGET Token
-get_api_token "$TARGET_NODE_ADDRESS" "$API_USERNAME" "$API_TARGET_PASSWORD" "$ROOT_CENTREON_FOLDER"
-# Send cURL to POST Register
-register_server
-
-# get token of Remote API
-get_api_token "$CURRENT_NODE_ADDRESS" "$API_CURRENT_NODE_USERNAME" "$API_CURRENT_NODE_PASSWORD" "$API_CURRENT_NODE_CENTREON_FOLDER"
-# send request to update informations and convert remote
-request_to_remote
 
 exit 0

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15536,6 +15536,11 @@ msgid "Notification sent to"
 msgstr "Notification envoyée à"
 
 #: api/platform
+msgid "Unable to convert in remote server, no Central to link provided"
+msgstr "Impossible de convertir en remote, aucun Central à lier renseigné"
+
+
+#: api/platform
 msgid "Unable to update the platform information"
 msgstr "Impossible de mettre à jour les informations de la plateforme"
 

--- a/src/Centreon/Application/Controller/PlatformController.php
+++ b/src/Centreon/Application/Controller/PlatformController.php
@@ -30,10 +30,12 @@ use Centreon\Domain\Menu\MenuException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Centreon\Domain\Platform\PlatformException;
+use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Domain\Exception\EntityNotFoundException;
 use Centreon\Domain\RemoteServer\RemoteServerException;
 use Centreon\Domain\Proxy\Interfaces\ProxyServiceInterface;
 use Centreon\Domain\PlatformInformation\PlatformInformation;
+use Centreon\Domain\PlatformTopology\PlatformConflictException;
 use Centreon\Domain\Platform\Interfaces\PlatformServiceInterface;
 use Centreon\Domain\PlatformInformation\PlatformInformationException;
 use Centreon\Domain\PlatformTopology\PlatformException as PlatformTopologyException;
@@ -243,7 +245,9 @@ class PlatformController extends AbstractController
             | EntityNotFoundException
             | RemoteServerException
             | MenuException
-            | PlatformTopologyException $ex
+            | PlatformTopologyException
+            | RepositoryException
+            | PlatformConflictException $ex
         ) {
             return $this->view(['message' => $ex->getMessage()], Response::HTTP_BAD_REQUEST);
         } catch (\Throwable $ex) {

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
@@ -87,7 +87,19 @@ class PlatformInformationService implements PlatformInformationServiceInterface
          */
         try {
             if ($platformInformationUpdate->isRemote() && !$currentPlatformInformation->isRemote()) {
-                $this->remoteServerService->convertCentralToRemote();
+                if ($platformInformationUpdate->getCentralServerAddress() !== null) {
+                    $this->remoteServerService->convertCentralToRemote(
+                        $platformInformationUpdate->getCentralServerAddress()
+                    );
+                } elseif ($currentPlatformInformation->getCentralServerAddress() !== null) {
+                    $this->remoteServerService->convertCentralToRemote(
+                        $currentPlatformInformation->getCentralServerAddress()
+                    );
+                }else {
+                    throw new RemoteServerException(
+                        _("Unable to convert in remote server, no Central to attached provided.")
+                    );
+                }
             } elseif ($platformInformationUpdate->isCentral() && !$currentPlatformInformation->isCentral()) {
                 $this->remoteServerService->convertRemoteToCentral();
             }

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
@@ -89,13 +89,24 @@ class PlatformInformationService implements PlatformInformationServiceInterface
             if ($platformInformationUpdate->isRemote() && !$currentPlatformInformation->isRemote()) {
                 if ($platformInformationUpdate->getCentralServerAddress() !== null) {
                     $this->remoteServerService->convertCentralToRemote(
-                        $platformInformationUpdate->getCentralServerAddress()
+                        $platformInformationUpdate
                     );
+                /**
+                 * If the updated information as no Central Server Address, check in the existing information if its
+                 * provided.
+                 */
                 } elseif ($currentPlatformInformation->getCentralServerAddress() !== null) {
-                    $this->remoteServerService->convertCentralToRemote(
+                    $platformInformationUpdate->setCentralServerAddress(
                         $currentPlatformInformation->getCentralServerAddress()
                     );
-                }else {
+                    $this->remoteServerService->convertCentralToRemote(
+                        $platformInformationUpdate
+                    );
+                /**
+                 * If no CentralServerAddress are provided into the updated or current information,
+                 * we can't convert the platform in remote.
+                 */
+                } else {
                     throw new RemoteServerException(
                         _("Unable to convert in remote server, no Central to attached provided.")
                     );

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
@@ -111,7 +111,7 @@ class PlatformInformationService implements PlatformInformationServiceInterface
                  */
                 } else {
                     throw new RemoteServerException(
-                        _("Unable to convert in remote server, no Central to attached provided.")
+                        _("Unable to convert in remote server, no Central to link provided")
                     );
                 }
             } elseif ($platformInformationUpdate->isCentral() && !$currentPlatformInformation->isCentral()) {

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
@@ -23,11 +23,14 @@ declare(strict_types=1);
 namespace Centreon\Domain\PlatformInformation;
 
 use Centreon\Domain\Menu\MenuException;
+use Centreon\Domain\Repository\RepositoryException;
+use Centreon\Domain\Exception\EntityNotFoundException;
+use Centreon\Domain\PlatformTopology\PlatformException;
+use Centreon\Domain\RemoteServer\RemoteServerException;
+use Centreon\Domain\PlatformTopology\PlatformConflictException;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface;
 use Centreon\Domain\PlatformInformation\Interfaces\PlatformInformationServiceInterface;
 use Centreon\Domain\PlatformInformation\Interfaces\PlatformInformationRepositoryInterface;
-use Centreon\Domain\PlatformTopology\PlatformException;
-use Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface;
-use Centreon\Domain\RemoteServer\RemoteServerException;
 
 /**
  * Service intended to use rest API on 'information' specific configuration data
@@ -116,7 +119,14 @@ class PlatformInformationService implements PlatformInformationServiceInterface
             }
 
             $this->platformInformationRepository->updatePlatformInformation($platformInformationUpdate);
-        } catch (RemoteServerException | MenuException | PlatformException $ex) {
+        } catch (
+            RemoteServerException
+            | MenuException
+            | PlatformException
+            | RepositoryException
+            | EntityNotFoundException
+            | PlatformConflictException $ex
+        ) {
             throw $ex;
         } catch (\Exception $ex) {
             throw new PlatformInformationException(_("An error occured while your platform update"), 0, $ex);

--- a/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerServiceInterface.php
+++ b/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerServiceInterface.php
@@ -23,13 +23,15 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\RemoteServer\Interfaces;
 
+use Centreon\Domain\PlatformInformation\PlatformInformation;
+
 interface RemoteServerServiceInterface
 {
     /**
      * Convert a Central into a Remote Server
-     * @param string $centralAddress
+     * @param PlatformInformation $platformInformation
      */
-    public function convertCentralToRemote(string $centralAddress): void;
+    public function convertCentralToRemote(PlatformInformation $platformInformation): void;
 
     /**
      * Convert a Remote Server into a Central

--- a/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerServiceInterface.php
+++ b/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerServiceInterface.php
@@ -27,8 +27,9 @@ interface RemoteServerServiceInterface
 {
     /**
      * Convert a Central into a Remote Server
+     * @param string $centralAddress
      */
-    public function convertCentralToRemote(): void;
+    public function convertCentralToRemote(string $centralAddress): void;
 
     /**
      * Convert a Remote Server into a Central

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -28,6 +28,7 @@ use Centreon\Domain\PlatformTopology\Platform;
 use Centreon\Domain\PlatformTopology\PlatformException;
 use Centreon\Domain\RemoteServer\RemoteServerException;
 use Centreon\Domain\Menu\Interfaces\MenuRepositoryInterface;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRepositoryInterface;
 use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface;
@@ -51,9 +52,9 @@ class RemoteServerService implements RemoteServerServiceInterface
     private $remoteServerRepository;
 
     /**
-     * @var string
+     * @var MonitoringServerRepositoryInterface
      */
-    private $centreonEtcPath;
+    private $monitoringServerRepository;
 
     /**
      * @param MenuRepositoryInterface $menuRepository
@@ -62,17 +63,19 @@ class RemoteServerService implements RemoteServerServiceInterface
     public function __construct(
         MenuRepositoryInterface $menuRepository,
         PlatformTopologyRepositoryInterface $platformTopologyRepository,
-        RemoteServerRepositoryInterface $remoteServerRepository
+        RemoteServerRepositoryInterface $remoteServerRepository,
+        MonitoringServerRepositoryInterface $monitoringServerRepository
     ) {
         $this->menuRepository = $menuRepository;
         $this->platformTopologyRepository = $platformTopologyRepository;
         $this->remoteServerRepository = $remoteServerRepository;
+        $this->monitoringServerRepository = $monitoringServerRepository;
     }
 
     /**
      * @inheritDoc
      */
-    public function convertCentralToRemote(): void
+    public function convertCentralToRemote(string $centralAddress): void
     {
         /**
          * Stop conversion if the Central has remote children
@@ -89,6 +92,11 @@ class RemoteServerService implements RemoteServerServiceInterface
         } catch (\Exception $ex) {
             throw new RemoteServerException(_('An error occured while searching any remote children'));
         }
+
+        /**
+         * Find any children platform and forward them to Central Parent.
+         */
+        dd($this->monitoringServerRepository->findServersWithoutRequestParameters());
 
         /**
          * Set Remote type into Platform_Topology

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -114,7 +114,7 @@ class RemoteServerService implements RemoteServerServiceInterface
         /**
          * Get the parent platform to register it later.
          *
-         * @var Platform $topLevelPlatform
+         * @var Platform|null $topLevelPlatform
          */
         $topLevelPlatform = $this->platformTopologyRepository->findTopLevelPlatform();
         if ($topLevelPlatform === null) {

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -113,6 +113,8 @@ class RemoteServerService implements RemoteServerServiceInterface
 
         /**
          * Get the parent platform to register it later.
+         *
+         * @var Platform $topLevelPlatform
          */
         $topLevelPlatform = $this->platformTopologyRepository->findTopLevelPlatform();
         if ($topLevelPlatform === null) {
@@ -121,7 +123,6 @@ class RemoteServerService implements RemoteServerServiceInterface
         /**
          * Add the future Parent Central as Parent Address to be able to register it later.
          *
-         * @var Platform $topLevelPlatform
          */
         $topLevelPlatform->setParentAddress($platformInformation->getCentralServerAddress());
 

--- a/tests/api/features/PlatformInformation.feature
+++ b/tests/api/features/PlatformInformation.feature
@@ -30,7 +30,7 @@ Feature:
             "apiCredentials": "centreon",
             "apiScheme": "http",
             "apiPort": 80,
-            "centralServerAddress": "10.30.2.137",
+            "centralServerAddress": "1.1.1.10",
             "apiPath": "centreon"
         }
         """

--- a/tests/api/features/PlatformInformation.feature
+++ b/tests/api/features/PlatformInformation.feature
@@ -25,12 +25,10 @@ Feature:
         When I send a PATCH request to '/beta/platform' with body:
         """
         {
-            "isRemote": true,
             "apiUsername": "admin",
             "apiCredentials": "centreon",
             "apiScheme": "http",
             "apiPort": 80,
-            "centralServerAddress": "1.1.1.10",
             "apiPath": "centreon"
         }
         """

--- a/tests/php/Centreon/Domain/PlatformInformation/PlatformInformationServiceTest.php
+++ b/tests/php/Centreon/Domain/PlatformInformation/PlatformInformationServiceTest.php
@@ -55,7 +55,9 @@ class PlatformInformationServiceTest extends TestCase
         $this->platformInformationRepository = $this->createMock(PlatformInformationRepositoryInterface::class);
         $this->remoteServerService = $this->createMock(RemoteServerServiceInterface::class);
         $this->remoteInformation = (new PlatformInformation())->setIsRemote(true);
-        $this->centralInformation = (new PlatformInformation())->setIsCentral(true);
+        $this->centralInformation = (new PlatformInformation())
+            ->setIsCentral(true)
+            ->setCentralServerAddress('192.168.0.1');
     }
 
     /**


### PR DESCRIPTION
## Description
This PR fix an issue with the PATCH /platform, where if a platform is converted from Central to Remote, If the platform previously had Pollers, the pollers weren't registered on the target Central Platform, it was a regression compared to the old remote conversion.

**Fixes** # MON-6432

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
