### PR TITLE
fix(monitoring): handle macros in Resource Status

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -238,9 +238,6 @@ class MonitoringResourceController extends AbstractController
 
             // add shortcuts
             $this->provideLinks($resource, $contact);
-
-            // replace macros in external links
-            $this->resource->replaceMacrosInExternalLinks($resource);
         }
 
         return $this->view([

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -238,6 +238,9 @@ class MonitoringResourceController extends AbstractController
 
             // add shortcuts
             $this->provideLinks($resource, $contact);
+
+            // replace macros in external links
+            $this->resource->replaceMacrosInExternalLinks($resource);
         }
 
         return $this->view([

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -131,6 +131,14 @@ interface ResourceServiceInterface
     public function enrichServiceWithDetails(ResourceEntity $resource): void;
 
     /**
+     * Replace macros set in the external links by their actual values
+     *
+     * @param ResourceEntity $resource
+     * @return void
+     */
+    public function replaceMacrosInExternalLinks(ResourceEntity $resource): void;
+
+    /**
      * Used to filter requests according to a contact.
      * If the filter is defined, all requests will use the ACL of the contact
      * to fetch data.

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -108,6 +108,10 @@ class ResourceService extends AbstractCentreonService implements ResourceService
         // try to avoid exception from the regexp bad syntax in search criteria
         try {
             $list = $this->resourceRepository->findResources($filter);
+            // replace macros in external links
+            foreach ($list as $resource) {
+                $this->replaceMacrosInExternalLinks($resource);
+            }
         } catch (RepositoryException $ex) {
             throw new ResourceException($ex->getMessage(), 0, $ex);
         } catch (\Exception $ex) {
@@ -231,11 +235,11 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      */
     private function replaceMacrosInUrlsForHostResource(ResourceEntity $resource, string $url): string
     {
-        $url = str_replace("\$HOSTADDRESS\$", $resource->getFqdn(), $url);
-        $url = str_replace("\$HOSTNAME\$", $resource->getName(), $url);
-        $url = str_replace("\$HOSTSTATE\$", $resource->getStatus()->getName(), $url);
-        $url = str_replace("\$HOSTSTATEID\$", $resource->getStatus()->getCode(), $url);
-        $url = str_replace("\$HOSTALIAS\$", $resource->getAlias(), $url);
+        $url = str_replace('$HOSTADDRESS$', $resource->getFqdn(), $url);
+        $url = str_replace('$HOSTNAME$', $resource->getName(), $url);
+        $url = str_replace('$HOSTSTATE$', $resource->getStatus()->getName(), $url);
+        $url = str_replace('$HOSTSTATEID$', $resource->getStatus()->getCode(), $url);
+        $url = str_replace('$HOSTALIAS$', $resource->getAlias(), $url);
 
         return $url;
     }
@@ -249,14 +253,14 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      */
     private function replaceMacrosInUrlsForServiceResource(ResourceEntity $resource, string $url): string
     {
-        $url = str_replace("\$HOSTADDRESS\$", $resource->getParent()->getFqdn(), $url);
-        $url = str_replace("\$HOSTNAME\$", $resource->getParent()->getName(), $url);
-        $url = str_replace("\$HOSTSTATE\$", $resource->getParent()->getStatus()->getName(), $url);
-        $url = str_replace("\$HOSTSTATEID\$", $resource->getParent()->getStatus()->getCode(), $url);
-        $url = str_replace("\$HOSTALIAS\$", $resource->getParent()->getAlias(), $url);
-        $url = str_replace("\$SERVICEDESC\$", $resource->getName(), $url);
-        $url = str_replace("\$SERVICESTATE\$", $resource->getStatus()->getName(), $url);
-        $url = str_replace("\$SERVICESTATEID\$", $resource->getStatus()->getCode(), $url);
+        $url = str_replace('$HOSTADDRESS$', $resource->getParent()->getFqdn(), $url);
+        $url = str_replace('$HOSTNAME$', $resource->getParent()->getName(), $url);
+        $url = str_replace('$HOSTSTATE$', $resource->getParent()->getStatus()->getName(), $url);
+        $url = str_replace('$HOSTSTATEID$', $resource->getParent()->getStatus()->getCode(), $url);
+        $url = str_replace('$HOSTALIAS$', $resource->getParent()->getAlias(), $url);
+        $url = str_replace('$SERVICEDESC$', $resource->getName(), $url);
+        $url = str_replace('$SERVICESTATE$', $resource->getStatus()->getName(), $url);
+        $url = str_replace('$SERVICESTATEID$', $resource->getStatus()->getCode(), $url);
 
         return $url;
     }

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -223,6 +223,73 @@ class ResourceService extends AbstractCentreonService implements ResourceService
     }
 
     /**
+     * Replaces macros in the URL for host resource type
+     *
+     * @param ResourceEntity $resource
+     * @param string $url
+     * @return string
+     */
+    private function replaceMacrosInUrlsForHostResource(ResourceEntity $resource, string $url): string
+    {
+        $url = str_replace("\$HOSTADDRESS\$", $resource->getFqdn(), $url);
+        $url = str_replace("\$HOSTNAME\$", $resource->getName(), $url);
+        $url = str_replace("\$HOSTSTATE\$", $resource->getStatus()->getName(), $url);
+        $url = str_replace("\$HOSTSTATEID\$", $resource->getStatus()->getCode(), $url);
+        $url = str_replace("\$HOSTALIAS\$", $resource->getAlias(), $url);
+
+        return $url;
+    }
+
+    /**
+     * Replaces macros in the URL for service resource type
+     *
+     * @param ResourceEntity $resource
+     * @param string $url
+     * @return string
+     */
+    private function replaceMacrosInUrlsForServiceResource(ResourceEntity $resource, string $url): string
+    {
+        $url = str_replace("\$HOSTADDRESS\$", $resource->getParent()->getFqdn(), $url);
+        $url = str_replace("\$HOSTNAME\$", $resource->getParent()->getName(), $url);
+        $url = str_replace("\$HOSTSTATE\$", $resource->getParent()->getStatus()->getName(), $url);
+        $url = str_replace("\$HOSTSTATEID\$", $resource->getParent()->getStatus()->getCode(), $url);
+        $url = str_replace("\$HOSTALIAS\$", $resource->getParent()->getAlias(), $url);
+        $url = str_replace("\$SERVICEDESC\$", $resource->getName(), $url);
+        $url = str_replace("\$SERVICESTATE\$", $resource->getStatus()->getName(), $url);
+        $url = str_replace("\$SERVICESTATEID\$", $resource->getStatus()->getCode(), $url);
+
+        return $url;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function replaceMacrosInExternalLinks(ResourceEntity $resource): void
+    {
+        $actionUrl = $resource->getLinks()->getExternals()->getActionUrl();
+        $notesUrl = $resource->getLinks()->getExternals()->getNotesUrl();
+        $resourceType = $resource->getType();
+
+        if ($actionUrl != null) {
+            if ($resourceType == ResourceEntity::TYPE_HOST) {
+                $actionUrl = $this->replaceMacrosInUrlsForHostResource($resource, $actionUrl);
+            } elseif ($resourceType == ResourceEntity::TYPE_SERVICE) {
+                $actionUrl = $this->replaceMacrosInUrlsForServiceResource($resource, $actionUrl);
+            }
+            $resource->getLinks()->getExternals()->setActionUrl($actionUrl);
+        }
+
+        if ($notesUrl != null) {
+            if ($resourceType == ResourceEntity::TYPE_HOST) {
+                $notesUrl = $this->replaceMacrosInUrlsForHostResource($resource, $notesUrl);
+            } elseif ($resourceType == ResourceEntity::TYPE_SERVICE) {
+                $notesUrl = $this->replaceMacrosInUrlsForServiceResource($resource, $notesUrl);
+            }
+            $resource->getLinks()->getExternals()->setNotesUrl($notesUrl);
+        }
+    }
+
+    /**
      * Validates input for resource based on groups
      * @param EntityValidator $validator
      * @param ResourceEntity $resource

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -274,19 +274,19 @@ class ResourceService extends AbstractCentreonService implements ResourceService
         $notesUrl = $resource->getLinks()->getExternals()->getNotesUrl();
         $resourceType = $resource->getType();
 
-        if ($actionUrl != null) {
-            if ($resourceType == ResourceEntity::TYPE_HOST) {
+        if ($actionUrl !== null) {
+            if ($resourceType === ResourceEntity::TYPE_HOST) {
                 $actionUrl = $this->replaceMacrosInUrlsForHostResource($resource, $actionUrl);
-            } elseif ($resourceType == ResourceEntity::TYPE_SERVICE) {
+            } elseif ($resourceType === ResourceEntity::TYPE_SERVICE) {
                 $actionUrl = $this->replaceMacrosInUrlsForServiceResource($resource, $actionUrl);
             }
             $resource->getLinks()->getExternals()->setActionUrl($actionUrl);
         }
 
-        if ($notesUrl != null) {
-            if ($resourceType == ResourceEntity::TYPE_HOST) {
+        if ($notesUrl !== null) {
+            if ($resourceType === ResourceEntity::TYPE_HOST) {
                 $notesUrl = $this->replaceMacrosInUrlsForHostResource($resource, $notesUrl);
-            } elseif ($resourceType == ResourceEntity::TYPE_SERVICE) {
+            } elseif ($resourceType === ResourceEntity::TYPE_SERVICE) {
                 $notesUrl = $this->replaceMacrosInUrlsForServiceResource($resource, $notesUrl);
             }
             $resource->getLinks()->getExternals()->setNotesUrl($notesUrl);

--- a/tests/api/features/ResourceMonitoring.feature
+++ b/tests/api/features/ResourceMonitoring.feature
@@ -13,6 +13,7 @@ Feature:
     """
     HOST;ADD;host_test;Test host;127.0.0.1;generic-host;central;
     SERVICE;ADD;host_test;service_ping;Ping-LAN
+    SERVICE;setparam;host_test;service_ping;notes_url;$HOSTNAME$_$SERVICEDESC$
     """
     And the configuration is generated and exported
     And I wait until host "host_test" is monitored
@@ -23,3 +24,4 @@ Feature:
     And the response should be formatted like JSON format "standard/listing.json"
     And the json node "result" should have 1 elements
     And the JSON node "result[0].name" should be equal to the string "service_ping"
+    And the JSON node "result[0].links.externals.notes_url" should be equal to the string "host_test_service_ping"


### PR DESCRIPTION
This PR intends to handle macros mainly for the mediawiki in the resource status page. (notes _url and action_url)

Supported Macros (for now)

```
$HOSTADDRESS$
$HOSTNAME$
$HOSTSTATE$
$HOSTSTATEID$
$HOSTALIAS$
$SERVICEDESC$
$SERVICESTATE$
$SERVICESTATEID$
```
**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Simply fill the extented information of a host or service to see it resolved on the Resource Status page
- Simply use the mediawiki and check that everything works

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
