### PR TITLE
enh(Resource-status/Actions): Disables acknowledge action when resource has an OK or UP status

### DIFF
--- a/www/front_src/src/Resources/Actions/Resource/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/index.tsx
@@ -8,7 +8,12 @@ import IconAcknowledge from '@material-ui/icons/Person';
 import IconCheck from '@material-ui/icons/Sync';
 import IconMore from '@material-ui/icons/MoreHoriz';
 
-import { useCancelTokenSource, Severity, useSnackbar } from '@centreon/ui';
+import {
+  useCancelTokenSource,
+  Severity,
+  useSnackbar,
+  SeverityCode,
+} from '@centreon/ui';
 
 import IconDowntime from '../../icons/Downtime';
 import {
@@ -186,7 +191,7 @@ const ResourceActionsContent = ({
   };
 
   const areSelectedResourcesOk = all(
-    pathEq(['status', 'severity_code'], 5),
+    pathEq(['status', 'severity_code'], SeverityCode.Ok),
     selectedResources,
   );
 

--- a/www/front_src/src/Resources/Actions/Resource/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { head, pick } from 'ramda';
+import { all, allPass, head, pathEq, pick } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { ButtonProps, Grid, Menu, MenuItem } from '@material-ui/core';
@@ -185,7 +185,13 @@ const ResourceActionsContent = ({
     setMoreActionsMenuAnchor(event.currentTarget);
   };
 
-  const disableAcknowledge = !canAcknowledge(selectedResources);
+  const areSelectedResourcesOk = all(
+    pathEq(['status', 'severity_code'], 5),
+    selectedResources,
+  );
+
+  const disableAcknowledge =
+    !canAcknowledge(selectedResources) || areSelectedResourcesOk;
   const disableDowntime = !canDowntime(selectedResources);
   const disableCheck = !canCheck(selectedResources);
   const disableDisacknowledge = !canDisacknowledge(selectedResources);

--- a/www/front_src/src/Resources/Actions/Resource/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { all, allPass, head, pathEq, pick } from 'ramda';
+import { all, head, pathEq, pick } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { ButtonProps, Grid, Menu, MenuItem } from '@material-ui/core';

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -14,6 +14,7 @@ import {
 import userEvent from '@testing-library/user-event';
 
 import { useUserContext } from '@centreon/ui-context';
+import { SeverityCode } from '@centreon/ui';
 
 import {
   labelAcknowledgedBy,
@@ -893,14 +894,14 @@ describe(Actions, () => {
           ...host,
           status: {
             name: 'UP',
-            severity_code: 5,
+            severity_code: SeverityCode.Ok,
           },
         },
         {
           ...service,
           status: {
             name: 'OK',
-            severity_code: 5,
+            severity_code: SeverityCode.Ok,
           },
         },
       ]);

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -883,4 +883,31 @@ describe(Actions, () => {
       );
     });
   });
+
+  it('disables the acknowledge action when selected resources have an OK or UP status', async () => {
+    const { getByText } = renderActions();
+
+    act(() => {
+      context.setSelectedResources([
+        {
+          ...host,
+          status: {
+            name: 'UP',
+            severity_code: 5,
+          },
+        },
+        {
+          ...service,
+          status: {
+            name: 'OK',
+            severity_code: 5,
+          },
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(getByText(labelAcknowledge).parentElement).toBeDisabled();
+    });
+  });
 });

--- a/www/front_src/src/Resources/Listing/columns/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { pipe, split, head, propOr, T } from 'ramda';
+import { pipe, split, head, propOr, T, pathEq } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { Grid, Typography, makeStyles } from '@material-ui/core';
@@ -94,7 +94,9 @@ const StatusColumnOnHover = ({
 
   const { canAcknowledge, canDowntime, canCheck } = useAclQuery();
 
-  const disableAcknowledge = !canAcknowledge([row]);
+  const isResourceOk = pathEq(['status', 'severity_code'], 5, row);
+
+  const disableAcknowledge = !canAcknowledge([row]) || isResourceOk;
   const disableDowntime = !canDowntime([row]);
   const disableCheck = !canCheck([row]);
 

--- a/www/front_src/src/Resources/Listing/columns/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/index.tsx
@@ -94,7 +94,11 @@ const StatusColumnOnHover = ({
 
   const { canAcknowledge, canDowntime, canCheck } = useAclQuery();
 
-  const isResourceOk = pathEq(['status', 'severity_code'], 5, row);
+  const isResourceOk = pathEq(
+    ['status', 'severity_code'],
+    SeverityCode.Ok,
+    row,
+  );
 
   const disableAcknowledge = !canAcknowledge([row]) || isResourceOk;
   const disableDowntime = !canDowntime([row]);


### PR DESCRIPTION
## Description

This prevents the user from having the possibility to send a useless ack action when the resource is already up (service) or ok (host).

![2021-02-16 11 57 14](https://user-images.githubusercontent.com/8367233/108054054-79e8ec00-704e-11eb-9e9a-ec5ca1a76a34.gif)

**Fixes** MON-5103

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x (master)

