### PR TITLE
fix(Chart): Display metric legend with the same color as the corresponding curve

### DIFF
--- a/www/include/views/graphs/javascript/centreon-graph.js
+++ b/www/include/views/graphs/javascript/centreon-graph.js
@@ -717,7 +717,7 @@
               jQuery('<div>')
                 .addClass('chart-legend-color')
                 .css({
-                  'background-color': self.chart.color(curveId)
+                  'background-color': legend.ds_data.ds_color_line
                 })
             )
             .append(


### PR DESCRIPTION
## Description

Colors of the curves  and  label are matching now, is the same.
![colorsLabels_curves_matching](https://user-images.githubusercontent.com/16045498/106571698-c3f2ad80-6537-11eb-90a6-2278d3ba19ee.png)



## Fixes 

The color of the labels does not match the color of the curves on graphs with many curves


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Choose a service with many perfdatas, like "broker-stats" service, and check the curves/labels.
Colors of the curves must mach label color, or label color must match the curve color…


