### PR TITLE
fix(UI): Display confirmation popup before deleting an extension from the details modal

### DIFF
--- a/www/front_src/src/route-components/administration/extensions/manager/index.js
+++ b/www/front_src/src/route-components/administration/extensions/manager/index.js
@@ -407,6 +407,23 @@ class ExtensionsRoute extends Component {
       });
   };
 
+  getEntityByIdAndType = (id, type) => {
+    const { extensions } = this.state;
+
+    if (type === 'module') {
+      return extensions.result.module.entities.find(
+        (entity) => entity.id === id,
+      );
+    }
+    return extensions.result.widget.entities.find((entity) => entity.id === id);
+  };
+
+  toggleDeleteModalByIdAndType = (id, type) => {
+    const entity = this.getEntityByIdAndType(id, type);
+
+    this.toggleDeleteModal(entity, type);
+  };
+
   render() {
     const {
       extensions,
@@ -560,7 +577,7 @@ class ExtensionsRoute extends Component {
             loading={modalDetailsLoading}
             onCloseClicked={this.hideExtensionDetails.bind(this)}
             onInstallClicked={this.installById}
-            onDeleteClicked={this.deleteById}
+            onDeleteClicked={this.toggleDeleteModalByIdAndType}
             onUpdateClicked={this.updateById}
             modalDetails={extensionDetails}
           />


### PR DESCRIPTION
## Description

When removing a module or widget from the extension page (Like BAM/MBI/MAP/etc.....) 
You have a popup warning you that data will be deleted.

But if you first click on the module/widget (Card) , then on the delete icon, there is no popup warning you

**Fixes** # (issue)

When you click on module or widget card, modal is activate  and when you click on deleting icon , no popup warning is displayed and module/widget are uninstall immediatly without warning information.

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

1/ Into Extension manager , click on any card (module and widget).
2/ On modal , click on deleting icon , the   warning's popup with Module/Widget name is displayed

![Result_fix](https://user-images.githubusercontent.com/16045498/107539572-627caf80-6bc5-11eb-9e57-be247e4f4957.png)

