### PR TITLE
chore(documentation): add missing property in platform/topology documentation

### DIFF
--- a/doc/API/centreon-api-v2.1.yaml
+++ b/doc/API/centreon-api-v2.1.yaml
@@ -2546,6 +2546,10 @@ paths:
                                     type: string
                                     description: physical name of a platform
                                     example: "localhost.localdomain"
+                                  address:
+                                    type: string
+                                    description: address of a platform
+                                    example: "192.168.0.1"
                       edges:
                         type: array
                         minItems: 0

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -2666,6 +2666,10 @@ paths:
                                     type: string
                                     description: physical name of a platform
                                     example: "localhost.localdomain"
+                                  address:
+                                    type: string
+                                    description: address of a platform
+                                    example: "192.168.0.1"
                       edges:
                         type: array
                         minItems: 0


### PR DESCRIPTION
## Description

Add a missing property into API Documentation for GET /platform/topology endpoint.

**Fixes** # MON-5789

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)