### PR TITLE
fix(api): correctly filter on criticality

### DIFF
--- a/www/api/class/centreon_realtime_hosts.class.php
+++ b/www/api/class/centreon_realtime_hosts.class.php
@@ -340,7 +340,7 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
 
         if ($this->criticality) {
             $query .= " AND h.host_id = cvs.host_id ";
-            $query .= " AND cvs.name = 'CRITICALITY_ID' ";
+            $query .= " AND cvs.name = 'CRITICALITY_LEVEL' ";
             $query .= " AND cvs.service_id IS NULL ";
             $query .= " AND cvs.value = :criticality ";
             $queryValues['criticality'] = (string)$this->criticality;

--- a/www/api/class/centreon_realtime_services.class.php
+++ b/www/api/class/centreon_realtime_services.class.php
@@ -162,11 +162,8 @@ class CentreonRealtimeServices extends CentreonRealtimeBase
         } else {
             $this->instance = null;
         }
-        if (isset($this->arguments['criticality'])) {
-            $this->criticality = $this->arguments['criticality'];
-        } else {
-            $this->criticality = null;
-        }
+        // set criticality
+        $this->criticality = $this->arguments['criticality'] ?? null;
 
         /* view properties */
         if (isset($this->arguments['viewType'])) {

--- a/www/api/class/centreon_realtime_services.class.php
+++ b/www/api/class/centreon_realtime_services.class.php
@@ -162,6 +162,11 @@ class CentreonRealtimeServices extends CentreonRealtimeBase
         } else {
             $this->instance = null;
         }
+        if (isset($this->arguments['criticality'])) {
+            $this->criticality = $this->arguments['criticality'];
+        } else {
+            $this->criticality = null;
+        }
 
         /* view properties */
         if (isset($this->arguments['viewType'])) {
@@ -390,7 +395,7 @@ class CentreonRealtimeServices extends CentreonRealtimeBase
         if ($this->criticality) {
             $query .= " AND s.service_id = cvs. service_id " .
                 "AND cvs.host_id = h.host_id " .
-                "AND cvs.name = 'CRITICALITY_ID' " .
+                "AND cvs.name = 'CRITICALITY_LEVEL' " .
                 "AND cvs.value =  :criticality";
             $queryValues['criticality'] = (string)$this->criticality;
         }


### PR DESCRIPTION
It is decribed in the documentation for the API v1 that it is possible to filter the result of the service-status by criticality https://docs.centreon.com/current/en/api/rest-api-v1.html#service-status

However for the service status this was not handled and for the host-status it was broken.

We do want to filter by the value of the CRITICALITY and not the ID as it is not displayed in the WUI

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a service | host categorie with a criticality level
- Link it to services | hosts
- Use the service-status and host-status endpoints to retrieve results and filter on criticality

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
