### PR TITLE
fix(select2): do not fetch default data if id is not set

### DIFF
--- a/www/lib/HTML/QuickForm/select2.php
+++ b/www/lib/HTML/QuickForm/select2.php
@@ -475,6 +475,8 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
     public function setDefaultAjaxDatas()
     {
         if (preg_match('/id=$/', $this->_defaultDatasetRoute)) {
+            // do not fetch data if id is not set
+            // it happens when creating a new object
             return '';
         }
 

--- a/www/lib/HTML/QuickForm/select2.php
+++ b/www/lib/HTML/QuickForm/select2.php
@@ -474,6 +474,10 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
      */
     public function setDefaultAjaxDatas()
     {
+        if (preg_match('/id=$/', $this->_defaultDatasetRoute)) {
+            return '';
+        }
+
         $ajaxDefaultDatas = '$request' . $this->getName() . ' = jQuery.ajax({
             url: "' . $this->_defaultDatasetRoute . '",
         });


### PR DESCRIPTION
## Description

Do not fetch default data if id is not set
It avoids to get some errors with http code 400 when add a new object (eg: add a new host)

**Fixes** MON-6633

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Open browser console
* Create a new host
* Check that no error 400 is thrown in browser console