### PR TITLE
fix(ui): restore status chip color in timeline

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Timeline/Event.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/Event.tsx
@@ -142,7 +142,7 @@ const EventTimelineEvent = ({ event }: Props): JSX.Element => {
         <div className={classes.infoHeader}>
           <Date event={event} />
           <StatusChip
-            className={classes.chip}
+            classes={{ root: classes.chip }}
             severityCode={event.status?.severity_code as number}
             label={t(event.status?.name as string)}
           />


### PR DESCRIPTION
## Description

restore status chip color in timeline

![image](https://user-images.githubusercontent.com/11978823/107080835-1828b680-67f2-11eb-8df3-b52d75587d8e.png)

**Fixes** MON-6650

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check status events in timeline