### PR TITLE
fix(security) fix host status default data filter

### DIFF
--- a/www/include/configuration/configObject/host/listHost.php
+++ b/www/include/configuration/configObject/host/listHost.php
@@ -219,12 +219,13 @@ $form->addElement('select2', 'template', "", array(), $attrHosttemplates);
 
 //select2 Host Status
 $attrHostStatus = null;
+$statusDefault = '';
 if ($status) {
     $statusDefault = array($statusFilter[$status] => $status);
-    $attrHostStatus = array(
-        'defaultDataset' => $statusDefault
-    );
 }
+$attrHostStatus = array(
+    'defaultDataset' => $statusDefault
+);
 $form->addElement('select2', 'status', "", $statusFilter, $attrHostStatus);
 
 $attrBtnSuccess = array(


### PR DESCRIPTION
## Description

Sanitize default select2 parameters on host listing configuration.

Fixes # MON-5923

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
