### PR TITLE
fix(hostDetails): correct comments that were no longer displayed

### DIFF
--- a/www/include/monitoring/objectDetails/hostDetails.php
+++ b/www/include/monitoring/objectDetails/hostDetails.php
@@ -429,7 +429,8 @@ if (!$is_admin && !$haveAccess) {
 
         $host_status[$host_name]["is_flapping"] = $en[$host_status[$host_name]["is_flapping"]];
 
-        if (isset($host_status[$host_name]["scheduled_downtime_depth"]) &&
+        if (
+            isset($host_status[$host_name]["scheduled_downtime_depth"]) &&
             $host_status[$host_name]["scheduled_downtime_depth"]
         ) {
             $host_status[$host_name]["scheduled_downtime_depth"] = 1;
@@ -668,7 +669,8 @@ if (!$is_admin && !$haveAccess) {
         $tools = array();
         $DBRESULT = $pearDB->query("SELECT * FROM modules_informations");
         while ($module = $DBRESULT->fetchrow()) {
-            if (isset($module['host_tools']) && $module['host_tools'] == 1
+            if (
+                isset($module['host_tools']) && $module['host_tools'] == 1
                 && file_exists('modules/' . $module['name'] . '/host_tools.php')
             ) {
                 include('modules/' . $module['name'] . '/host_tools.php');

--- a/www/include/monitoring/objectDetails/hostDetails.php
+++ b/www/include/monitoring/objectDetails/hostDetails.php
@@ -353,13 +353,13 @@ if (!$is_admin && !$haveAccess) {
          * Get comments for hosts
          */
         $tabCommentHosts = array();
-        $rq2 = " SELECT cmt.entry_time as comment_time, cmt.comment_id, cmt.author AS author_name,
+        $rq2 = "SELECT cmt.entry_time as comment_time, cmt.comment_id, cmt.author AS author_name,
          cmt.data AS comment_data, cmt.persistent AS is_persistent, h.name AS host_name " .
             " FROM comments cmt, hosts h " .
-            " WHERE cmt.host_id = '" . $host_id . "' 
-                  AND h.host_id = cmt.host_id 
-                  AND cmt.service_id IS NULL 
-                  AND cmt.expires = 0 
+            " WHERE cmt.host_id = '" . $host_id . "'
+                  AND h.host_id = cmt.host_id
+                  AND cmt.type = 1
+                  AND cmt.expires = 0
                   AND (cmt.deletion_time IS NULL OR cmt.deletion_time = 0)
                   ORDER BY cmt.entry_time DESC";
         $DBRESULT = $pearDBO->query($rq2);

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -321,7 +321,7 @@
                         <div id='tab4' class='tab'>
                             <table class="ListTable">
                                 <tr class='list_lvl_1'>
-                                    <td class="ListColHeaderCenter FormHeader">{$cmt_host_name}</td>
+                                    <td class="ListColHeaderCenter FormHeader" width="200">{$cmt_host_name}</td>
                                     <td class="ListColHeaderCenter FormHeader" width="180">{$cmt_entry_time}</td>
                                     <td class="ListColHeaderCenter FormHeader" width="120">{$cmt_author}</td>
                                     <td class="ListColHeaderCenter FormHeader">{$cmt_comment}</td>
@@ -329,10 +329,10 @@
                                 </tr>
                                 {foreach item=tch from=$tab_comments_host}
                                 <tr class={cycle values="list_two, list_one"}>
-                                    <td class="ListColLeft">{$tch.host_name}</td>
-                                    <td class="ListColRight isTimestamp">{$tch.comment_time}</td>
+                                    <td class="ListColCenter">{$tch.host_name}</td>
+                                    <td class="ListColCenter isTimestamp">{$tch.comment_time}</td>
                                     <td class="ListColCenter">{$tch.author_name}</td>
-                                    <td class="ListColLeft containsURI">{$tch.comment_data}</td>
+                                    <td class="ListColCenter containsURI">{$tch.comment_data}</td>
                                     <td class="ListColCenter">{$tch.is_persistent}</td>
                                 </tr>
                                 {/foreach}


### PR DESCRIPTION
This PR intends to
- Correct the SQL request that gathers the comments of the Host detail opened.
- Improve the display of the tab by centering the data regarding the columns.
- Correct some coding style issues regarding PSR12

![image](https://user-images.githubusercontent.com/31647811/104347581-132d5b80-5501-11eb-9712-f37bf55ce6cc.png)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Put some comments on a host
- Go to Monitoring -> Host details -> Host -> tab comments
- Comments sent previously should appear

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
