### PR TITLE
enh(host group): Take into account the ACL when displaying the list of host groups

### DIFF
--- a/config/packages/serializer/Centreon/HostConfiguration.Host.yml
+++ b/config/packages/serializer/Centreon/HostConfiguration.Host.yml
@@ -38,6 +38,11 @@ Centreon\Domain\HostConfiguration\Host:
       type: array<Centreon\Domain\HostConfiguration\Model\HostCategory>
       groups:
         - 'host_categories'
+    groups:
+      since_version: 2.1
+      type: array<Centreon\Domain\HostConfiguration\Model\HostGroup>
+      groups:
+        - 'host_groups'
     comment:
       type: string
       groups:

--- a/config/packages/serializer/Centreon/HostConfiguration.Model.HostGroup.yml
+++ b/config/packages/serializer/Centreon/HostConfiguration.Model.HostGroup.yml
@@ -1,0 +1,6 @@
+Centreon\Domain\HostConfiguration\Model\HostGroup:
+  properties:
+    name:
+      type: string
+      groups:
+        - 'host_group_conf_name'

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15994,5 +15994,11 @@ msgstr "Sélectionner les critères"
 msgid "Error when searching for the host category (%s)"
 msgstr "Erreur lors de la recherche de la catégorie de l'hôte (%s)"
 
+msgid "Error when searching for the host group (%s)"
+msgstr "Erreur lors de la recherche du groupe d'hôte (%s)"
+
 msgid "Host category (%s) not found"
 msgstr "Catégorie de l'hôte (%s) non trouvé"
+
+msgid "Host group (%s) not found"
+msgstr "Groupe d'hôte (%s) non trouvé"

--- a/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
+++ b/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
@@ -30,11 +30,25 @@ namespace Centreon\Domain\HostConfiguration\Exception;
 class HostGroupException extends \Exception
 {
     /**
-     * @param \Exception $ex
+     * @param \Throwable $ex
      * @return self
      */
-    public static function searchHostGroupsException(\Exception $ex): self
+    public static function findHostGroupsException(\Throwable $ex): self
     {
         return new self(_('Error when searching for host groups'), 0, $ex);
+    }
+
+    /**
+     * @param \Throwable $ex
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function findHostGroupException(\Throwable $ex, array $data = []): self
+    {
+        return new self(
+            sprintf(_('Error when searching for the host group (%s)'), $data['id'] ?? $data['name'] ?? null),
+            0,
+            $ex
+        );
     }
 }

--- a/src/Centreon/Domain/HostConfiguration/Host.php
+++ b/src/Centreon/Domain/HostConfiguration/Host.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace Centreon\Domain\HostConfiguration;
 
 use Centreon\Domain\HostConfiguration\Model\HostCategory;
+use Centreon\Domain\HostConfiguration\Model\HostGroup;
 use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\Annotation\EntityDescriptor;
 
@@ -119,6 +120,11 @@ class Host
      * @var HostCategory[]
      */
     private $categories = [];
+
+    /**
+     * @var HostGroup[]
+     */
+    private $groups = [];
 
     /**
      * @return int|null
@@ -405,7 +411,7 @@ class Host
 
     /**
      * @param HostCategory $category
-     * @return $this
+     * @return self
      */
     public function addCategory(HostCategory $category): self
     {
@@ -427,6 +433,33 @@ class Host
     public function clearCategories(): self
     {
         $this->categories = [];
+        return $this;
+    }
+
+    /**
+     * @param HostGroup $hostGroup
+     * @return self
+     */
+    public function addGroup(HostGroup $hostGroup): self
+    {
+        $this->groups[] = $hostGroup;
+        return $this;
+    }
+
+    /**
+     * @return HostGroup[]
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+
+    /**
+     * @return self
+     */
+    public function clearGroups(): self
+    {
+        $this->groups = [];
         return $this;
     }
 }

--- a/src/Centreon/Domain/HostConfiguration/HostGroupService.php
+++ b/src/Centreon/Domain/HostConfiguration/HostGroupService.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\HostConfiguration;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\HostConfiguration\Exception\HostGroupException;
+use Centreon\Domain\HostConfiguration\Interfaces\HostGroup\HostGroupReadRepositoryInterface;
+use Centreon\Domain\HostConfiguration\Interfaces\HostGroup\HostGroupServiceInterface;
+use Centreon\Domain\HostConfiguration\Model\HostGroup;
+use Centreon\Domain\Repository\RepositoryException;
+
+/**
+ * This class is designed to manage the host groups.
+ *
+ * @package Centreon\Domain\HostConfiguration
+ */
+class HostGroupService implements HostGroupServiceInterface
+{
+    /**
+     * @var HostGroupReadRepositoryInterface
+     */
+    private $readRepository;
+
+    /**
+     * @var ContactInterface
+     */
+    private $contact;
+
+    /**
+     * @param HostGroupReadRepositoryInterface $repository
+     * @param ContactInterface $contact
+     */
+    public function __construct(
+        HostGroupReadRepositoryInterface $repository,
+        ContactInterface $contact
+    ) {
+        $this->readRepository = $repository;
+        $this->contact = $contact;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findAllWithAcl(): array
+    {
+        try {
+            return $this->readRepository->findAllByContact($this->contact);
+        } catch (RepositoryException $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            throw HostGroupException::findHostGroupsException($ex);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findAllWithoutAcl(): array
+    {
+        try {
+            return $this->readRepository->findAll();
+        } catch (RepositoryException $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            throw HostGroupException::findHostGroupsException($ex);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findWithAcl(int $groupId): ?HostGroup
+    {
+        try {
+            return $this->readRepository->findByIdAndContact($groupId, $this->contact);
+        } catch (RepositoryException $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            throw HostGroupException::findHostGroupException($ex, ['id' => $groupId]);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findWithoutAcl(int $groupId): ?HostGroup
+    {
+        try {
+            return $this->readRepository->findById($groupId);
+        } catch (RepositoryException $ex) {
+            throw $ex;
+        } catch (\Exception $ex) {
+            throw HostGroupException::findHostGroupException($ex, ['id' => $groupId]);
+        }
+    }
+}

--- a/src/Centreon/Domain/HostConfiguration/Interfaces/HostGroup/HostGroupReadRepositoryInterface.php
+++ b/src/Centreon/Domain/HostConfiguration/Interfaces/HostGroup/HostGroupReadRepositoryInterface.php
@@ -22,7 +22,10 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\HostConfiguration\Interfaces\HostGroup;
 
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\HostConfiguration\Model\HostCategory;
 use Centreon\Domain\HostConfiguration\Model\HostGroup;
+use Centreon\Domain\Repository\RepositoryException;
 
 /**
  * This interface gathers all the reading operations on the repository.
@@ -31,6 +34,46 @@ use Centreon\Domain\HostConfiguration\Model\HostGroup;
  */
 interface HostGroupReadRepositoryInterface
 {
+    /**
+     * Find all host groups.
+     *
+     * @return HostGroup[]
+     * @throws RepositoryException
+     * @throws \Exception
+     */
+    public function findAll(): array;
+
+    /**
+     * Find all host groups by contact.
+     *
+     * @param ContactInterface $contact Contact related to host groups
+     * @return HostGroup[]
+     * @throws RepositoryException
+     * @throws \Exception
+     */
+    public function findAllByContact(ContactInterface $contact): array;
+
+    /**
+     * Find a host group by id.
+     *
+     * @param int $hostGroupId Id of the host group to be found
+     * @return HostGroup|null
+     * @throws RepositoryException
+     * @throws \Exception
+     */
+    public function findById(int $hostGroupId): ?HostGroup;
+
+    /**
+     * Find a host group by id and access groups.
+     *
+     * @param int $hostGroupId Id of the host group to be found
+     * @param ContactInterface $contact Contact related to host categories
+     * @return HostGroup|null
+     * @throws RepositoryException
+     * @throws \Exception
+     */
+    public function findByIdAndContact(int $hostGroupId, ContactInterface $contact): ?HostGroup;
+
     /**
      * Find all host groups.
      *

--- a/src/Centreon/Domain/HostConfiguration/Interfaces/HostGroup/HostGroupServiceInterface.php
+++ b/src/Centreon/Domain/HostConfiguration/Interfaces/HostGroup/HostGroupServiceInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\HostConfiguration\Interfaces\HostGroup;
+
+use Centreon\Domain\HostConfiguration\Exception\HostGroupException;
+use Centreon\Domain\HostConfiguration\Model\HostGroup;
+use Centreon\Domain\Repository\RepositoryException;
+
+/**
+ * @package Centreon\Domain\HostConfiguration\Interfaces\HostGroup
+ */
+interface HostGroupServiceInterface
+{
+    /**
+     * Find a host group (for non admin user).
+     *
+     * @param int $groupId Id of the host group to be found
+     * @return HostGroup|null
+     * @throws HostGroupException
+     * @throws RepositoryException
+     */
+    public function findWithAcl(int $groupId): ?HostGroup;
+
+    /**
+     * Find a host group (for admin user).
+     *
+     * @param int $groupId Id of the host group to be found
+     * @return HostGroup|null
+     * @throws HostGroupException
+     * @throws RepositoryException
+     */
+    public function findWithoutAcl(int $groupId): ?HostGroup;
+
+    /**
+     * Find all host groups (for non admin user).
+     *
+     * @return HostGroup[]
+     * @throws HostGroupException
+     * @throws RepositoryException
+     */
+    public function findAllWithAcl(): array;
+
+    /**
+     * Find all host groups (for admin user).
+     *
+     * @return HostGroup[]
+     * @throws HostGroupException
+     * @throws RepositoryException
+     */
+    public function findAllWithoutAcl(): array;
+}

--- a/src/Centreon/Domain/Repository/RepositoryException.php
+++ b/src/Centreon/Domain/Repository/RepositoryException.php
@@ -22,8 +22,9 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Repository;
 
-use Throwable;
-
+/**
+ * @package Centreon\Domain\Repository
+ */
 class RepositoryException extends \Exception
 {
 }

--- a/src/Centreon/Infrastructure/HostConfiguration/Repository/Model/HostGroupFactoryRdb.php
+++ b/src/Centreon/Infrastructure/HostConfiguration/Repository/Model/HostGroupFactoryRdb.php
@@ -37,7 +37,7 @@ class HostGroupFactoryRdb
      *
      * @param array<string, mixed> $data
      * @return HostGroup
-     * @throw \InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @throws \Assert\AssertionFailedException
      */
     public static function create(array $data): HostGroup

--- a/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -31,17 +31,23 @@ use Centreon\Infrastructure\RequestParameters\Interfaces\NormalizerInterface;
  */
 class SqlRequestParametersTranslator
 {
+    /**
+     * @var string[]
+     */
     private $aggregateOperators = [
         RequestParameters::AGGREGATE_OPERATOR_OR,
         RequestParameters::AGGREGATE_OPERATOR_AND
     ];
 
     /**
-     * @var array $concordanceArray Concordance table between the search column
+     * @var array<string, string> $concordanceArray Concordance table between the search column
      * and the real column name in the database. ['id' => 'my_table_id', ...]
      */
     private $concordanceArray = [];
 
+    /**
+     * @var array<string, mixed>
+     */
     private $searchValues = [];
 
     /**
@@ -66,7 +72,7 @@ class SqlRequestParametersTranslator
     /**
      * Create the database query based on the search parameters.
      *
-     * @param array $search Array containing search parameters
+     * @param array<mixed, mixed> $search Array containing search parameters
      * @param string|null $aggregateOperator Aggregate operator
      * @return string Return the processed database query
      * @throws RequestParametersTranslatorException
@@ -371,7 +377,7 @@ class SqlRequestParametersTranslator
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function getConcordanceArray(): array
     {
@@ -379,7 +385,7 @@ class SqlRequestParametersTranslator
     }
 
     /**
-     * @param array $concordanceArray
+     * @param array<string, string> $concordanceArray
      */
     public function setConcordanceArray(array $concordanceArray): void
     {
@@ -390,7 +396,7 @@ class SqlRequestParametersTranslator
      * Add a search value
      *
      * @param string $key Key
-     * @param array $value Array [type_value => value]
+     * @param array<int, mixed> $value Array [type_value => value]
      */
     public function addSearchValue(string $key, array $value): void
     {
@@ -398,7 +404,7 @@ class SqlRequestParametersTranslator
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function getSearchValues(): array
     {
@@ -406,7 +412,7 @@ class SqlRequestParametersTranslator
     }
 
     /**
-     * @param array $searchValues
+     * @param array<string, mixed> $searchValues
      */
     public function setSearchValues(array $searchValues): void
     {
@@ -433,6 +439,7 @@ class SqlRequestParametersTranslator
      * </code>
      * @param string $propertyName Property name for which the normalizer is applied
      * @param NormalizerInterface $normalizer Normalizer to applied
+     * @throws \InvalidArgumentException
      */
     public function addNormalizer(string $propertyName, NormalizerInterface $normalizer): void
     {

--- a/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostCategory/FindHostCategoriesResponseTest.php
+++ b/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostCategory/FindHostCategoriesResponseTest.php
@@ -20,14 +20,14 @@
  */
 declare(strict_types=1);
 
-namespace Tests\Centreon\Domain\HostConfiguration\UseCase\V21;
+namespace Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostCategory;
 
 use Centreon\Domain\HostConfiguration\UseCase\V21\HostCategory\FindHostCategoriesResponse;
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 use Tests\Centreon\Domain\HostConfiguration\Model\HostCategoryTest;
 
 /**
- * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21
+ * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostCategory
  */
 class FindHostCategoriesResponseTest extends TestCase
 {

--- a/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostCategory/FindHostCategoriesTest.php
+++ b/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostCategory/FindHostCategoriesTest.php
@@ -20,7 +20,7 @@
  */
 declare(strict_types=1);
 
-namespace Tests\Centreon\Domain\HostConfiguration\UseCase\V21;
+namespace Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostCategory;
 
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\HostConfiguration\HostCategoryService;
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
 use Tests\Centreon\Domain\HostConfiguration\Model\HostCategoryTest;
 
 /**
- * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21
+ * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostCategory
  */
 class FindHostCategoriesTest extends TestCase
 {

--- a/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostGroup/FindHostGroupsResponseTest.php
+++ b/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostGroup/FindHostGroupsResponseTest.php
@@ -26,7 +26,7 @@ use Centreon\Domain\HostConfiguration\UseCase\V21\HostGroup\FindHostGroupsRespon
 use Tests\Centreon\Domain\HostConfiguration\Model\HostGroupTest;
 
 /**
- * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21
+ * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostGroup
  */
 class FindHostGroupsResponseTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostSeverity/FindHostSeveritiesResponseTest.php
+++ b/tests/php/Centreon/Domain/HostConfiguration/UseCase/V21/HostSeverity/FindHostSeveritiesResponseTest.php
@@ -20,14 +20,14 @@
  */
 declare(strict_types=1);
 
-namespace Tests\Centreon\Domain\HostConfiguration\UseCase\V21;
+namespace Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostSeverity;
 
 use Centreon\Domain\HostConfiguration\UseCase\V21\HostSeverity\FindHostSeveritiesResponse;
 use PHPStan\Testing\TestCase;
 use Tests\Centreon\Domain\HostConfiguration\Model\HostSeverityTest;
 
 /**
- * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21
+ * @package Tests\Centreon\Domain\HostConfiguration\UseCase\V21\HostSeverity
  */
 class FindHostSeveritiesResponseTest extends TestCase
 {


### PR DESCRIPTION
## Description

Take into account the ACL when displaying the list of host groups

**Fixes**
The display of the list of host groups does not take into account the ACL.
Fix the host severity tests.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
