### PR TITLE
fix(secu): use the cron to remove expired sessions

### DIFF
--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -50,7 +50,6 @@ $centreonLog = new CentreonLog();
  * Define the period between two update in second for LDAP user/contactgroup
  */
 define('LDAP_UPDATE_PERIOD', 3600);
-define('SESSION_DEFAULT_DURATION', 120);
 
 /**
  * CentAcl script
@@ -111,35 +110,6 @@ try {
             $errorMessage = "centAcl marked as running. Exiting...";
         }
         programExit($errorMessage);
-    }
-
-    /**
-     * Remove expired sessions
-     */
-    // Find duration of session_expiration
-    $sessionDuration = SESSION_DEFAULT_DURATION;
-    $durationQuery = $pearDB->query("SELECT `value` from options where `key` = 'session_expire'");
-    if (($duration = $durationQuery->fetch(\PDO::FETCH_ASSOC)) !== false) {
-        $sessionDuration = $duration['value'];
-    } else {
-        // cannot find the default value. setting a new value
-        $pearDB->query("DELETE FROM options WHERE `key` = 'session_expire'");
-        $pearDB->query("INSERT INTO options (`key`, `value`) VALUES ('session_expire', '$sessionDuration')");
-    }
-
-    // Get users sessions list
-    $sessionQuery = $pearDB->query("SELECT `id`, `last_reload` FROM session");
-    $expiredSessions = [];
-    $expirationTime = time() - ($sessionDuration * 60);
-    while ($row = $sessionQuery->fetch(\PDO::FETCH_ASSOC)) {
-        if ($row['last_reload'] < $expirationTime) {
-            $expiredSessions[] = $row['id'];
-        }
-    }
-    if (!empty($expiredSessions)) {
-        // remove the sessions
-        $expiredSessions = implode(', ', $expiredSessions);
-        $pearDB->query("DELETE FROM session WHERE `id` IN ($expiredSessions)");
     }
 
     /**

--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -130,8 +130,8 @@ try {
     // Get users sessions list
     $sessionQuery = $pearDB->query("SELECT `id`, `last_reload` FROM session");
     $expiredSessions = [];
+    $expirationTime = time() - ($sessionDuration * 60);
     while ($row = $sessionQuery->fetch(\PDO::FETCH_ASSOC)) {
-        $expirationTime = time() - ($sessionDuration * 60);
         if ($row['last_reload'] < $expirationTime) {
             $expiredSessions[] = $row['id'];
         }

--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -50,6 +50,7 @@ $centreonLog = new CentreonLog();
  * Define the period between two update in second for LDAP user/contactgroup
  */
 define('LDAP_UPDATE_PERIOD', 3600);
+define('SESSION_DEFAULT_DURATION', 120);
 
 /**
  * CentAcl script
@@ -116,14 +117,14 @@ try {
      * Remove expired sessions
      */
     // Find duration of session_expiration
-    $sessionDuration = 120;
+    $sessionDuration = SESSION_DEFAULT_DURATION;
     $durationQuery = $pearDB->query("SELECT `value` from options where `key` = 'session_expire'");
     if (($duration = $durationQuery->fetch(\PDO::FETCH_ASSOC)) !== false) {
         $sessionDuration = $duration['value'];
     } else {
         // cannot find the default value. setting a new value
         $pearDB->query("DELETE FROM options WHERE `key` = 'session_expire'");
-        $pearDB->query("INSERT INTO options (`key`, `value`) VALUES ('session_expire', '120')");
+        $pearDB->query("INSERT INTO options (`key`, `value`) VALUES ('session_expire', '$sessionDuration')");
     }
 
     // Get users sessions list

--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -229,7 +229,6 @@ try {
                 }
                 $pearDB->commit();
                 $res1->closeCursor();
-
             } catch (\PDOException $e) {
                 $pearDB->rollBack();
                 $centreonLog->insertLog(

--- a/cron/session.php
+++ b/cron/session.php
@@ -1,0 +1,96 @@
+#!@PHP_BIN@
+<?php
+
+/*
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . "/../config/centreon.config.php");
+include_once _CENTREON_PATH_ . "/cron/centAcl-Func.php";
+include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
+include_once _CENTREON_PATH_ . "/www/class/centreonLog.class.php";
+
+$centreonLog = new CentreonLog();
+
+// Default session duration
+define('SESSION_DEFAULT_DURATION', 120);
+
+try {
+    // Init DB connections
+    $pearDB = new CentreonDB();
+
+    /**
+     * Remove expired sessions
+     */
+    // Find duration of session_expiration
+    $sessionDuration = SESSION_DEFAULT_DURATION;
+    $durationQuery = $pearDB->query("SELECT `value` from options where `key` = 'session_expire'");
+    if (($duration = $durationQuery->fetch(\PDO::FETCH_ASSOC)) !== false) {
+        $sessionDuration = $duration['value'];
+    } else {
+        // cannot find the default value. setting a new value
+        $pearDB->query("DELETE FROM options WHERE `key` = 'session_expire'");
+        $pearDB->query("INSERT INTO options (`key`, `value`) VALUES ('session_expire', '$sessionDuration')");
+        $centreonLog->insertLog(
+                1,
+                "Cannot find session duration value. Setting a default value of " .
+                SESSION_DEFAULT_DURATION . " minutes"
+        );
+    }
+
+    // Get users sessions list
+    $sessionQuery = $pearDB->query(
+        "SELECT s.id, s.last_reload, c.contact_alias AS account
+        FROM `session` s INNER JOIN `contact` c ON c.contact_id = s.user_id"
+    );
+    $expiredSessions = [];
+    $userSessions = [];
+    $expirationTime = time() - ($sessionDuration * 60);
+    while ($row = $sessionQuery->fetch(\PDO::FETCH_ASSOC)) {
+        if ($row['last_reload'] < $expirationTime) {
+            $expiredSessions[] = $row['id'];
+            $userSessions[] = $row['account'];
+        }
+    }
+    if (!empty($expiredSessions)) {
+        // remove the sessions
+        $expiredSessions = implode(', ', $expiredSessions);
+        $pearDB->query("DELETE FROM session WHERE `id` IN ($expiredSessions)");
+        // log session removed in login.log
+        foreach ($userSessions as $userSession) {
+            $centreonLog->insertLog(1, "Remove expired session of : " . $userSession);
+        }
+    }
+} catch (Exception $e) {
+    programExit($e->getMessage());
+}

--- a/cron/session.php
+++ b/cron/session.php
@@ -35,15 +35,15 @@
  *
  */
 
+// Default session duration
+define('SESSION_DEFAULT_DURATION', 120);
+
 require_once realpath(__DIR__ . "/../config/centreon.config.php");
 include_once _CENTREON_PATH_ . "/cron/centAcl-Func.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonLog.class.php";
 
 $centreonLog = new CentreonLog();
-
-// Default session duration
-define('SESSION_DEFAULT_DURATION', 120);
 
 try {
     // Init DB connections
@@ -62,9 +62,9 @@ try {
         $pearDB->query("DELETE FROM options WHERE `key` = 'session_expire'");
         $pearDB->query("INSERT INTO options (`key`, `value`) VALUES ('session_expire', '$sessionDuration')");
         $centreonLog->insertLog(
-                1,
-                "Cannot find session duration value. Setting a default value of " .
-                SESSION_DEFAULT_DURATION . " minutes"
+            1,
+            "Cannot find session duration value. Setting a default value of " .
+            SESSION_DEFAULT_DURATION . " minutes"
         );
     }
 

--- a/cron/session.php
+++ b/cron/session.php
@@ -71,7 +71,7 @@ try {
         $pearDB->query("DELETE FROM session WHERE `id` IN ($expiredSessions)");
         // log removed sessions in login.log
         foreach ($userSessions as $userSession) {
-            $centreonLog->insertLog(1, "Remove expired session of: " . $userSession);
+            $centreonLog->insertLog(1, "[CRON] [127.0.0.1] Remove expired session '$userSession'");
         }
     }
 } catch (Exception $e) {

--- a/cron/session.php
+++ b/cron/session.php
@@ -2,34 +2,19 @@
 <?php
 
 /*
- * Copyright 2005-2021 Centreon
- * Centreon is developed by : Julien Mathis and Romain Le Merlus under
- * GPL Licence 2.0.
+ * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation ; either version 2 of the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Linking this program statically or dynamically with other modules is making a
- * combined work based on this program. Thus, the terms and conditions of the GNU
- * General Public License cover the whole combination.
- *
- * As a special exception, the copyright holders of this program give Centreon
- * permission to link this program with independent modules to produce an executable,
- * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of Centreon choice, provided that
- * Centreon also meet, for each linked independent module, the terms  and conditions
- * of the license of that module. An independent module is a module which is not
- * derived from this program. If you modify this program, you may extend this
- * exception to your version of the program, but you are not obliged to do so. If you
- * do not wish to do so, delete this exception statement from your version.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * For more information : contact@centreon.com
  *
@@ -88,7 +73,7 @@ try {
         $pearDB->query("DELETE FROM session WHERE `id` IN ($expiredSessions)");
         // log session removed in login.log
         foreach ($userSessions as $userSession) {
-            $centreonLog->insertLog(1, "Remove expired session of : " . $userSession);
+            $centreonLog->insertLog(1, "Remove expired session of: " . $userSession);
         }
     }
 } catch (Exception $e) {

--- a/cron/session.php
+++ b/cron/session.php
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cron/session.php
+++ b/cron/session.php
@@ -35,15 +35,15 @@
  *
  */
 
-// Default session duration
-define('SESSION_DEFAULT_DURATION', 120);
-
 require_once realpath(__DIR__ . "/../config/centreon.config.php");
 include_once _CENTREON_PATH_ . "/cron/centAcl-Func.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonLog.class.php";
 
 $centreonLog = new CentreonLog();
+
+// Default session duration
+define('SESSION_DEFAULT_DURATION', 120);
 
 try {
     // Init DB connections

--- a/cron/session.php
+++ b/cron/session.php
@@ -25,8 +25,8 @@ include_once _CENTREON_PATH_ . "/cron/centAcl-Func.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonLog.class.php";
 
-$centreonLog = new CentreonLog();
 $pearDB = new CentreonDB();
+$centreonLog = new CentreonUserLog(0, $pearDB);
 
 // Default session duration
 define('SESSION_DEFAULT_DURATION', 120);

--- a/cron/session.php
+++ b/cron/session.php
@@ -71,7 +71,7 @@ try {
         // remove the sessions
         $expiredSessions = implode(', ', $expiredSessions);
         $pearDB->query("DELETE FROM session WHERE `id` IN ($expiredSessions)");
-        // log session removed in login.log
+        // log removed sessions in login.log
         foreach ($userSessions as $userSession) {
             $centreonLog->insertLog(1, "Remove expired session of: " . $userSession);
         }

--- a/cron/session.php
+++ b/cron/session.php
@@ -26,14 +26,12 @@ include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonLog.class.php";
 
 $centreonLog = new CentreonLog();
+$pearDB = new CentreonDB();
 
 // Default session duration
 define('SESSION_DEFAULT_DURATION', 120);
 
 try {
-    // Init DB connections
-    $pearDB = new CentreonDB();
-
     /**
      * Remove expired sessions
      */

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -542,6 +542,14 @@ check_result $? "$(gettext "Change macros for centAcl.php")"
 cp -f $TMP_DIR/work/cron/centAcl.php \
     $TMP_DIR/final/cron/centAcl.php >> "$LOG_FILE" 2>&1
 
+log "INFO" "$(gettext "Change macros for session.php")"
+${SED} -e 's|@PHP_BIN@|'"$PHP_BIN"'|g' \
+    $TMP_DIR/src/cron/session.php > $TMP_DIR/work/cron/session.php
+check_result $? "$(gettext "Change macros for session.php")"
+
+cp -f $TMP_DIR/work/cron/session.php \
+    $TMP_DIR/final/cron/session.php >> "$LOG_FILE" 2>&1
+
 log "INFO" "$(gettext "Change macros for downtimeManager.php")"
 ${SED} -e 's|@CENTREON_ETC@|'"$CENTREON_ETC"'|g' \
     -e 's|@CENTREON_VARLIB@|'"$CENTREON_VARLIB"'|g' \

--- a/tmpl/install/centreon.cron
+++ b/tmpl/install/centreon.cron
@@ -13,7 +13,7 @@ CRONTAB_EXEC_USER=""
 
 ############################
 # Cron for Session
-* * * * * @WEB_USER@ @PHP_BIN@ -q @INSTALL_DIR_CENTREON@/cron/session.php >> @CENTREON_LOG@/centAcl.log 2>&1
+* * * * * @WEB_USER@ @PHP_BIN@ -q @INSTALL_DIR_CENTREON@/cron/session.php
 
 ############################
 # Cron for Centreon-Downtime

--- a/tmpl/install/centreon.cron
+++ b/tmpl/install/centreon.cron
@@ -12,6 +12,10 @@ CRONTAB_EXEC_USER=""
 * * * * * @WEB_USER@ @PHP_BIN@ -q @INSTALL_DIR_CENTREON@/cron/centAcl.php >> @CENTREON_LOG@/centAcl.log 2>&1
 
 ############################
+# Cron for Session
+* * * * * @WEB_USER@ @PHP_BIN@ -q @INSTALL_DIR_CENTREON@/cron/session.php >> @CENTREON_LOG@/centAcl.log 2>&1
+
+############################
 # Cron for Centreon-Downtime
 */5 * * * * @WEB_USER@ @PHP_BIN@ -q @INSTALL_DIR_CENTREON@/cron/downtimeManager.php >> @CENTREON_LOG@/downtimeManager.log 2>&1
 

--- a/www/class/centreonLog.class.php
+++ b/www/class/centreonLog.class.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -168,7 +169,7 @@ class CentreonLog
         /*
          * Construct alerte message
          */
-        $string = date("Y-m-d H:i") . "|$page|$option|$str";
+        $string = date("Y-m-d H:i:s") . "|$page|$option|$str";
 
         /*
          * Display error on Standard exit


### PR DESCRIPTION
## Description

When the browser is closed without login out, the session can remain valid.
The Cron will now check and clean the saved sessions

Resulting with a 3 min session validity value (set in centreon-ui form)
```
2020-11-13 11:22:02|1|0|0|[WEB] [192.168.0.16] Authentication succeeded for 'admin'
2020-11-13 11:25:01|0|0|0|[CRON] [127.0.0.1] Remove expired session 'admin'
```

**Fixes** # (MON-4253)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
