### PR TITLE
fix(chore): correct step5 undefined variable

### DIFF
--- a/www/install/step_upgrade/process/process_step5.php
+++ b/www/install/step_upgrade/process/process_step5.php
@@ -74,7 +74,7 @@ function recurseCopy($source, $dest)
 }
 
 $parameters = filter_input_array(INPUT_POST);
-$current = $_POST['current'];
+$current = filter_var($_POST['current'] ?? "step 5", FILTER_SANITIZE_STRING);
 
 if ($parameters) {
     if ((int)$parameters["send_statistics"] === 1) {


### PR DESCRIPTION
## Description

Fix the annoying step5 error on update : 
```
[13-Nov-2020 11:18:15 Europe/Paris] PHP Notice:  Undefined index: current in /usr/share/centreon/www/install/step_upgrade/process/process_step5.php on line 77
[13-Nov-2020 11:18:15 Europe/Paris] PHP Stack trace:
[13-Nov-2020 11:18:15 Europe/Paris] PHP   1. {main}() /usr/share/centreon/www/install/step_upgrade/process/process_step5.php:0
```

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
