### PR TITLE
fix(host template): Fix list of host template when SNMP version are not common

### DIFF
--- a/src/Centreon/Domain/HostConfiguration/Model/HostTemplate.php
+++ b/src/Centreon/Domain/HostConfiguration/Model/HostTemplate.php
@@ -390,12 +390,17 @@ class HostTemplate
      */
     public function setParentIds(array $parentIds): HostTemplate
     {
-        $this->parentIds = array_filter(
-            filter_var_array($parentIds, FILTER_VALIDATE_INT),
-            function ($value) {
-                return is_int($value);
-            }
-        );
+        $parentIds = filter_var_array($parentIds, FILTER_VALIDATE_INT);
+        if (is_array($parentIds)) {
+            $this->parentIds = array_values(
+                array_filter(
+                    $parentIds,
+                    function ($value) {
+                        return is_int($value);
+                    }
+                )
+            );
+        }
         return $this;
     }
 
@@ -706,10 +711,11 @@ class HostTemplate
      */
     public function setSnmpVersion(?string $snmpVersion): HostTemplate
     {
-        if ($snmpVersion !== null && !in_array($snmpVersion, ['1', '2c', '3'])) {
-            throw HostTemplateArgumentException::badSnmpVersion($snmpVersion);
+        if ($snmpVersion !== null) {
+            $this->snmpVersion = in_array($snmpVersion, ['1', '2c', '3'])
+                ? $snmpVersion
+                : null;
         }
-        $this->snmpVersion = $snmpVersion;
         return $this;
     }
 

--- a/tests/php/Centreon/Domain/HostConfiguration/Model/HostTemplateTest.php
+++ b/tests/php/Centreon/Domain/HostConfiguration/Model/HostTemplateTest.php
@@ -315,9 +315,9 @@ class HostTemplateTest extends TestCase
     public function testBadSnmpVersion(): void
     {
         $snmpVersion = '4';
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(HostTemplateArgumentException::badSnmpVersion($snmpVersion)->getMessage());
-        (new HostTemplate())->setSnmpVersion($snmpVersion);
+        $hostTemplate = new HostTemplate();
+        $hostTemplate->setSnmpVersion($snmpVersion);
+        $this->assertNull($hostTemplate->getSnmpVersion());
     }
 
     /**
@@ -390,6 +390,17 @@ class HostTemplateTest extends TestCase
             )->getMessage()
         );
         (new HostTemplate())->setNotes($notes);
+    }
+
+    /**
+     * Test the parentIds
+     */
+    public function testParentIds(): void
+    {
+        $hostTemplate = new HostTemplate();
+        $hostTemplate->setParentIds(['a', 2, 'c', 7]);
+        $this->assertCount(2, $hostTemplate->getParentIds());
+        $this->assertEquals([2, 7], $hostTemplate->getParentIds());
     }
 
     /**


### PR DESCRIPTION
## Description
Fix list of host template when SNMP version are not common

**Fixes** 
When SNMP versions are not common (1, 2c, 3 or none), an exception appears when requesting the host template list.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)


## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
