### PR TITLE
fix(ACL): sanitize name in testExistence

### DIFF
--- a/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -43,23 +43,16 @@ function testExistence($name = null)
     $id = null;
 
     if (isset($form)) {
-        $id = $form->getSubmitValue('lca_id');
+        $id = $form->getSubmitValue('acl_res_id');
     }
     $name = filter_var($name, FILTER_SANITIZE_STRING);
     $statement = $pearDB->prepare("SELECT acl_res_name, acl_res_id FROM `acl_resources` WHERE acl_res_name = :name");
     $statement->bindValue(':name', $name, \PDO::PARAM_STR);
     $statement->execute();
-    if ($lca = $statement->fetch()) {
-        if ($statement->rowCount() >= 1 && $lca["acl_res_id"] == $id) {
-            return true;
-        } elseif ($statement->rowCount() >= 1 && $lca["acl_res_id"] != $id) {
-            return false;
-        } else {
-            return true;
-        }
-    } else {
+    if (($lca = $statement->fetch()) && $lca["acl_res_id"] != $id) {
         return false;
     }
+    return true;
 }
 
 /**

--- a/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -45,6 +45,7 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('lca_id');
     }
+    $name = filter_var($name, FILTER_SANITIZE_STRING);
     $query = "SELECT acl_res_name, acl_res_id FROM `acl_resources` WHERE acl_res_name = '" . $name . "'";
     $dbResult = $pearDB->query($query);
     $lca = $dbResult->fetch();

--- a/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -46,12 +46,13 @@ function testExistence($name = null)
         $id = $form->getSubmitValue('lca_id');
     }
     $name = filter_var($name, FILTER_SANITIZE_STRING);
-    $query = "SELECT acl_res_name, acl_res_id FROM `acl_resources` WHERE acl_res_name = '" . $name . "'";
-    $dbResult = $pearDB->query($query);
-    $lca = $dbResult->fetch();
-    if ($dbResult->rowCount() >= 1 && $lca["acl_res_id"] == $id) {
+    $statement = $pearDB->prepare("SELECT acl_res_name, acl_res_id FROM `acl_resources` WHERE acl_res_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
+    $statement->execute();
+    $lca = $statement->fetch();
+    if ($statement->rowCount() >= 1 && $lca["acl_res_id"] == $id) {
         return true;
-    } elseif ($dbResult->rowCount() >= 1 && $lca["acl_res_id"] != $id) {
+    } elseif ($statement->rowCount() >= 1 && $lca["acl_res_id"] != $id) {
         return false;
     } else {
         return true;

--- a/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -49,13 +49,16 @@ function testExistence($name = null)
     $statement = $pearDB->prepare("SELECT acl_res_name, acl_res_id FROM `acl_resources` WHERE acl_res_name = :name");
     $statement->bindValue(':name', $name, \PDO::PARAM_STR);
     $statement->execute();
-    $lca = $statement->fetch();
-    if ($statement->rowCount() >= 1 && $lca["acl_res_id"] == $id) {
-        return true;
-    } elseif ($statement->rowCount() >= 1 && $lca["acl_res_id"] != $id) {
-        return false;
+    if ($lca = $statement->fetch()) {
+        if ($statement->rowCount() >= 1 && $lca["acl_res_id"] == $id) {
+            return true;
+        } elseif ($statement->rowCount() >= 1 && $lca["acl_res_id"] != $id) {
+            return false;
+        } else {
+            return true;
+        }
     } else {
-        return true;
+        return false;
     }
 }
 

--- a/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+++ b/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
@@ -475,7 +475,7 @@ $redirect->setValue($o);
 $form->applyFilter('__ALL__', 'myTrim');
 $form->addRule('acl_res_name', _("Required"), 'required');
 $form->registerRule('exist', 'callback', 'testExistence');
-if ($o == "a") {
+if ($o == "a" || $o == "c") {
     $form->addRule('acl_res_name', _("Already exists"), 'exist');
 }
 $form->setRequiredNote(_("Required field"));


### PR DESCRIPTION
## Description

This PR Fix on ACL Resources where $name wasn't sanitize in testExistence method, so an PDOException was thrown if the name containing quotes.

**Fixes** # MON-5917

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
