### PR TITLE
fix(clapi): retrieve default export order of acl menu relations

### DIFF
--- a/www/class/centreon-clapi/centreonACLMenu.class.php
+++ b/www/class/centreon-clapi/centreonACLMenu.class.php
@@ -436,7 +436,6 @@ class CentreonACLMenu extends CentreonObject
      */
     private function grantMenu($aclTopoId, $aclTopoName)
     {
-
         $grantedMenu = '';
 
         $grantedMenuTpl = $this->action . $this->delim .
@@ -450,7 +449,8 @@ class CentreonACLMenu extends CentreonObject
             '2' => 'GRANTRO'
         );
 
-        $queryAclMenuRelations = 'SELECT t.topology_page, t.topology_id, t.topology_name, atr.access_right ' .
+        $queryAclMenuRelations = 'SELECT t.topology_page, atr.topology_topology_id AS topology_id, ' .
+            't.topology_name, atr.access_right ' .
             'FROM acl_topology_relations atr, topology t ' .
             'WHERE atr.topology_topology_id = t.topology_id ' .
             "AND atr.access_right <> '0' " .

--- a/www/class/centreon-clapi/centreonACLMenu.class.php
+++ b/www/class/centreon-clapi/centreonACLMenu.class.php
@@ -449,11 +449,10 @@ class CentreonACLMenu extends CentreonObject
             '2' => 'GRANTRO'
         );
 
-        $queryAclMenuRelations = 'SELECT t.topology_page, atr.topology_topology_id AS topology_id, ' .
-            't.topology_name, atr.access_right ' .
-            'FROM acl_topology_relations atr, topology t ' .
-            'WHERE atr.topology_topology_id = t.topology_id ' .
-            "AND atr.access_right <> '0' " .
+        $queryAclMenuRelations = 'SELECT t.topology_page, t.topology_id, t.topology_name, atr.access_right ' .
+            'FROM acl_topology_relations atr ' .
+            'LEFT JOIN topology t ON t.topology_id = atr.topology_topology_id ' .
+            "WHERE atr.access_right <> '0' " .
             'AND atr.acl_topo_id = :topoId';
         $stmt = $this->db->prepare($queryAclMenuRelations);
         $stmt->bindParam(':topoId', $aclTopoId);


### PR DESCRIPTION
## Description

retrieve default export order of acl menu relations
This is related to upgrave of MariaDB 10.3 to 10.5

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check clapi acceptance test