### PR TITLE
enh(API): refactor DELETE platform/topology/id 

### DIFF
--- a/config/packages/prod/Centreon.yaml
+++ b/config/packages/prod/Centreon.yaml
@@ -253,10 +253,14 @@ services:
     Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface:
         class: Centreon\Domain\RemoteServer\RemoteServerService
 
-    Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface:
+    Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryFileInterface:
         class: Centreon\Infrastructure\RemoteServer\RemoteServerRepositoryFile
         calls:
             - [setCentreonConfFilePath, ['%centreon_etc_path%/conf.pm']]
+
+    Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface:
+        class: Centreon\Infrastructure\RemoteServer\RemoteServerRepositoryRDB
+
     # Menu
     Centreon\Domain\Menu\Interfaces\MenuRepositoryInterface:
         class: Centreon\Infrastructure\Menu\MenuRepositoryRDB

--- a/config/packages/prod/Centreon.yaml
+++ b/config/packages/prod/Centreon.yaml
@@ -253,7 +253,7 @@ services:
     Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface:
         class: Centreon\Domain\RemoteServer\RemoteServerService
 
-    Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryFileInterface:
+    Centreon\Domain\RemoteServer\Interfaces\RemoteServerLocalConfigurationRepositoryInterface:
         class: Centreon\Infrastructure\RemoteServer\RemoteServerRepositoryFile
         calls:
             - [setCentreonConfFilePath, ['%centreon_etc_path%/conf.pm']]

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15149,6 +15149,10 @@ msgstr "Erreur lors de la recherche de ressources"
 msgid "Error when searching for monitoring servers"
 msgstr "Erreur lors de la recherche de serveurs de supervision"
 
+#:Centreon/Domain/MonitoringServer/MonitoringServerService.php:142
+msgid "Error when deleting a monitoring server"
+msgstr "Erreur lors de la supression d'un serveur de supervision"
+
 #:Centreon/Domain/MonitoringServer/MonitoringServerService.php:69
 msgid "Error when searching for a resource of monitoring server"
 msgstr "Erreur lors de la recherche de la ressource attachée au serveur de supervision"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15701,8 +15701,15 @@ msgid "Unable to decipher central's credentials. Please check the credentials in
 msgstr "Impossible de déchiffrer les identifiants du Central. Veuillez vérifier le formulaire 'Accès du Remote'"
 
 #: api/platform/topology
-msgid "Failed to get the auth token. Cannot register the platform : '%s'@'%s' on the Central"
-msgstr "Echec d'obtention du token d'auth. Impossible d'enregistrer sur le Central: '%s'@'%s'"
+msgid "Failed to get the auth token from Central : '%s'"
+msgstr "Echec d'obtention du token d'auth. sur le Central: '%s'@'%s'"
+
+#: api/platform/topology
+msgid "The platform: '%s'@'%s' cannot be found on the Central"
+msgstr "La plateforme: '%s'@'%s' ne peut pas être trouvé sur le Central"
+
+msgid "The platform: '%s'@'%s' cannot be delete from the Central"
+msgstr "La plateforme: '%s'@'%s' ne peut pas être supprimé depuis le Central"
 
 #: api/platform/topology
 msgid "Request to the Central's API failed"

--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\MonitoringServer\Interfaces;
 
-use Centreon\Domain\Entity\EntityCreator;
+
 use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\MonitoringServer\MonitoringServerException;
 use Centreon\Domain\MonitoringServer\MonitoringServerResource;
-use Centreon\Infrastructure\MonitoringServer\MonitoringServerRepositoryRDB;
+
 
 interface MonitoringServerRepositoryInterface
 {
@@ -88,4 +88,11 @@ interface MonitoringServerRepositoryInterface
      * @throws MonitoringServerException
      */
     public function findServerByName(string $monitoringServerName): ?MonitoringServer;
+
+    /**
+     * Delete a monitoring server.
+     *
+     * @param integer $monitoringServerId
+     */
+    public function deleteServer(int $monitoringServerId): void;
 }

--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
@@ -18,15 +18,14 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Centreon\Domain\MonitoringServer\Interfaces;
 
-
 use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\MonitoringServer\MonitoringServerException;
 use Centreon\Domain\MonitoringServer\MonitoringServerResource;
-
 
 interface MonitoringServerRepositoryInterface
 {

--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerServiceInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerServiceInterface.php
@@ -25,7 +25,6 @@ namespace Centreon\Domain\MonitoringServer\Interfaces;
 use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\MonitoringServer\MonitoringServerException;
 use Centreon\Domain\MonitoringServer\MonitoringServerResource;
-use Centreon\Domain\MonitoringServer\MonitoringServerService;
 
 interface MonitoringServerServiceInterface
 {
@@ -81,4 +80,12 @@ interface MonitoringServerServiceInterface
      * @throws MonitoringServerException
      */
     public function findServerByName(string $monitoringServerName): ?MonitoringServer;
+
+    /**
+     * Delete a monitoring server.
+     *
+     * @param integer $monitoringServerId
+     * @throws MonitoringServerException
+     */
+    public function deleteServer(int $monitoringServerId): void;
 }

--- a/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
+++ b/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
@@ -130,4 +130,16 @@ class MonitoringServerService implements MonitoringServerServiceInterface
             throw new MonitoringServerException('Error when notifying a configuration change', 0, $ex);
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteServer(int $monitoringServerId): void
+    {
+        try {
+            $this->monitoringServerRepository->deleteServer($monitoringServerId);
+        } catch (\Exception $ex) {
+            throw new MonitoringServerException('Error when deleting a monitoring server', 0, $ex);
+        }
+    }
 }

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
@@ -115,7 +115,7 @@ class PlatformInformationService implements PlatformInformationServiceInterface
                     );
                 }
             } elseif ($platformInformationUpdate->isCentral() && !$currentPlatformInformation->isCentral()) {
-                $this->remoteServerService->convertRemoteToCentral();
+                $this->remoteServerService->convertRemoteToCentral($platformInformationUpdate);
             }
 
             $this->platformInformationRepository->updatePlatformInformation($platformInformationUpdate);

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRegisterRepositoryInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRegisterRepositoryInterface.php
@@ -44,4 +44,19 @@ interface PlatformTopologyRegisterRepositoryInterface
         PlatformInformation $platformInformation,
         Proxy $proxy = null
     ): void;
+
+    /**
+     * Delete the platform on its parent
+     *
+     * @param Platform $platform
+     * @param PlatformInformation $platformInformation
+     * @param Proxy $proxy
+     * @throws RepositoryException
+     * @throws PlatformConflictException
+     */
+    public function deletePlatformToParent(
+        Platform $platform,
+        PlatformInformation $platformInformation,
+        Proxy $proxy = null
+    ): void;
 }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -664,6 +664,8 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                 }
 
                 $this->monitoringServerService->deleteServer($deletedPlatform->getServerId());
+            } else {
+                $this->platformTopologyRepository->deletePlatform($deletedPlatform->getId());
             }
         } catch (EntityNotFoundException | PlatformException $ex) {
             throw $ex;

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -39,6 +39,7 @@ use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyServiceInterface
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRepositoryInterface;
 use Centreon\Domain\PlatformInformation\Interfaces\PlatformInformationServiceInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRegisterRepositoryInterface;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface;
 
 /**
  * Service intended to register a new server to the platform topology
@@ -83,6 +84,11 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     private $brokerRepository;
 
     /**
+     * @var RemoteServerRepositoryInterface
+     */
+    private $remoteServerRepository;
+
+    /**
      * Broker Retention Parameter
      */
     public const BROKER_PEER_RETENTION = "one_peer_retention_mode";
@@ -105,7 +111,8 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
         EngineConfigurationServiceInterface $engineConfigurationService,
         MonitoringServerServiceInterface $monitoringServerService,
         BrokerRepositoryInterface $brokerRepository,
-        PlatformTopologyRegisterRepositoryInterface $platformTopologyRegisterRepository
+        PlatformTopologyRegisterRepositoryInterface $platformTopologyRegisterRepository,
+        RemoteServerRepositoryInterface $remoteServerRepository
     ) {
         $this->platformTopologyRepository = $platformTopologyRepository;
         $this->platformInformationService = $platformInformationService;
@@ -114,6 +121,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
         $this->monitoringServerService = $monitoringServerService;
         $this->brokerRepository = $brokerRepository;
         $this->platformTopologyRegisterRepository = $platformTopologyRegisterRepository;
+        $this->remoteServerRepository = $remoteServerRepository;
     }
 
     /**
@@ -616,7 +624,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     public function deletePlatformAndReallocateChildren(int $serverId): void
     {
         try {
-            if ($this->platformTopologyRepository->findPlatform($serverId) === null) {
+            if (($deletedPlatform = $this->platformTopologyRepository->findPlatform($serverId)) === null) {
                 throw new EntityNotFoundException(_('Platform not found'));
             }
             /**
@@ -638,14 +646,25 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                 }
 
                 /**
-                 * Update children parent_id
+                 * Update children parent_id.
                  */
                 foreach ($childPlatforms as $platform) {
                     $platform->setParentId($topLevelPlatform->getId());
                     $this->updatePlatformParameters($platform);
                 }
             }
-            $this->platformTopologyRepository->deletePlatform($serverId);
+
+            /**
+             * Delete the monitoring server and the topology.
+             */
+            if ($deletedPlatform->getServerId() !== null) {
+                if($deletedPlatform->getType() === Platform::TYPE_REMOTE) {
+                    $this->remoteServerRepository->deleteRemoteServerByAddress($deletedPlatform->getAddress());
+                    $this->remoteServerRepository->deleteAdditionalRemoteServer($deletedPlatform->getServerId());
+                }
+
+                $this->monitoringServerService->deleteServer($deletedPlatform->getServerId());
+            }
         } catch (EntityNotFoundException | PlatformException $ex) {
             throw $ex;
         } catch (\Exception $ex) {

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -658,7 +658,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
              * Delete the monitoring server and the topology.
              */
             if ($deletedPlatform->getServerId() !== null) {
-                if($deletedPlatform->getType() === Platform::TYPE_REMOTE) {
+                if ($deletedPlatform->getType() === Platform::TYPE_REMOTE) {
                     $this->remoteServerRepository->deleteRemoteServerByAddress($deletedPlatform->getAddress());
                     $this->remoteServerRepository->deleteAdditionalRemoteServer($deletedPlatform->getServerId());
                 }

--- a/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerLocalConfigurationRepositoryInterface.php
+++ b/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerLocalConfigurationRepositoryInterface.php
@@ -23,7 +23,10 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\RemoteServer\Interfaces;
 
-interface RemoteServerRepositoryFileInterface
+/**
+ * This inteface is designed to configure the local instance mode of the platform.
+ */
+interface RemoteServerLocalConfigurationRepositoryInterface
 {
     /**
      * Update the platform instance mode to Central.

--- a/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerRepositoryFileInterface.php
+++ b/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerRepositoryFileInterface.php
@@ -23,19 +23,15 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\RemoteServer\Interfaces;
 
-use Centreon\Domain\PlatformInformation\PlatformInformation;
-
-interface RemoteServerServiceInterface
+interface RemoteServerRepositoryFileInterface
 {
     /**
-     * Convert a Central into a Remote Server
-     * @param PlatformInformation $platformInformation
+     * Update the instance mode of centreon to Central.
      */
-    public function convertCentralToRemote(PlatformInformation $platformInformation): void;
+    public function updateInstanceModeCentral(): void;
 
     /**
-     * Convert a Remote Server into a Central
-     * @param PlatformInformation $platformInformation
+     * Update the instance mode of centreon to Remote.
      */
-    public function convertRemoteToCentral(PlatformInformation $platformInformation): void;
+    public function updateInstanceModeRemote(): void;
 }

--- a/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerRepositoryFileInterface.php
+++ b/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerRepositoryFileInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,12 +26,12 @@ namespace Centreon\Domain\RemoteServer\Interfaces;
 interface RemoteServerRepositoryFileInterface
 {
     /**
-     * Update the instance mode of centreon to Central.
+     * Update the platform instance mode to Central.
      */
     public function updateInstanceModeCentral(): void;
 
     /**
-     * Update the instance mode of centreon to Remote.
+     * Update the platform instance mode to Remote.
      */
     public function updateInstanceModeRemote(): void;
 }

--- a/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerRepositoryInterface.php
+++ b/src/Centreon/Domain/RemoteServer/Interfaces/RemoteServerRepositoryInterface.php
@@ -26,12 +26,16 @@ namespace Centreon\Domain\RemoteServer\Interfaces;
 interface RemoteServerRepositoryInterface
 {
     /**
-     * Update the instance mode of centreon to Central.
+     * Delete a Remote Server.
+     *
+     * @param string $address
      */
-    public function updateInstanceModeCentral(): void;
+    public function deleteRemoteServerByAddress(string $address): void;
 
     /**
-     * Update the instance mode of centreon to Remote.
+     * Delete an Additional Remote Server, for pollers linked to multiple Remote Servers.
+     *
+     * @param integer $monitoringServerId
      */
-    public function updateInstanceModeRemote(): void;
+    public function deleteAdditionalRemoteServer(int $monitoringServerId): void;
 }

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -68,6 +68,9 @@ class RemoteServerService implements RemoteServerServiceInterface
      */
     private $proxyService;
 
+    /**
+     * @var MonitoringServerServiceInterface
+     */
     private $monitoringServerService;
 
     /**

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -25,17 +25,14 @@ namespace Centreon\Domain\RemoteServer;
 
 use Centreon\Domain\Menu\MenuException;
 use Centreon\Domain\PlatformTopology\Platform;
-use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Domain\Exception\EntityNotFoundException;
 use Centreon\Domain\PlatformTopology\PlatformException;
 use Centreon\Domain\RemoteServer\RemoteServerException;
 use Centreon\Domain\Proxy\Interfaces\ProxyServiceInterface;
 use Centreon\Domain\Menu\Interfaces\MenuRepositoryInterface;
 use Centreon\Domain\PlatformInformation\PlatformInformation;
-use Centreon\Domain\PlatformTopology\PlatformConflictException;
 use Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface;
-use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryFileInterface;
-use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerLocalConfigurationRepositoryInterface;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerServiceInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRepositoryInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRegisterRepositoryInterface;
@@ -54,7 +51,7 @@ class RemoteServerService implements RemoteServerServiceInterface
     private $platformTopologyRepository;
 
     /**
-     * @var RemoteServerRepositoryFileInterface
+     * @var RemoteServerLocalConfigurationRepositoryInterface
      */
     private $remoteServerRepository;
 
@@ -80,7 +77,7 @@ class RemoteServerService implements RemoteServerServiceInterface
     public function __construct(
         MenuRepositoryInterface $menuRepository,
         PlatformTopologyRepositoryInterface $platformTopologyRepository,
-        RemoteServerRepositoryFileInterface $remoteServerRepository,
+        RemoteServerLocalConfigurationRepositoryInterface $remoteServerRepository,
         PlatformTopologyRegisterRepositoryInterface $platformTopologyRegisterRepository,
         ProxyServiceInterface $proxyService,
         MonitoringServerServiceInterface $monitoringServerService

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -171,7 +171,8 @@ class RemoteServerService implements RemoteServerServiceInterface
     public function convertRemoteToCentral(PlatformInformation $platformInformation): void
     {
         /**
-         * Delete the platform on its parent.
+         * Delete the platform on its parent before anything else,
+         * If this step throw an exception, don't go further and avoid decorelation betweens platforms.
          */
         $platform = $this->platformTopologyRepository->findTopLevelPlatform();
         $this->platformTopologyRegisterRepository->deletePlatformToParent(

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -34,7 +34,7 @@ use Centreon\Domain\Menu\Interfaces\MenuRepositoryInterface;
 use Centreon\Domain\PlatformInformation\PlatformInformation;
 use Centreon\Domain\PlatformTopology\PlatformConflictException;
 use Centreon\Domain\RemoteServer\Interfaces\RemoteServerServiceInterface;
-use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryFileInterface;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRepositoryInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRegisterRepositoryInterface;
@@ -53,7 +53,7 @@ class RemoteServerService implements RemoteServerServiceInterface
     private $platformTopologyRepository;
 
     /**
-     * @var RemoteServerRepositoryInterface
+     * @var RemoteServerRepositoryFileInterface
      */
     private $remoteServerRepository;
 
@@ -74,7 +74,7 @@ class RemoteServerService implements RemoteServerServiceInterface
     public function __construct(
         MenuRepositoryInterface $menuRepository,
         PlatformTopologyRepositoryInterface $platformTopologyRepository,
-        RemoteServerRepositoryInterface $remoteServerRepository,
+        RemoteServerRepositoryFileInterface $remoteServerRepository,
         PlatformTopologyRegisterRepositoryInterface $platformTopologyRegisterRepository,
         ProxyServiceInterface $proxyService
     ) {
@@ -168,8 +168,18 @@ class RemoteServerService implements RemoteServerServiceInterface
     /**
      * @inheritDoc
      */
-    public function convertRemoteToCentral(): void
+    public function convertRemoteToCentral(PlatformInformation $platformInformation): void
     {
+        /**
+         * Delete the platform on its parent.
+         */
+        $platform = $this->platformTopologyRepository->findTopLevelPlatform();
+        $this->platformTopologyRegisterRepository->deletePlatformToParent(
+            $platform,
+            $platformInformation,
+            $this->proxyService->getProxy()
+        );
+
         /**
          * Set Central type into Platform_Topology
          */

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -188,7 +188,7 @@ class RemoteServerService implements RemoteServerServiceInterface
 
         /**
          * Find any children platform and remove them,
-         * as they now attached to the Central and no longer to this platform.
+         * as they are now attached to the Central and no longer to this platform.
          *
          * @var Platform[] $childrenPlatforms
          */

--- a/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
@@ -230,7 +230,7 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
     public function findResource(int $monitoringServerId, string $resourceName): ?MonitoringServerResource
     {
         $request = $this->translateDbName(
-            'SELECT resource.* FROM `:db`.cfg_resource resource 
+            'SELECT resource.* FROM `:db`.cfg_resource resource
             INNER JOIN `:db`.cfg_resource_instance_relations rel
                 ON rel.resource_id = resource.resource_id
             WHERE rel.instance_id = :monitoring_server_id
@@ -272,5 +272,15 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
             $statement->bindValue(':server_name', $monitoringServer->getName(), \PDO::PARAM_STR);
             $statement->execute();
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteServer(int $monitoringServerId): void
+    {
+        $statement = $this->db->prepare($this->translateDbName("DELETE FROM `:db`.nagios_server WHERE id = :id"));
+        $statement->bindValue(':id', $monitoringServerId, \PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -73,26 +73,26 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
      *
      * @param Platform $platform
      * @param PlatformInformation $platformInformation
-     * @param Proxy $proxyService
+     * @param Proxy $proxy
      * @return string
      */
     private function getToken(
         Platform $platform,
         PlatformInformation $platformInformation,
-        Proxy $proxyService = null
+        Proxy $proxy = null
     ): string {
         // Central's API endpoints base path building
         $this->baseApiEndpoint = $platformInformation->getApiScheme() . '://'
             . $platformInformation->getCentralServerAddress() . ':'
-            . $platformInformation->getApiPort() . '/'
+            . $platformInformation->getApiPort() . DIRECTORY_SEPARATOR
             . $platformInformation->getApiPath() . '/api/v'
-            . ((string) $this->apiPlatform->getVersion()) . '/';
+            . ((string) $this->apiPlatform->getVersion()) . DIRECTORY_SEPARATOR;
 
         // Enable specific options
         $optionPayload = [];
         // Enable proxy
-        if (null !== $proxyService && !empty((string) $proxyService)) {
-            $optionPayload['proxy'] = (string) $proxyService;
+        if (null !== $proxy && !empty((string) $proxy)) {
+            $optionPayload['proxy'] = (string) $proxy;
         }
         // On https scheme, the SSL verify_peer needs to be specified
         if ('https' === $platformInformation->getApiScheme()) {
@@ -142,14 +142,14 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
     public function registerPlatformToParent(
         Platform $platform,
         PlatformInformation $platformInformation,
-        Proxy $proxyService = null
+        Proxy $proxy = null
     ): void {
         /**
          * Call the API on the n-1 server to register it too
          */
         try {
             // Get a Token
-            $token = $this->getToken($platform, $platformInformation, $proxyService);
+            $token = $this->getToken($platform, $platformInformation, $proxy);
 
             // Central's API register platform payload
             $registerPayload = [
@@ -219,13 +219,16 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
         }
     }
 
+    /**
+     * @inheritDoc
+     */
     public function deletePlatformToParent(
         Platform $platform,
         PlatformInformation $platformInformation,
-        ?Proxy $proxyService = null
+        ?Proxy $proxy = null
     ): void {
         try {
-            $token = $this->getToken($platform, $platformInformation, $proxyService);
+            $token = $this->getToken($platform, $platformInformation, $proxy);
 
             $getPayload = [
                 'headers' => [

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -61,7 +61,6 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
      * PlatformTopologyRegisterRepositoryAPI constructor.
      * @param HttpClientInterface $httpClient
      * @param ApiPlatform $apiPlatform
-     * @throws RepositoryException
      */
     public function __construct(HttpClientInterface $httpClient, ApiPlatform $apiPlatform)
     {
@@ -74,6 +73,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
      *
      * @param PlatformInformation $platformInformation
      * @param Proxy $proxy
+     * @throws RepositoryException
      * @return string
      */
     private function getToken(

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -79,8 +79,8 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
     private function getToken(
         Platform $platform,
         PlatformInformation $platformInformation,
-        Proxy $proxyService = null): string
-    {
+        Proxy $proxyService = null
+    ): string {
         // Central's API endpoints base path building
         $this->baseApiEndpoint = $platformInformation->getApiScheme() . '://'
             . $platformInformation->getCentralServerAddress() . ':'
@@ -222,8 +222,8 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
     public function deletePlatformToParent(
         Platform $platform,
         PlatformInformation $platformInformation,
-        ?Proxy $proxyService = null): void
-    {
+        ?Proxy $proxyService = null
+    ): void {
         try {
             $token = $this->getToken($platform, $platformInformation, $proxyService);
 
@@ -262,7 +262,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
 
             $platformToDeleteId = null;
             foreach ($platformsOnParent as $topologyId => $platformOnParent) {
-                if($platformOnParent['metadata']['address'] === $platform->getAddress()) {
+                if ($platformOnParent['metadata']['address'] === $platform->getAddress()) {
                     $platformToDeleteId = $topologyId;
                 }
             }

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -61,6 +61,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
      * PlatformTopologyRegisterRepositoryAPI constructor.
      * @param HttpClientInterface $httpClient
      * @param ApiPlatform $apiPlatform
+     * @throws RepositoryException
      */
     public function __construct(HttpClientInterface $httpClient, ApiPlatform $apiPlatform)
     {
@@ -71,13 +72,11 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
     /**
      * Get a valid token to request the API.
      *
-     * @param Platform $platform
      * @param PlatformInformation $platformInformation
      * @param Proxy $proxy
      * @return string
      */
     private function getToken(
-        Platform $platform,
         PlatformInformation $platformInformation,
         Proxy $proxy = null
     ): string {
@@ -149,7 +148,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
          */
         try {
             // Get a Token
-            $token = $this->getToken($platform, $platformInformation, $proxy);
+            $token = $this->getToken($platformInformation, $proxy);
 
             // Central's API register platform payload
             $registerPayload = [
@@ -228,7 +227,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
         ?Proxy $proxy = null
     ): void {
         try {
-            $token = $this->getToken($platform, $platformInformation, $proxy);
+            $token = $this->getToken($platformInformation, $proxy);
 
             $getPayload = [
                 'headers' => [
@@ -244,7 +243,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             // Get request status code and return the error message
             if (Response::HTTP_OK !== $getResponse->getStatusCode()) {
                 $errorMessage = sprintf(
-                    _("The remote: '%s'@'%s' cannot be found to the Central"),
+                    _("The platform: '%s'@'%s' cannot be found on the Central"),
                     $platform->getName(),
                     $platform->getAddress()
                 );
@@ -271,7 +270,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             }
 
             if ($platformToDeleteId === null) {
-                throw new PlatformConflictException(_("The platform '%s'@'%s' can't be found on the Central."));
+                throw new PlatformConflictException(_("The platform '%s'@'%s' cannot be found on the Central."));
             }
 
             $deletePayload = [
@@ -288,7 +287,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             // Get request status code and return the error message
             if (Response::HTTP_NO_CONTENT !== $deleteResponse->getStatusCode()) {
                 $errorMessage = sprintf(
-                    _("The remote: '%s'@'%s' cannot be delete from the Central"),
+                    _("The platform: '%s'@'%s' cannot be delete from the Central"),
                     $platform->getName(),
                     $platform->getAddress()
                 );

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -86,7 +86,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             . $platformInformation->getCentralServerAddress() . ':'
             . $platformInformation->getApiPort() . DIRECTORY_SEPARATOR
             . $platformInformation->getApiPath() . '/api/v'
-            . ((string) $this->apiPlatform->getVersion()) . DIRECTORY_SEPARATOR;
+            . ((string) $this->apiPlatform->getVersion());
 
         // Enable specific options
         $optionPayload = [];
@@ -119,7 +119,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
         // Login on the Central to get a valid token
         $loginResponse = $this->httpClient->request(
             'POST',
-            $this->baseApiEndpoint . 'login',
+            $this->baseApiEndpoint . '/login',
             $loginPayload
         );
 
@@ -167,7 +167,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
 
             $registerResponse = $this->httpClient->request(
                 'POST',
-                $this->baseApiEndpoint . 'platform/topology',
+                $this->baseApiEndpoint . '/platform/topology',
                 $registerPayload
             );
 
@@ -237,7 +237,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             ];
             $getResponse = $this->httpClient->request(
                 'GET',
-                $this->baseApiEndpoint . 'platform/topology/',
+                $this->baseApiEndpoint . '/platform/topology/',
                 $getPayload
             );
 
@@ -281,7 +281,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             ];
             $deleteResponse = $this->httpClient->request(
                 'DELETE',
-                $this->baseApiEndpoint . 'platform/topology/' . $platformToDeleteId,
+                $this->baseApiEndpoint . '/platform/topology/' . $platformToDeleteId,
                 $deletePayload
             );
 

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -51,6 +51,13 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
     private $apiPlatform;
 
     /**
+     * Central's API endpoints base path
+     *
+     * @var string
+     */
+    private $baseApiEndpoint;
+
+    /**
      * PlatformTopologyRegisterRepositoryAPI constructor.
      * @param HttpClientInterface $httpClient
      * @param ApiPlatform $apiPlatform
@@ -59,6 +66,74 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
     {
         $this->httpClient = $httpClient;
         $this->apiPlatform = $apiPlatform;
+    }
+
+    /**
+     * Get a valid token to request the API.
+     *
+     * @param Platform $platform
+     * @param PlatformInformation $platformInformation
+     * @param Proxy $proxyService
+     * @return string
+     */
+    private function getToken(
+        Platform $platform,
+        PlatformInformation $platformInformation,
+        Proxy $proxyService = null): string
+    {
+        // Central's API endpoints base path building
+        $this->baseApiEndpoint = $platformInformation->getApiScheme() . '://'
+            . $platformInformation->getCentralServerAddress() . ':'
+            . $platformInformation->getApiPort() . '/'
+            . $platformInformation->getApiPath() . '/api/v'
+            . ((string) $this->apiPlatform->getVersion()) . '/';
+
+        // Enable specific options
+        $optionPayload = [];
+        // Enable proxy
+        if (null !== $proxyService && !empty((string) $proxyService)) {
+            $optionPayload['proxy'] = (string) $proxyService;
+        }
+        // On https scheme, the SSL verify_peer needs to be specified
+        if ('https' === $platformInformation->getApiScheme()) {
+            $optionPayload['verify_peer'] = $platformInformation->hasApiPeerValidation();
+            $optionPayload['verify_host'] = $platformInformation->hasApiPeerValidation();
+        }
+        // Set the options for next http_client calls
+        if (!empty($optionPayload)) {
+            $this->httpClient = HttpClient::create($optionPayload);
+        }
+
+        // Central's API login payload
+        $loginPayload = [
+            'json' => [
+                "security" => [
+                    "credentials" => [
+                        "login" => $platformInformation->getApiUsername(),
+                        "password" => $platformInformation->getApiCredentials()
+                    ]
+                ]
+            ]
+        ];
+
+        // Login on the Central to get a valid token
+        $loginResponse = $this->httpClient->request(
+            'POST',
+            $this->baseApiEndpoint . 'login',
+            $loginPayload
+        );
+
+        $token = $loginResponse->toArray()['security']['token'] ?? false;
+
+        if (false === $token) {
+            throw new RepositoryException(
+                sprintf(
+                    _("Failed to get the auth token from Central : '%s''"),
+                    $platformInformation->getCentralServerAddress()
+                )
+            );
+        }
+        return $token;
     }
 
     /**
@@ -73,60 +148,8 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
          * Call the API on the n-1 server to register it too
          */
         try {
-            // Central's API endpoints base path
-
-            $baseApiEndpoint = $platformInformation->getApiScheme() . '://'
-                . $platformInformation->getCentralServerAddress() . ':'
-                . $platformInformation->getApiPort() . '/'
-                . $platformInformation->getApiPath() . '/api/v'
-                . ((string) $this->apiPlatform->getVersion()) . '/';
-
-            // Enable specific options
-            $optionPayload = [];
-            // Enable proxy
-            if (null !== $proxyService && !empty((string) $proxyService)) {
-                $optionPayload['proxy'] = (string) $proxyService;
-            }
-            // On https scheme, the SSL verify_peer needs to be specified
-            if ('https' === $platformInformation->getApiScheme()) {
-                $optionPayload['verify_peer'] = $platformInformation->hasApiPeerValidation();
-                $optionPayload['verify_host'] = $platformInformation->hasApiPeerValidation();
-            }
-            // Set the options for next http_client calls
-            if (!empty($optionPayload)) {
-                $this->httpClient = HttpClient::create($optionPayload);
-            }
-
-            // Central's API login payload
-            $loginPayload = [
-                'json' => [
-                    "security" => [
-                        "credentials" => [
-                            "login" => $platformInformation->getApiUsername(),
-                            "password" => $platformInformation->getApiCredentials()
-                        ]
-                    ]
-                ]
-            ];
-
-            // Login on the Central to get a valid token
-            $loginResponse = $this->httpClient->request(
-                'POST',
-                $baseApiEndpoint . 'login',
-                $loginPayload
-            );
-
-            $token = $loginResponse->toArray()['security']['token'] ?? false;
-
-            if (false === $token) {
-                throw new RepositoryException(
-                    sprintf(
-                        _("Failed to get the auth token. Cannot register the platform : '%s'@'%s' on the Central"),
-                        $platform->getName(),
-                        $platform->getAddress()
-                    )
-                );
-            }
+            // Get a Token
+            $token = $this->getToken($platform, $platformInformation, $proxyService);
 
             // Central's API register platform payload
             $registerPayload = [
@@ -144,7 +167,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
 
             $registerResponse = $this->httpClient->request(
                 'POST',
-                $baseApiEndpoint . 'platform/topology',
+                $this->baseApiEndpoint . 'platform/topology',
                 $registerPayload
             );
 
@@ -192,6 +215,117 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
         } catch (\Exception $e) {
             throw new RepositoryException(
                 _("Error from Central's register API") . (' : ') . $e->getMessage()
+            );
+        }
+    }
+
+    public function deletePlatformToParent(
+        Platform $platform,
+        PlatformInformation $platformInformation,
+        ?Proxy $proxyService = null): void
+    {
+        try {
+            $token = $this->getToken($platform, $platformInformation, $proxyService);
+
+            $getPayload = [
+                'headers' => [
+                    "X-AUTH-TOKEN" => $token
+                ]
+            ];
+            $getResponse = $this->httpClient->request(
+                'GET',
+                $this->baseApiEndpoint . 'platform/topology/',
+                $getPayload
+            );
+
+            // Get request status code and return the error message
+            if (Response::HTTP_OK !== $getResponse->getStatusCode()) {
+                $errorMessage = sprintf(
+                    _("The remote: '%s'@'%s' cannot be found to the Central"),
+                    $platform->getName(),
+                    $platform->getAddress()
+                );
+                $returnedMessage = json_decode($getResponse->getContent(false), true);
+
+                if (!empty($returnedMessage)) {
+                    $errorMessage .= "  /  " . _("Central's response => Code : ") .
+                        implode(', ', $returnedMessage);
+                }
+                throw new PlatformConflictException(
+                    $errorMessage
+                );
+            }
+
+            // Parse the response body to found the platform we want to delete
+            $responseBody = json_decode($getResponse->getContent(false), true);
+            $platformsOnParent = $responseBody['graph']['nodes'];
+
+            $platformToDeleteId = null;
+            foreach ($platformsOnParent as $topologyId => $platformOnParent) {
+                if($platformOnParent['metadata']['address'] === $platform->getAddress()) {
+                    $platformToDeleteId = $topologyId;
+                }
+            }
+
+            if ($platformToDeleteId === null) {
+                throw new PlatformConflictException(_("The platform '%s'@'%s' can't be found on the Central."));
+            }
+
+            $deletePayload = [
+                'headers' => [
+                    "X-AUTH-TOKEN" => $token
+                ]
+            ];
+            $deleteResponse = $this->httpClient->request(
+                'DELETE',
+                $this->baseApiEndpoint . 'platform/topology/' . $platformToDeleteId,
+                $deletePayload
+            );
+
+            // Get request status code and return the error message
+            if (Response::HTTP_NO_CONTENT !== $deleteResponse->getStatusCode()) {
+                $errorMessage = sprintf(
+                    _("The remote: '%s'@'%s' cannot be delete from the Central"),
+                    $platform->getName(),
+                    $platform->getAddress()
+                );
+                $returnedMessage = json_decode($deleteResponse->getContent(false), true);
+
+                if (!empty($returnedMessage)) {
+                    $errorMessage .= "  /  " . _("Central's response => Code : ") .
+                        implode(', ', $returnedMessage);
+                }
+                throw new PlatformConflictException(
+                    $errorMessage
+                );
+            }
+        } catch (TransportExceptionInterface $e) {
+            throw new RepositoryException(
+                _("Request to the Central's API failed") . (' : ') . $e->getMessage()
+            );
+        } catch (ClientExceptionInterface $e) {
+            throw new RepositoryException(
+                _("API calling the Central returned a Client exception") . (' : ') . $e->getMessage()
+            );
+        } catch (RedirectionExceptionInterface $e) {
+            throw new RepositoryException(
+                _("API calling the Central returned a Redirection exception") . (' : ') . $e->getMessage()
+            );
+        } catch (ServerExceptionInterface $e) {
+            $message = _("API calling the Central returned a Server exception");
+            if (!empty($optionPayload['proxy'])) {
+                $message .= '. ' . _("Please check the 'Centreon UI' form and your proxy configuration");
+            }
+            throw new RepositoryException(
+                $message . (' : ') . $e->getMessage()
+            );
+        } catch (DecodingExceptionInterface $e) {
+            throw new RepositoryException(
+                _("Unable to convert Central's API response") . (' : ') . $e->getMessage()
+            );
+        } catch (\Exception $e) {
+            throw new RepositoryException(
+                _("Error from Central's API") . (' : ') . $e->getMessage()
             );
         }
     }

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRegisterRepositoryAPI.php
@@ -237,7 +237,7 @@ class PlatformTopologyRegisterRepositoryAPI implements PlatformTopologyRegisterR
             ];
             $getResponse = $this->httpClient->request(
                 'GET',
-                $this->baseApiEndpoint . '/platform/topology/',
+                $this->baseApiEndpoint . '/platform/topology',
                 $getPayload
             );
 

--- a/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
+++ b/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace Centreon\Infrastructure\RemoteServer;
 
-use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryFileInterface;
 
-class RemoteServerRepositoryFile implements RemoteServerRepositoryInterface
+class RemoteServerRepositoryFile implements RemoteServerRepositoryFileInterface
 {
 
     /**

--- a/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
+++ b/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace Centreon\Infrastructure\RemoteServer;
 
-use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryFileInterface;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerLocalConfigurationRepositoryInterface;
 
-class RemoteServerRepositoryFile implements RemoteServerRepositoryFileInterface
+class RemoteServerRepositoryFile implements RemoteServerLocalConfigurationRepositoryInterface
 {
 
     /**

--- a/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryRDB.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Infrastructure\RemoteServer;
+
+use Centreon\Domain\MonitoringServer\MonitoringServer;
+use Centreon\Infrastructure\DatabaseConnection;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface;
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+
+class RemoteServerRepositoryRDB extends AbstractRepositoryDRB implements RemoteServerRepositoryInterface
+{
+    /**
+     * RemoteServerRepositoryRDB constructor.
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteRemoteServerByAddress(string $address): void
+    {
+        $statement = $this->db->prepare($this->translateDbName("DELETE FROM remote_servers WHERE ip = :address"));
+        $statement->bindValue(':address', $address, \PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteAdditionalRemoteServer(int $monitoringServerId): void
+    {
+        $statement = $this->db->prepare($this->translateDbName("DELETE FROM rs_poller_relation WHERE remote_server_id = :id"));
+        $statement->bindValue(':id', $monitoringServerId, \PDO::PARAM_INT);
+        $statement->execute();
+    }
+}

--- a/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryRDB.php
@@ -53,7 +53,9 @@ class RemoteServerRepositoryRDB extends AbstractRepositoryDRB implements RemoteS
      */
     public function deleteAdditionalRemoteServer(int $monitoringServerId): void
     {
-        $statement = $this->db->prepare($this->translateDbName("DELETE FROM rs_poller_relation WHERE remote_server_id = :id"));
+        $statement = $this->db->prepare(
+            $this->translateDbName("DELETE FROM rs_poller_relation WHERE remote_server_id = :id")
+        );
         $statement->bindValue(':id', $monitoringServerId, \PDO::PARAM_INT);
         $statement->execute();
     }

--- a/tests/php/Centreon/Domain/PlatformTopology/PlatformTopologyServiceTest.php
+++ b/tests/php/Centreon/Domain/PlatformTopology/PlatformTopologyServiceTest.php
@@ -45,6 +45,7 @@ use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerServiceInterface
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRepositoryInterface;
 use Centreon\Domain\PlatformInformation\Interfaces\PlatformInformationServiceInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRegisterRepositoryInterface;
+use Centreon\Domain\RemoteServer\Interfaces\RemoteServerRepositoryInterface;
 
 class PlatformTopologyServiceTest extends TestCase
 {
@@ -114,9 +115,16 @@ class PlatformTopologyServiceTest extends TestCase
     protected $brokerRepository;
 
     /**
-     * @var PlatformRegisterRepositoryInterface
+     * @var PlatformTopologyRegisterRepositoryInterface&MockObject $platformTopologyRegisterRepository
      */
     private $platformTopologyRegisterRepository;
+
+    /**
+     * Undocumented variable
+     *
+     * @var RemoteServerRepositoryInterface&MockObject $remoteServerRepository
+     */
+    private $remoteServerRepository;
 
     /**
      * initiate query data
@@ -167,6 +175,7 @@ class PlatformTopologyServiceTest extends TestCase
         $this->platformTopologyRegisterRepository = $this->createMock(
             PlatformTopologyRegisterRepositoryInterface::class
         );
+        $this->remoteServerRepository = $this->createMock(RemoteServerRepositoryInterface::class);
     }
 
     /**
@@ -203,7 +212,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         $this->expectException(PlatformConflictException::class);
@@ -250,7 +260,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         $this->expectException(EntityNotFoundException::class);
@@ -299,7 +310,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         $this->assertNull($platformTopologyService->addPlatformToTopology($this->platform));
@@ -336,7 +348,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         $this->assertIsArray($platformTopologyService->getPlatformTopology());
@@ -364,7 +377,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         /**
@@ -424,7 +438,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         /**
@@ -464,7 +479,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         $this->assertEquals(null, $platformTopologyService->deletePlatformAndReallocateChildren(
@@ -486,7 +502,8 @@ class PlatformTopologyServiceTest extends TestCase
             $this->engineConfigurationService,
             $this->monitoringServerService,
             $this->brokerRepository,
-            $this->platformTopologyRegisterRepository
+            $this->platformTopologyRegisterRepository,
+            $this->remoteServerRepository
         );
 
         $this->expectException(EntityNotFoundException::class);


### PR DESCRIPTION
## Description

This PR is a rework of DELETE platform/topology/id endpoint.
- Now when deleting a platform from a topology will also totally remove the platform (not only the topology)
- When a Remote is reconverted to a Central, Delete it from its previous parent.

**Fixes** # MON-6553

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
