### PR TITLE
fix(acl): fix query for non admin users on metric list

### DIFF
--- a/www/api/class/centreon_metric.class.php
+++ b/www/api/class/centreon_metric.class.php
@@ -77,7 +77,7 @@ class CentreonMetric extends CentreonWebService
         }
 
         $query = 'SELECT DISTINCT(`metric_name`) COLLATE utf8_bin as "metric_name" ' .
-            'FROM `metrics` ' .
+            'FROM `metrics` m, `index_data` i ' .
             'WHERE metric_name LIKE ? ';
 
         /**

--- a/www/include/Administration/parameters/ldap/form.php
+++ b/www/include/Administration/parameters/ldap/form.php
@@ -54,7 +54,7 @@ $filterVarOptions = array(
 
 if (isset($_POST['ar_id'])) {
     $arId = filter_var($_POST['ar_id'], FILTER_VALIDATE_INT, $filterVarOptions);
-} elseif (isset($_GET['arId'])) {
+} elseif (isset($_GET['ar_id'])) {
     $arId = filter_var($_GET['ar_id'], FILTER_VALIDATE_INT, $filterVarOptions);
 }
 


### PR DESCRIPTION
## Description

* fix query for non admin users on metric list
* fix ldap form on update whiwh was empty

**Fixes** MON-6617

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

get list of metrics with non admin user