### PR TITLE
fix(Resource-status/Services): only fetch services with graph data when in graph mode and fix tooltip position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,10 +1154,13 @@
       "dev": true
     },
     "@centreon/ui": {
-      "version": "github:centreon/centreon-ui#bde7afabd6d98737c75e490f50df8f3333e983e6",
+      "version": "github:centreon/centreon-ui#822f0c722c7e6865ec66d1fd78f703a139cc849c",
       "from": "github:centreon/centreon-ui",
       "requires": {
         "@centreon/ui-context": "github:centreon/ui-context",
+        "@dnd-kit/core": "^1.0.0",
+        "@dnd-kit/sortable": "^1.0.0",
+        "@dnd-kit/utilities": "^1.0.0",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.56",
@@ -1174,7 +1177,6 @@
         "react-dom": "^17.0.1",
         "react-files": "^2.4.8",
         "react-router-dom": "^5.2.0",
-        "react-sortable-hoc": "^1.11.0",
         "resize-observer-polyfill": "^1.5.1",
         "ts.data.json": "^1.2.0",
         "ulog": "^2.0.0-beta.7"
@@ -1234,6 +1236,42 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
       "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
       "dev": true
+    },
+    "@dnd-kit/accessibility": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-1.0.1.tgz",
+      "integrity": "sha512-rPkUFbhDrBHacTqEM0WlurgXLN+pBFW+o9PB6DgnREK5hNRXAxzqwGfSlrVUgdh7PK/YslAiljM//6lI9JHuAA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-shIv8YxhrgkS6tnDmfPdh3ds0U/9e9WQhBHPtEIcdvnBcT0h8mXJHrfhY1nmXVAtcYfXO7L4obABXf2a0DcX4w==",
+      "requires": {
+        "@dnd-kit/accessibility": "^1.0.1",
+        "@dnd-kit/utilities": "^1.0.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/sortable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-1.0.1.tgz",
+      "integrity": "sha512-At+qaFVIo4P8jJjmUgOYEp4fwu+7dD/DU6W0IBoVpR1JIMCtK+SwJoBpNCzqZOFuveLOwGjBodC9hI/xU+yd5A==",
+      "requires": {
+        "@dnd-kit/core": "^1.0.1",
+        "@dnd-kit/utilities": "^1.0.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/utilities": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-1.0.1.tgz",
+      "integrity": "sha512-mH0SsXw39ytNwnZ484blRKdpac0Ad3Gh3UkbsiQs0LwFoC+O/j967mS3WhP+G++mlgr6uZ2OM3BlPYZkSMOusA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@emotion/cache": {
       "version": "10.0.29",
@@ -2477,9 +2515,9 @@
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
     },
     "@types/aria-query": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
-      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
+      "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==",
       "dev": true
     },
     "@types/babel__core": {
@@ -2606,9 +2644,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g=="
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
     },
     "@types/geojson": {
       "version": "7946.0.7",
@@ -2824,9 +2862,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.25",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.25.tgz",
-      "integrity": "sha512-cr6kZ+4m9lp86ytQc1jPOJXgINQyz3kLLunZ57jznW+WIAL0JqZbGubQk4GlD42MuQL5JGOABrxdpqqWeovlVQ==",
+      "version": "4.41.26",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.26.tgz",
+      "integrity": "sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==",
       "requires": {
         "@types/anymatch": "*",
         "@types/node": "*",
@@ -2867,64 +2905,65 @@
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.12.0.tgz",
-      "integrity": "sha512-wHKj6q8s70sO5i39H2g1gtpCXCvjVszzj6FFygneNFyIAxRvNSVz9GML7XpqrB9t7hNutXw+MHnLN/Ih6uyB8Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.13.0.tgz",
+      "integrity": "sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.12.0",
-        "@typescript-eslint/scope-manager": "4.12.0",
+        "@typescript-eslint/experimental-utils": "4.13.0",
+        "@typescript-eslint/scope-manager": "4.13.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.15",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.12.0.tgz",
-      "integrity": "sha512-MpXZXUAvHt99c9ScXijx7i061o5HEjXltO+sbYfZAAHxv3XankQkPaNi5myy0Yh0Tyea3Hdq1pi7Vsh0GJb0fA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.13.0.tgz",
+      "integrity": "sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.12.0",
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/typescript-estree": "4.12.0",
+        "@typescript-eslint/scope-manager": "4.13.0",
+        "@typescript-eslint/types": "4.13.0",
+        "@typescript-eslint/typescript-estree": "4.13.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.12.0.tgz",
-      "integrity": "sha512-9XxVADAo9vlfjfoxnjboBTxYOiNY93/QuvcPgsiKvHxW6tOZx1W4TvkIQ2jB3k5M0pbFP5FlXihLK49TjZXhuQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.13.0.tgz",
+      "integrity": "sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==",
       "requires": {
-        "@typescript-eslint/scope-manager": "4.12.0",
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/typescript-estree": "4.12.0",
+        "@typescript-eslint/scope-manager": "4.13.0",
+        "@typescript-eslint/types": "4.13.0",
+        "@typescript-eslint/typescript-estree": "4.13.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.12.0.tgz",
-      "integrity": "sha512-QVf9oCSVLte/8jvOsxmgBdOaoe2J0wtEmBr13Yz0rkBNkl5D8bfnf6G4Vhox9qqMIoG7QQoVwd2eG9DM/ge4Qg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz",
+      "integrity": "sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==",
       "requires": {
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/visitor-keys": "4.12.0"
+        "@typescript-eslint/types": "4.13.0",
+        "@typescript-eslint/visitor-keys": "4.13.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g=="
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.12.0.tgz",
-      "integrity": "sha512-gZkFcmmp/CnzqD2RKMich2/FjBTsYopjiwJCroxqHZIY11IIoN0l5lKqcgoAPKHt33H2mAkSfvzj8i44Jm7F4w==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz",
+      "integrity": "sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==",
       "requires": {
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/visitor-keys": "4.12.0",
+        "@typescript-eslint/types": "4.13.0",
+        "@typescript-eslint/visitor-keys": "4.13.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -2934,25 +2973,25 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.12.0.tgz",
-      "integrity": "sha512-hVpsLARbDh4B9TKYz5cLbcdMIOAoBYgFPCSP9FFS/liSF+b33gVNq8JHY3QGhHNVz85hObvL7BEYLlgx553WCw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz",
+      "integrity": "sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==",
       "requires": {
-        "@typescript-eslint/types": "4.12.0",
+        "@typescript-eslint/types": "4.13.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
     "@visx/annotation": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/annotation/-/annotation-1.3.0.tgz",
-      "integrity": "sha512-QeIDMBfcLtp4mHzHZ3MAXGqIH0M8b7k3qJxZwEQsGVPxTqvgg1c9RHikSopCkrlGMjQncObPQJsmiZ6hCuK4ww==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/annotation/-/annotation-1.4.0.tgz",
+      "integrity": "sha512-LxskgApI1/2cMR6F+CR2KmMFSVvQwSu6ihEzjn+hhdpS9v5NUEJiTe0YwkV53yCmol9k+h1asmqc4JfIJY14nw==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/react": "*",
         "@visx/drag": "1.3.0",
         "@visx/group": "1.0.0",
         "@visx/point": "1.0.0",
-        "@visx/shape": "1.3.0",
+        "@visx/shape": "1.4.0",
         "@visx/text": "1.3.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.5.10",
@@ -2960,16 +2999,16 @@
       }
     },
     "@visx/axis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/axis/-/axis-1.3.0.tgz",
-      "integrity": "sha512-HXEdrL8olT25mF311QF6ANRi08TIaflNQlOExafw6yiQX7pc7SOLFOSCttkG8BOsrqb2av66XUEMWpKKhv94Jg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/axis/-/axis-1.4.0.tgz",
+      "integrity": "sha512-VBq170tBu+PJ1XJLk6xwzmNEXrqriaSiaP808peR3oArXd0yMOgmI+HKm18qzPS2hbdRgxZNQOnlDZvB43H95w==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/react": "*",
         "@visx/group": "1.0.0",
         "@visx/point": "1.0.0",
-        "@visx/scale": "1.3.0",
-        "@visx/shape": "1.3.0",
+        "@visx/scale": "1.4.0",
+        "@visx/shape": "1.4.0",
         "@visx/text": "1.3.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
@@ -2986,13 +3025,13 @@
       }
     },
     "@visx/brush": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/brush/-/brush-1.3.0.tgz",
-      "integrity": "sha512-TBW2XZLzsqp+A04EaU8z96MzI8KptWWfEFx3xui0iW6p6GHsB46R3CjA7jX4qD3FuhhiMX0766elcE8lvxq4qA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/brush/-/brush-1.4.0.tgz",
+      "integrity": "sha512-Hg+J45rj3csXT98/DTyzigxPFndlJ65vdR7O+JdefQ5i3XJGK6vp/HDILthG5pdyCxqyYoCtfsy+u4bqzR1nrQ==",
       "requires": {
         "@visx/drag": "1.3.0",
         "@visx/group": "1.0.0",
-        "@visx/shape": "1.3.0",
+        "@visx/shape": "1.4.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1"
       }
@@ -3073,16 +3112,16 @@
       }
     },
     "@visx/grid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-1.3.0.tgz",
-      "integrity": "sha512-PCfq2YGCt2frzuiRHtJFC5A+Bry7wP7n8n9XA14cRpiFtTmd4rfsC1gCUokIINSgiE29OklulwnMK9+dL7OWxg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-1.4.0.tgz",
+      "integrity": "sha512-POwnGByfqYlZc5MOHU2I8RFXA5qO97LVx8ibSXLk2cV44Uoif7zHwQMZ+qup3JpYDKhtvjdO6GkBJ4UCE0apmg==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/react": "*",
         "@visx/group": "1.0.0",
         "@visx/point": "1.0.0",
-        "@visx/scale": "1.3.0",
-        "@visx/shape": "1.3.0",
+        "@visx/scale": "1.4.0",
+        "@visx/shape": "1.4.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2"
       }
@@ -3125,27 +3164,27 @@
       }
     },
     "@visx/legend": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/legend/-/legend-1.3.0.tgz",
-      "integrity": "sha512-QcUhSn2dmUk9a4rfasvwUZ82CAwYTMg8y3sVmt360K55C4sHkx3r+y0OHfls9klHHIOvDpbryoX9UmtKymQn/A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/legend/-/legend-1.4.0.tgz",
+      "integrity": "sha512-NkYfk62D+uHOkcsury5OqnTNnzbSakuwbocqwn3DHdE/jdpJIJVx9gh3OBHWqdIIallLhnT7p2oBtDuN8lrsvw==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/react": "*",
         "@visx/group": "1.0.0",
-        "@visx/scale": "1.3.0",
+        "@visx/scale": "1.4.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.5.10"
       }
     },
     "@visx/marker": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/marker/-/marker-1.3.0.tgz",
-      "integrity": "sha512-rj/VZykundKxRrZT7HwWndPZxQUfPiJQO92vmrxnLPtJK7y7v2ZtnwlWNMNORBabSb8/MzkXNN+d2S6ckteshQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/marker/-/marker-1.4.0.tgz",
+      "integrity": "sha512-UelBxlyzIjrj0YAWo80TL/tc2dBpqD4Fz0/+W7i1d6c2y4Y5lEp9SxRVK3nl4LmHd2dZAQe5XOmreKhiFvq3PQ==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/react": "*",
         "@visx/group": "1.0.0",
-        "@visx/shape": "1.3.0",
+        "@visx/shape": "1.4.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2"
       }
@@ -3200,9 +3239,9 @@
       }
     },
     "@visx/scale": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-1.3.0.tgz",
-      "integrity": "sha512-u7ksnRs4UE0Q0sydTCcK4SYX+X9deQoAQ9wc6tYUKBspzFeYejIP+NO4fRTtjLsKpYFXad34HKW7vErL7f8FZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-1.4.0.tgz",
+      "integrity": "sha512-uNy/hsZCmCtL1hC7rTasMUtf9/faG/QcXNtQioe6VYwtbZxCMR53+yvz3W1oqAW8Y0bslGfKRMzT8T29OjAD/g==",
       "requires": {
         "@types/d3-interpolate": "^1.3.1",
         "@types/d3-scale": "^3.2.1",
@@ -3213,9 +3252,9 @@
       }
     },
     "@visx/shape": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-1.3.0.tgz",
-      "integrity": "sha512-cysfz1VghSOlhYYR6n3hOKdm1xihmiZJjC5E43eZwnWQGjmqvdlwy+6Cxq4sn1wQwaxj6UD4QfLzxiPSlAQeqg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-1.4.0.tgz",
+      "integrity": "sha512-iTeFGtsidHXoeEyfriwRj7vkgs3BYqXWuDVe/uW4kpn76u7M0LhRCy59ADlufYDn+19qdA/rVPv4oD6nrWMhCw==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/d3-path": "^1.0.8",
@@ -3224,7 +3263,7 @@
         "@types/react": "*",
         "@visx/curve": "1.0.0",
         "@visx/group": "1.0.0",
-        "@visx/scale": "1.3.0",
+        "@visx/scale": "1.4.0",
         "classnames": "^2.2.5",
         "d3-path": "^1.0.5",
         "d3-shape": "^1.2.0",
@@ -3260,14 +3299,14 @@
       }
     },
     "@visx/visx": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@visx/visx/-/visx-1.3.0.tgz",
-      "integrity": "sha512-wWVSoSCwloBcNsiXGoUkuQ+uqmIpkBKK+VTd4a/ODc7QtmyrlaXEWrPVJrSts5M84KswI2heFbUPRzVREaH5Gw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@visx/visx/-/visx-1.4.0.tgz",
+      "integrity": "sha512-5fv10x3JaEAShkZM73d/hTY4oA8nRSaIJ33B8utYci9jBBDHx5p7fpWBK1ocdlLwMzQnoU3oUxO5NcG0FK6Sow==",
       "requires": {
-        "@visx/annotation": "1.3.0",
-        "@visx/axis": "1.3.0",
+        "@visx/annotation": "1.4.0",
+        "@visx/axis": "1.4.0",
         "@visx/bounds": "1.0.0",
-        "@visx/brush": "1.3.0",
+        "@visx/brush": "1.4.0",
         "@visx/clip-path": "1.0.0",
         "@visx/curve": "1.0.0",
         "@visx/drag": "1.3.0",
@@ -3275,19 +3314,19 @@
         "@visx/geo": "1.0.0",
         "@visx/glyph": "1.0.0",
         "@visx/gradient": "1.0.0",
-        "@visx/grid": "1.3.0",
+        "@visx/grid": "1.4.0",
         "@visx/group": "1.0.0",
         "@visx/heatmap": "1.0.0",
         "@visx/hierarchy": "1.0.0",
-        "@visx/legend": "1.3.0",
-        "@visx/marker": "1.3.0",
+        "@visx/legend": "1.4.0",
+        "@visx/marker": "1.4.0",
         "@visx/mock-data": "1.0.0",
         "@visx/network": "1.1.0",
         "@visx/pattern": "1.1.0",
         "@visx/point": "1.0.0",
         "@visx/responsive": "1.3.0",
-        "@visx/scale": "1.3.0",
-        "@visx/shape": "1.3.0",
+        "@visx/scale": "1.4.0",
+        "@visx/shape": "1.4.0",
         "@visx/text": "1.3.0",
         "@visx/tooltip": "1.3.0",
         "@visx/voronoi": "1.0.0",
@@ -4971,9 +5010,9 @@
       }
     },
     "call-bind": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.1.tgz",
-      "integrity": "sha512-tvAvUwNcRikl3RVF20X9lsYmmepsovzTWeJiXjO0PkJp15uy/6xKFZOQtuiSULwYW+6ToZBprphCgWXC2dSgcQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -5014,13 +5053,6 @@
       "requires": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "camelcase": {
@@ -5126,6 +5158,13 @@
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "ci-info": {
@@ -6674,13 +6713,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "dot-prop": {
@@ -6771,9 +6803,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.635",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.635.tgz",
-      "integrity": "sha512-RRriZOLs9CpW6KTLmgBqyUdnY0QNqqWs0HOtuQGGEMizOTNNn1P7sGRBxARnUeLejOsgwjDyRqT3E/CSst02ZQ=="
+      "version": "1.3.636",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.636.tgz",
+      "integrity": "sha512-Adcvng33sd3gTjNIDNXGD1G4H6qCImIy2euUJAQHtLNplEKU5WEz5KRJxupRNIIT8sD5oFZLTKBWAf12Bsz24A=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -6825,9 +6857,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -8331,6 +8363,13 @@
         "react-fast-compare": "^2.0.1",
         "tiny-warning": "^1.0.2",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "forwarded": {
@@ -9025,9 +9064,9 @@
       }
     },
     "html-react-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.1.1.tgz",
-      "integrity": "sha512-z2O8aeh36Bnn17AtRReEZckpzVUaqRMsY8TMIxCyjQhCblQuN8l2D4mWY7V2bdLL7B2/FS4YD/dpndxuHtvYIQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.1.2.tgz",
+      "integrity": "sha512-nR2UNyJvH9kY/GnVFd0XUbctl/ic02Zpr/FrOREwTp84nqnxqN+tCGa3arJrg0j+UbdZWK+bJYdAMbXWOJru6Q==",
       "requires": {
         "html-dom-parser": "1.0.0",
         "react-property": "1.0.1",
@@ -12016,13 +12055,6 @@
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "lru-cache": {
@@ -12649,13 +12681,6 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "node-forge": {
@@ -13405,13 +13430,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "parent-module": {
@@ -13462,13 +13480,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "pascalcase": {
@@ -16259,16 +16270,6 @@
         }
       }
     },
-    "react-sortable-hoc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
-      "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
-      }
-    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
@@ -16386,9 +16387,9 @@
       }
     },
     "recharts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.0.0.tgz",
-      "integrity": "sha512-0ZoqQJEmhC47uZnbiOCgswS1pKj0ur4jXrnhFUT0armMNRAMPLl5sYvcq45+DKlGBlW6Zsu6DK95y/cZOlWY/w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.0.2.tgz",
+      "integrity": "sha512-oDpAgG0UfvidQpDI4CHJV7GvGLVD/P3XxpJxwcakA76ln3gPWsOVtuXls2IseTXzeZZKPAEvSrdjdykjlCWGUw==",
       "requires": {
         "classnames": "^2.2.5",
         "d3-interpolate": "^2.0.1",
@@ -17443,9 +17444,9 @@
       }
     },
     "sass-loader": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.0.tgz",
-      "integrity": "sha512-ZCKAlczLBbFd3aGAhowpYEy69Te3Z68cg8bnHHl6WnSCvnKpbM6pQrz957HWMa8LKVuhnD9uMplmMAHwGQtHeg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.1.tgz",
+      "integrity": "sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==",
       "dev": true,
       "requires": {
         "klona": "^2.0.4",
@@ -19069,9 +19070,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsutils": {
       "version": "3.19.1",
@@ -19079,6 +19080,13 @@
       "integrity": "sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==",
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "tty-browserify": {
@@ -19808,9 +19816,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.12.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.12.3.tgz",
-      "integrity": "sha512-7tiQmcTnKhZwbf7X7sEfXe0pgkGjUZjT6JfYkZHvvIb4/ZsXl1rJu5PxsJoN7W3v5sNSP/8TgBoiOdDqVdvK5w==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.13.0.tgz",
+      "integrity": "sha512-NPhMEtfhSVegp1FNPkCM1MPygDm0GHwpreG10dh//0Gr0epfB0br9nlgEfxSghxJqrQ7j9XzgO91CGGLWZiHeA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -19821,7 +19829,7 @@
         "acorn": "^8.0.4",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.3.1",
+        "enhanced-resolve": "^5.6.0",
         "eslint-scope": "^5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -19838,6 +19846,12 @@
         "webpack-sources": "^2.1.1"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "0.0.45",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
+          "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+          "dev": true
+        },
         "@webassemblyjs/ast": {
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
@@ -19974,9 +19988,9 @@
           "dev": true
         },
         "enhanced-resolve": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.1.tgz",
-          "integrity": "sha512-4GbyIMzYktTFoRSmkbgZ1LU+RXwf4AQ8Z+rSuuh1dC8plp0PPeaWvx6+G4hh4KnUJ48VoxKbNyA1QQQIUpXjYA==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.6.0.tgz",
+          "integrity": "sha512-C3GGDfFZmqUa21o10YRKbZN60DPl0HyXKXxoEnQMWso9u7KMU23L7CBHfr/rVxORddY/8YQZaU2MZ1ewTS8Pcw==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.4",

--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -13,13 +13,13 @@ const MemoizedPerformanceGraph = React.memo(
     const nextResource = nextProps.resource;
     const prevPeriodQueryParameters = prevProps.periodQueryParameters;
     const nextPeriodQueryParameters = nextProps.periodQueryParameters;
-    const prevTooltipX = prevProps.tooltipX;
-    const nextTooltipX = nextProps.tooltipX;
+    const prevTooltipPosition = prevProps.tooltipPosition;
+    const nextTooltipPosition = nextProps.tooltipPosition;
 
     return (
       equals(prevResource?.id, nextResource?.id) &&
       equals(prevPeriodQueryParameters, nextPeriodQueryParameters) &&
-      equals(prevTooltipX, nextTooltipX)
+      equals(prevTooltipPosition, nextTooltipPosition)
     );
   },
 );
@@ -39,7 +39,9 @@ const ServiceGraphs = ({
   getIntervalDates,
   selectedTimePeriod,
 }: Props): JSX.Element => {
-  const [tooltipX, setTooltipX] = React.useState<number>();
+  const [tooltipPosition, setTooltipPosition] = React.useState<
+    [number, number]
+  >();
 
   const servicesWithGraph = services.filter(
     pipe(path(['links', 'endpoints', 'performance_graph']), isNil, not),
@@ -59,8 +61,8 @@ const ServiceGraphs = ({
               periodQueryParameters={periodQueryParameters}
               getIntervalDates={getIntervalDates}
               selectedTimePeriod={selectedTimePeriod}
-              onTooltipDisplay={setTooltipX}
-              tooltipX={tooltipX}
+              onTooltipDisplay={setTooltipPosition}
+              tooltipPosition={tooltipPosition}
             />
             {isLastService && <div ref={infiniteScrollTriggerRef} />}
           </div>

--- a/www/front_src/src/Resources/Details/tabs/Services/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/index.tsx
@@ -98,6 +98,7 @@ const ServicesTab = ({ details }: TabProps): JSX.Element => {
       limit,
       page: atPage,
       resourceTypes: ['service'],
+      onlyWithPerformanceData: graphMode ? true : undefined,
       search: {
         conditions: [
           {

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -59,8 +59,8 @@ interface Props {
   getIntervalDates: () => [string, string];
   periodQueryParameters: string;
   graphHeight: number;
-  onTooltipDisplay?: (x?: number) => void;
-  tooltipX?: number;
+  onTooltipDisplay?: (position?: [number, number]) => void;
+  tooltipPosition?: [number, number];
 }
 
 const ExportablePerformanceGraphWithTimeline = ({
@@ -70,7 +70,7 @@ const ExportablePerformanceGraphWithTimeline = ({
   periodQueryParameters,
   graphHeight,
   onTooltipDisplay,
-  tooltipX,
+  tooltipPosition,
 }: Props): JSX.Element => {
   const classes = useStyles();
   const { t } = useTranslation();
@@ -215,7 +215,7 @@ const ExportablePerformanceGraphWithTimeline = ({
           timeline={timeline}
           onAddComment={addCommentToTimeline}
           onTooltipDisplay={onTooltipDisplay}
-          tooltipX={tooltipX}
+          tooltipPosition={tooltipPosition}
         />
       </div>
     </Paper>

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -79,8 +79,8 @@ interface Props {
   base: number;
   lines: Array<LineModel>;
   xAxisTickFormat: string;
-  tooltipX?: number;
-  onTooltipDisplay?: (tooltipX?: number) => void;
+  tooltipPosition?: [number, number];
+  onTooltipDisplay?: (tooltipPosition?: [number, number]) => void;
   timeline?: Array<TimelineEvent>;
   resource: Resource | ResourceDetails;
   onAddComment?: (commentParameters: CommentParameters) => void;
@@ -137,7 +137,7 @@ const Graph = ({
   lines,
   xAxisTickFormat,
   timeline,
-  tooltipX,
+  tooltipPosition,
   onTooltipDisplay,
   resource,
   onAddComment,
@@ -294,7 +294,7 @@ const Graph = ({
 
       showTooltipAt({ x, y });
 
-      onTooltipDisplay?.(x);
+      onTooltipDisplay?.([x, y]);
     },
     [showTooltip, containerBounds, lines],
   );
@@ -304,13 +304,15 @@ const Graph = ({
       return;
     }
 
-    if (isNil(tooltipX)) {
+    if (isNil(tooltipPosition)) {
       hideTooltip();
       return;
     }
 
-    showTooltipAt({ x: tooltipX, y: 20 });
-  }, [tooltipX]);
+    const [x, y] = tooltipPosition;
+
+    showTooltipAt({ x, y });
+  }, [tooltipPosition]);
 
   const closeTooltip = (): void => {
     hideTooltip();

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -29,8 +29,8 @@ interface Props {
   resource: Resource | ResourceDetails;
   timeline?: Array<TimelineEvent>;
   onAddComment?: (commentParameters: CommentParameters) => void;
-  tooltipX?: number;
-  onTooltipDisplay?: (x?: number) => void;
+  tooltipPosition?: [number, number];
+  onTooltipDisplay?: (position?: [number, number]) => void;
 }
 
 const useStyles = makeStyles<Theme, Pick<Props, 'graphHeight'>>((theme) => ({
@@ -64,7 +64,7 @@ const PerformanceGraph = ({
   toggableLegend = false,
   eventAnnotationsActive = false,
   timeline,
-  tooltipX,
+  tooltipPosition,
   onTooltipDisplay,
   resource,
   onAddComment,
@@ -156,7 +156,7 @@ const PerformanceGraph = ({
             xAxisTickFormat={xAxisTickFormat}
             timeline={timeline}
             onTooltipDisplay={onTooltipDisplay}
-            tooltipX={tooltipX}
+            tooltipPosition={tooltipPosition}
             resource={resource}
             onAddComment={onAddComment}
             eventAnnotationsActive={eventAnnotationsActive}

--- a/www/front_src/src/Resources/Listing/api/endpoint.ts
+++ b/www/front_src/src/Resources/Listing/api/endpoint.ts
@@ -8,6 +8,7 @@ export type ListResourcesProps = {
   statuses: Array<string>;
   hostGroupIds: Array<number>;
   serviceGroupIds: Array<number>;
+  onlyWithPerformanceData?: boolean;
 } & ListingParameters;
 
 const buildResourcesEndpoint = (parameters: ListResourcesProps): string => {
@@ -20,6 +21,10 @@ const buildResourcesEndpoint = (parameters: ListResourcesProps): string => {
       { name: 'statuses', value: parameters.statuses },
       { name: 'hostgroup_ids', value: parameters.hostGroupIds },
       { name: 'servicegroup_ids', value: parameters.serviceGroupIds },
+      {
+        name: 'only_with_performance_data',
+        value: parameters.onlyWithPerformanceData,
+      },
     ],
   });
 };


### PR DESCRIPTION
## Description
This fetches services with graph data only when displayed in graph mode. It also adapts the tooltip Y of the adjacent graphes to the one currently hovered.  

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x (master)

