### PR TITLE
fix(install): information printed during installation

### DIFF
--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -58,8 +58,6 @@ class PartEngine
                 $dbResult = $db->query(
                     "ALTER TABLE " . $tableName . " ADD PARTITION (PARTITION `pmax` VALUES LESS THAN MAXVALUE)"
                 );
-                print "[" . date(DATE_RFC822) . "][updateParts] Create new part for table " . $tableName . " : "
-                    . "pmax - Range: MAXVALUE\n";
             } catch (\PDOException $e) {
                 throw new Exception(
                     "Error: cannot add a maxvalue partition for table "
@@ -93,9 +91,6 @@ class PartEngine
         if ($day < 10) {
             $day = "0" . $day;
         }
-
-        print "[" . date(DATE_RFC822) . "][updateParts] Create new part for table " . $tableName . " : "
-            . ($ntime[5] + 1900) . $month . $day . " - Range: $current_time\n";
 
         $partitionQuery = "PARTITION `p" . ($ntime[5] + 1900) . $month . $day
             . "` VALUES LESS THAN(" . $current_time . ")";


### PR DESCRIPTION
## Description

Since this commit https://github.com/centreon/centreon/commit/9235bf155488af10981a0731fd2cd78acd74dd88 the installation process is broken when reaching partitionningTable step.

Some lines are printed during code execution which breaks the return when calling partitionTables.php (_which should only be json_) 

Here what happens during the installation

![image](https://user-images.githubusercontent.com/31647811/106800216-76be2b00-6660-11eb-856c-5715b6e3f0f1.png)

Which generates an error

![image (1)](https://user-images.githubusercontent.com/31647811/106800211-758cfe00-6660-11eb-863c-f753ae30f21b.png)

As there is no logs what so ever during the installation process, I've just removed those, waiting for the day when we'll have a fully logging system during installation process.


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Fresh installation of Centreon should be successful

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
