### PR TITLE
fix(downtime): cancel BA downtime from downtime page

### DIFF
--- a/www/include/monitoring/downtime/listDowntime.php
+++ b/www/include/monitoring/downtime/listDowntime.php
@@ -216,6 +216,7 @@ for ($i = 0; $data = $downtimesStatement->fetchRow(); $i++) {
         $tab_downtime_svc[$i]['s_details_uri'] = "./main.php?p=207&o=d&ba_id="
             . $tab_service_bam[$data['service_description']]['id'];
         $tab_downtime_svc[$i]['service_description'] = $tab_service_bam[$data['service_description']]['name'];
+        $tab_downtime_svc[$i]['downtime_type'] = 'SVC';
         if ($tab_downtime_svc[$i]['author_name'] == 'Centreon Broker BAM Module') {
             $tab_downtime_svc[$i]['scheduled_end_time'] = "Automatic";
             $tab_downtime_svc[$i]['duration'] = 'Automatic';


### PR DESCRIPTION
This PR aims to fix a bug regarding the action "Cancel a BA downtime from the dowtime monitoring page"

It was possible to cancel a downtime on a BA from the BAM Monitoring but not from the dedicated Downtime page.

Actually when _Module_BAM host was identified no type was set for the BA downtime which lead to send a unrecognized externalcmd to centengine "DEL__DOWNTIME".

**Fixes** MON-6519

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a Business Activity with some indicators
- Make sure that this BA is in a non-ok state
- Put a downtime on this BA from the BAM Monitoring page
- Cancel this downtime from Monitoring -> Downtimes -> Downtime page

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
