### PR TITLE
fix(api): Correct misstypo in Broker Domain and config file

### DIFF
--- a/config/packages/prod/Centreon.yaml
+++ b/config/packages/prod/Centreon.yaml
@@ -243,10 +243,7 @@ services:
         class: Centreon\Domain\ActionLog\ActionLogService
 
     # Broker
-    Centreon\Domain\Broker\Interfaces\BrokerServiceInterface:
-        class: Centreon\Domain\Broker\BrokerService
-
-    Centreon\Domain\Broker\Interfaces\BrokerServiceRepositoryInterface:
+    Centreon\Domain\Broker\Interfaces\BrokerRepositoryInterface:
         class: Centreon\Infrastructure\Broker\BrokerRepositoryRDB
 
     # Remote Server

--- a/src/Centreon/Infrastructure/Broker/BrokerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Broker/BrokerRepositoryRDB.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Centreon\Infrastructure\Broker;
 
-use Centreon\Domain\Broker\Broker;
 use Centreon\Domain\Broker\BrokerConfiguration;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Domain\Broker\Interfaces\BrokerRepositoryInterface;

--- a/tests/php/Centreon/Domain/PlatformTopology/PlatformTopologyServiceTest.php
+++ b/tests/php/Centreon/Domain/PlatformTopology/PlatformTopologyServiceTest.php
@@ -22,7 +22,6 @@
 namespace Tests\Centreon\Domain\PlatformTopology;
 
 use PHPUnit\Framework\TestCase;
-use Centreon\Domain\Broker\Broker;
 use Centreon\Domain\Broker\BrokerConfiguration;
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Engine\EngineException;


### PR DESCRIPTION
## Description

This PR clean bad naming and removed class entirely (still present in configuration and in some use namespace)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
