### PR TITLE
fix(UI): Add translation for acknowledge downtine popins, titles, notify option, date format and helper

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2519,7 +2519,7 @@ msgstr "Date de génération"
 #: centreon-web/www/include/monitoring/comments/AddSvcComment.php:124
 #: centreon-web/www/include/monitoring/comments/AddComment.php:125
 msgid "Persistent"
-msgstr "Acquittement persistant en cas de redémarrage de l'ordonnanceur."
+msgstr "Persistant"
 
 #: centreon-web/www/install/smarty_translate.php:915
 #: centreon-web/www/include/monitoring/external_cmd/popup/massive_downtime.php:82
@@ -5457,7 +5457,7 @@ msgstr "Intervalle de rafraîchissement de la page"
 #: centreon-web/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php:85
 #: centreon-web/www/include/monitoring/external_cmd/popup/massive_ack.php:114
 msgid "Sticky"
-msgstr "Acquittement persistant en cas de changement de statut non-OK"
+msgstr "Persistant (non-OK)"
 
 #: centreon-web/www/include/Administration/parameters/engine/form.php:99
 #: centreon-web/www/include/monitoring/acknowlegement/hostAcknowledge.php:77
@@ -15356,7 +15356,7 @@ msgstr "Dernier changement d'état"
 msgid "Next check"
 msgstr "Prochain contrôle"
 
-msgid "If checked, a notification is sent to the contacts linked to the object to warn that the incident of the resource has been acknowledged"
+msgid "If checked, a notification is sent to the contacts linked to the object to warn that the incident on the resource has been acknowledged"
 msgstr "Si cette option est cochée, une notification sera envoyée aux contacts liés à l'objet afin d'avertir que l'incident de la ressource a été acquitté"
 
 msgid "Open"

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -97,9 +97,9 @@ const DialogAcknowledge = ({
                 size="small"
               />
             }
-            label={labelNotify}
+            label={t(labelNotify)}
           />
-          <FormHelperText>{labelNotifyHelpCaption}</FormHelperText>
+          <FormHelperText>{t(labelNotifyHelpCaption)}</FormHelperText>
         </Grid>
         {hasHosts && (
           <Grid item>

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -127,3 +127,4 @@ const DialogAcknowledge = ({
 };
 
 export default DialogAcknowledge;
+

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -127,4 +127,3 @@ const DialogAcknowledge = ({
 };
 
 export default DialogAcknowledge;
-

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -212,7 +212,7 @@ const DialogDowntime = ({
                   size="small"
                 />
               }
-              label={labelFixed}
+              label={t(labelFixed)}
             />
           </Grid>
           <Grid item>

--- a/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Acknowledgement.tsx
+++ b/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Acknowledgement.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import parse from 'html-react-parser';
 import DOMPurify from 'dompurify';
+import { useTranslation } from 'react-i18next';
 
 import { makeStyles } from '@material-ui/core';
 
@@ -36,26 +37,28 @@ type Props = Pick<DetailsTableProps, 'endpoint'>;
 
 const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
   const classes = useStyles();
+  const { t } = useTranslation();
+
   const { toDateTime } = useLocaleDateTimeFormat();
 
   const columns = [
     {
       id: 'author',
-      label: labelAuthor,
+      label: t(labelAuthor),
       type: ColumnType.string,
       getContent: ({ author_name }): string => author_name,
       width: 100,
     },
     {
       id: 'entry_time',
-      label: labelEntryTime,
+      label: t(labelEntryTime),
       type: ColumnType.string,
       getContent: ({ entry_time }): string => toDateTime(entry_time),
       width: 150,
     },
     {
       id: 'is_persistent',
-      label: labelPersistent,
+      label: t(labelPersistent),
       type: ColumnType.string,
       getContent: ({ is_persistent_comment }): string =>
         getYesNoLabel(is_persistent_comment),
@@ -63,7 +66,7 @@ const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
     },
     {
       id: 'is_sticky',
-      label: labelSticky,
+      label: t(labelSticky),
       type: ColumnType.string,
       getContent: ({ is_sticky }): string => getYesNoLabel(is_sticky),
       width: 100,
@@ -71,7 +74,7 @@ const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
 
     {
       id: 'comment',
-      label: labelComment,
+      label: t(labelComment),
       type: ColumnType.string,
       width: 250,
       getContent: ({ comment }: AcknowledgementDetails): JSX.Element => {

--- a/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Acknowledgement.tsx
+++ b/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Acknowledgement.tsx
@@ -96,3 +96,4 @@ const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
 };
 
 export default AcknowledgementDetailsTable;
+

--- a/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Acknowledgement.tsx
+++ b/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Acknowledgement.tsx
@@ -96,4 +96,3 @@ const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
 };
 
 export default AcknowledgementDetailsTable;
-

--- a/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Downtime.tsx
+++ b/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Downtime.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import parse from 'html-react-parser';
 import DOMPurify from 'dompurify';
+import { useTranslation } from 'react-i18next';
 
 import { makeStyles } from '@material-ui/core';
 
@@ -38,34 +39,35 @@ type Props = Pick<DetailsTableProps, 'endpoint'>;
 
 const DowntimeDetailsTable = ({ endpoint }: Props): JSX.Element => {
   const classes = useStyles();
+  const { t } = useTranslation();
 
   const { toDateTime } = useLocaleDateTimeFormat();
 
   const columns = [
     {
       id: 'author',
-      label: labelAuthor,
+      label: t(labelAuthor),
       type: ColumnType.string,
       getContent: ({ author_name }): string => author_name,
       width: 100,
     },
     {
       id: 'is_fixed',
-      label: labelFixed,
+      label: t(labelFixed),
       type: ColumnType.string,
       getContent: ({ is_fixed }): string => (is_fixed ? labelYes : labelNo),
       width: 100,
     },
     {
       id: 'start_time',
-      label: labelStartTime,
+      label: t(labelStartTime),
       type: ColumnType.string,
       getContent: ({ start_time }): string => toDateTime(start_time),
       width: 150,
     },
     {
       id: 'end_time',
-      label: labelEndTime,
+      label: t(labelEndTime),
       type: ColumnType.string,
       getContent: ({ end_time }): string => toDateTime(end_time),
       width: 150,
@@ -73,7 +75,7 @@ const DowntimeDetailsTable = ({ endpoint }: Props): JSX.Element => {
 
     {
       id: 'comment',
-      label: labelComment,
+      label: t(labelComment),
       type: ColumnType.string,
       width: 250,
       getContent: ({ comment }: DowntimeDetails): JSX.Element => {

--- a/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Downtime.tsx
+++ b/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Downtime.tsx
@@ -94,4 +94,3 @@ const DowntimeDetailsTable = ({ endpoint }: Props): JSX.Element => {
 };
 
 export default DowntimeDetailsTable;
-

--- a/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Downtime.tsx
+++ b/www/front_src/src/Resources/Listing/columns/State/DetailsTable/Downtime.tsx
@@ -94,3 +94,4 @@ const DowntimeDetailsTable = ({ endpoint }: Props): JSX.Element => {
 };
 
 export default DowntimeDetailsTable;
+


### PR DESCRIPTION
## Description

When UI is in french, some sentences or words are not translated in popins  and timeline.

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Log on centreon , set language in french  and set an Acknowledge and set a Downtime.
After you can check in popins , timeline  and notify option  all translations are OK.

![DT_popin](https://user-images.githubusercontent.com/16045498/108737389-db1f2c80-7532-11eb-8361-2b98e5f51201.png)
![HoverACK](https://user-images.githubusercontent.com/16045498/108737394-dce8f000-7532-11eb-9084-14fe409c12dd.png)
![Notify-LabelHelper](https://user-images.githubusercontent.com/16045498/108737402-de1a1d00-7532-11eb-840f-88875b605579.png)
![Timeline](https://user-images.githubusercontent.com/16045498/108737410-dfe3e080-7532-11eb-8f45-05efe2e370b8.png)

