### PR TITLE
fix(Resource-status/Timeline): Fix timeline events date ordering

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
@@ -46,7 +46,7 @@ const Events = ({ timeline, infiniteScrollTriggerRef }: Props): JSX.Element => {
       pipe(prop('date'), toDate),
     ),
     toPairs,
-    sortWith([descend(head)]),
+    sortWith([descend(pipe(head, Date.parse))]),
   )(timeline) as DateEvents;
 
   const dates = eventsByDate.map(head);


### PR DESCRIPTION
## Description
This prevents the timeline events to appear in an incorect order. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x
- [x] 21.04.x (master)

