### PR TITLE
fix(configuration): "Conf changed" yes is green instead of red

### DIFF
--- a/www/include/configuration/configServers/listServers.php
+++ b/www/include/configuration/configServers/listServers.php
@@ -204,7 +204,8 @@ foreach ($servers as $config) {
     $confChangedMessage = _("N/A");
     $hasChanged = false;
     if ($config["ns_activate"] && isset($nagiosRestart[$config['id']])) {
-        $confChangedMessage = $changeStateServers[$config['id']] ? _("Yes") : _("No");
+        $hasChanged = $changeStateServers[$config['id']];
+        $confChangedMessage = $hasChanged ? _("Yes") : _("No");
     }
 
     // Manage flag for update time


### PR DESCRIPTION
## Description

Fix "Conf changed" yes is green instead of red

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Without the patch, "Conf changed" yes is green instead of red

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
