### PR TITLE
fix(clapi): remove inexistant platform_topology table

### DIFF
--- a/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -553,25 +553,13 @@ class CentreonConfigPoller
              * Get Parent Remote Servers of the Poller
              */
             $statementRemotes = $pearDB->prepare(
-                'SELECT ns.id
-                FROM nagios_server AS ns
-                JOIN platform_topology AS pt ON (ns.id = pt.server_id)
-                WHERE ns.id = :pollerId
-                AND pt.type = "remote"
-                UNION
-                SELECT ns1.id
-                FROM nagios_server AS ns1
-                JOIN platform_topology AS pt ON (ns1.id = pt.server_id)
-                JOIN nagios_server AS ns2 ON ns1.id = ns2.remote_id
+                'SELECT ns.id FROM nagios_server
+                AS ns JOIN nagios_server AS ns2 ON ns.id = ns2.remote_id
                 WHERE ns2.id = :pollerId
-                AND pt.type = "remote"
                 UNION
-                SELECT ns1.id
-                FROM nagios_server AS ns1
-                JOIN platform_topology AS pt ON (ns1.id = pt.server_id)
-                JOIN rs_poller_relation AS rspr ON rspr.remote_server_id = ns1.id
-                WHERE rspr.poller_server_id = :pollerId
-                AND pt.type = "remote"'
+                SELECT ns.id FROM nagios_server AS ns
+                JOIN rs_poller_relation AS rspr ON rspr.remote_server_id = ns.id
+                WHERE rspr.poller_server_id = :pollerId'
             );
             $statementRemotes->bindValue(':pollerId', $pollerId, \PDO::PARAM_INT);
             $statementRemotes->execute();

--- a/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -553,8 +553,8 @@ class CentreonConfigPoller
              * Get Parent Remote Servers of the Poller
              */
             $statementRemotes = $pearDB->prepare(
-                'SELECT ns.id FROM nagios_server
-                AS ns JOIN nagios_server AS ns2 ON ns.id = ns2.remote_id
+                'SELECT ns.id FROM nagios_server AS ns
+                JOIN nagios_server AS ns2 ON ns.id = ns2.remote_id
                 WHERE ns2.id = :pollerId
                 UNION
                 SELECT ns.id FROM nagios_server AS ns


### PR DESCRIPTION
## Description

This PR fix an issue where while using the CFGMOVE Clapi command, an error was sent due to the inexistence of platform_topology table.
The request no longer join this inexistent table.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
