### PR TITLE
fix(secu): remove expired sessions more globally

### DIFF
--- a/www/api/class/centreon_keepalive.class.php
+++ b/www/api/class/centreon_keepalive.class.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2017 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -34,7 +35,7 @@
  */
 
 require_once _CENTREON_PATH_ . 'www/class/centreonSession.class.php';
-require_once dirname(__FILE__) . "/webService.class.php";
+require_once __DIR__ . "/webService.class.php";
 
 /**
  * Class CentreonKeepalive
@@ -51,6 +52,7 @@ class CentreonKeepalive extends CentreonWebService
 
     /**
      * Keep alive
+     * @throws RestUnauthorizedException
      */
     public function getKeepAlive()
     {

--- a/www/api/internal.php
+++ b/www/api/internal.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -33,12 +34,12 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../../bootstrap.php';
+require_once __DIR__ . '/../../bootstrap.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonSession.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreon.class.php';
 require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once dirname(__FILE__) . '/class/webService.class.php';
-require_once dirname(__FILE__) . '/interface/di.interface.php';
+require_once __DIR__ . '/class/webService.class.php';
+require_once __DIR__ . '/interface/di.interface.php';
 
 error_reporting(-1);
 ini_set('display_errors', 0);
@@ -46,7 +47,6 @@ ini_set('display_errors', 0);
 $pearDB = new CentreonDB();
 
 CentreonSession::start(1);
-
 if (!isset($_SESSION["centreon"])) {
     CentreonWebService::sendResult("Unauthorized", 401);
 }
@@ -56,7 +56,7 @@ $pearDB = new CentreonDB();
 /*
  * Define Centreon var alias
  */
-if (isset($_SESSION["centreon"])) {
+if (isset($_SESSION["centreon"]) && CentreonSession::checkSession(session_id(), $pearDB)) {
     $oreon = $centreon = $_SESSION["centreon"];
 }
 

--- a/www/class/centreonSession.class.php
+++ b/www/class/centreonSession.class.php
@@ -125,7 +125,6 @@ class CentreonSession
     /**
      * Delete all expired sessions
      * @param CentreonDB $db
-     * @throws Exception
      */
     public static function deleteExpiredSession(CentreonDB $db): void
     {

--- a/www/class/centreonSession.class.php
+++ b/www/class/centreonSession.class.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -36,11 +37,11 @@
 class CentreonSession
 {
     /*
-	 * Constructor class
-	 *
-	 * @access public
-	 * @return 	object	object session
-	 */
+     * Constructor class
+     *
+     * @access public
+     * @return 	object	object session
+     */
     public function __construct()
     {
     }
@@ -108,6 +109,9 @@ class CentreonSession
      */
     public static function checkSession($sessionId, CentreonDB $db)
     {
+        // First, Drop expired sessions
+        self::deleteExpiredSession($db);
+
         if (empty($sessionId)) {
             return 0;
         }
@@ -116,6 +120,23 @@ class CentreonSession
         $prepare->execute();
         $total = (int) $prepare->fetch(\PDO::FETCH_ASSOC)['total'];
         return ($total > 0) ? 1 : 0;
+    }
+
+    /**
+     * Delete all expired sessions
+     * @param CentreonDB $db
+     * @throws Exception
+     */
+    public static function deleteExpiredSession(CentreonDB $db): void
+    {
+        $db->query(
+            'DELETE FROM `session`
+            WHERE last_reload <
+                (SELECT UNIX_TIMESTAMP(NOW() - INTERVAL (`value` * 60) SECOND)
+                FROM `options`
+                WHERE `key` = \'session_expire\')
+            OR last_reload IS NULL'
+        );
     }
 
     /**

--- a/www/class/centreonXMLBGRequest.class.php
+++ b/www/class/centreonXMLBGRequest.class.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -37,7 +37,7 @@
 /*
  * Need Centreon Configuration file
  */
-require_once realpath(dirname(__FILE__) . "/../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../config/centreon.config.php");
 require_once realpath(__DIR__ . "/../../bootstrap.php");
 
 /** * ****************************
@@ -216,18 +216,6 @@ class CentreonXMLBGRequest
     }
 
     /*
-     * Update session table for this user.
-     * 	=> value used for logout session
-     */
-
-    public function reloadSession()
-    {
-        $query = "UPDATE `session` SET `last_reload` = '" . time() . "', `ip_address` = '" . $_SERVER["REMOTE_ADDR"] .
-            "' WHERE `session_id` = '" . $this->session_id . "'";
-        $this->DB->query($query);
-    }
-
-    /*
      * Check if user is admin
      */
 
@@ -287,7 +275,6 @@ class CentreonXMLBGRequest
     /*
      * Send headers information for web server
      */
-
     public function header()
     {
         /* Force no encoding compress */

--- a/www/include/core/header/header.php
+++ b/www/include/core/header/header.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005-2020 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -61,7 +61,7 @@ require_once "$classdir/centreonDB.class.php";
 require_once "$classdir/centreonLang.class.php";
 require_once "$classdir/centreonSession.class.php";
 require_once "$classdir/centreon.class.php";
-require_once $classdir . '/centreonFeature.class.php';
+require_once "$classdir/centreonFeature.class.php";
 require_once SMARTY_DIR . "Smarty.class.php";
 
 /*
@@ -76,23 +76,10 @@ $centreonSession = new CentreonSession();
 
 CentreonSession::start();
 
-/*
- * Delete Session Expired
- */
-$DBRESULT = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'session_expire' LIMIT 1");
-$session_expire = $DBRESULT->fetch();
-if (!isset($session_expire["value"]) || !$session_expire["value"]) {
-    $session_expire["value"] = 2;
-}
-$time_limit = time() - ($session_expire["value"] * 60);
-
-$DBRESULT = $pearDB->query("DELETE FROM `session` WHERE `last_reload` < '" . $time_limit . "'");
-
-// drop session if session has been deleted due to expiration
+// Check session and drop all expired sessions
 if (!CentreonSession::checkSession(session_id(), $pearDB)) {
     CentreonSession::stop();
 }
-
 
 $args = "&redirect='";
 $a = 0;

--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -53,7 +53,7 @@ $centreon = $_SESSION['centreon'] ?? null;
 if (!isset($_SESSION['centreon'])) {
     exit;
 }
-if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
+if (!isset($obj->session_id) || !CentreonSession::checkSession($sid, $obj->DB)) {
     exit;
 }
 

--- a/www/index.php
+++ b/www/index.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -30,7 +31,6 @@
  * do not wish to do so, delete this exception statement from your version.
  *
  * For more information : contact@centreon.com
- *
  *
  */
 

--- a/www/main.get.php
+++ b/www/main.get.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *


### PR DESCRIPTION
## Description

When the browser is closed without login out or when a computer is back from hibernation, the session can remain valid.
The check on session expiration is made more globally when the session is checked
And more often while notifications are send and when internal API is called, to avoid to refresh an expired session

**Fixes** # (MON-4253)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
