### PR TITLE
fix(sec): avoid to display already logged in users

### DIFF
--- a/www/include/core/login/login.php
+++ b/www/include/core/login/login.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -59,7 +60,7 @@ $openIdConnectMode = $result->fetch()["value"];
  * Defining Login Form
  */
 $form = new HTML_QuickFormCustom('Form', 'post', './index.php');
-$form->addElement('text', 'useralias', _("Login:"), array('class' => 'inputclassic'));
+$form->addElement('text', 'useralias', _("Login:"), array('class' => 'inputclassic', 'autocomplete' => 'off'));
 $form->addElement('password', 'password', _("Password"), array('class' => 'inputclassicPass'));
 $submitLogin = $form->addElement('submit', 'submitLogin', _("Connect"), array('class' => 'btc bt_info'));
 

--- a/www/include/core/login/template/login.ihtml
+++ b/www/include/core/login/template/login.ihtml
@@ -3,7 +3,7 @@
     <head>
         <title>Centreon - IT & Network Monitoring</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2020 Open Source Matters. All rights reserved." />
+        <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2021 Open Source Matters. All rights reserved." />
         <meta name="robots" content="index, nofollow" />
         <meta http-equiv="refresh" content="840">
         <link href="./Themes/Centreon-2/login.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
## Description

Avoid to display already logged in users

**Fixes** MON-6620

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Type a letter in user login field and check already logged in are not proposed