### PR TITLE
fix(select2): avoid error 400 in hg & connector forms

### DIFF
--- a/www/include/configuration/configObject/connector/formConnector.php
+++ b/www/include/configuration/configObject/connector/formConnector.php
@@ -105,8 +105,8 @@ try {
         'datasourceOrigin' => 'ajax',
         'multiple' => true,
         'defaultDatasetRoute' => './include/common/webServices/rest/internal.php?'
-        . 'object=centreon_configuration_command&action=defaultValues&target=connector&field=command_id'
-        . (isset($connector_id) ? "&id={$connector_id}" : ''),
+        . 'object=centreon_configuration_command&action=defaultValues&target=connector&field=command_id&id='
+        . (isset($connector_id) ? $connector_id : ''),
         'availableDatasetRoute' => './include/common/webServices/rest/internal.php?'
         . 'object=centreon_configuration_command&action=list',
         'linkedObject' => 'centreonCommand'

--- a/www/include/configuration/configObject/hostgroup/formHostGroup.php
+++ b/www/include/configuration/configObject/hostgroup/formHostGroup.php
@@ -78,20 +78,14 @@ $attrsAdvSelect = array("style" => "width: 300px; height: 220px;");
 $attrsTextarea = array("rows" => "4", "cols" => "60");
 $eTemplate = '<table><tr><td><div class="ams">{label_2}</div>{unselected}</td><td align="center">{add}<br /><br />'
     . '<br />{remove}</td><td><div class="ams">{label_3}</div>{selected}</td></tr></table>';
-$hostRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_host&action=list';
+$hostRoute = './api/internal.php?object=centreon_configuration_host&action=list';
 $attrHosts = array(
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $hostRoute,
     'multiple' => true,
     'linkedObject' => 'centreonHost'
 );
-$hostGrRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_hostgroup&action=list';
-$attrHostgroups = array(
-    'datasourceOrigin' => 'ajax',
-    'availableDatasetRoute' => $hostGrRoute,
-    'multiple' => true,
-    'linkedObject' => 'centreonHostgroups'
-);
+$hostGrRoute = './api/internal.php?object=centreon_configuration_hostgroup&action=list';
 
 /*
  * Create formulary
@@ -116,20 +110,12 @@ $form->addElement('text', 'hg_alias', _("Alias"), $attrsText);
  * Hosts Selection
  */
 $hostRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_host'
-    . '&action=defaultValues&target=hostgroups&field=hg_hosts&id=' . $hg_id;
+    . '&action=defaultValues&target=hostgroups&field=hg_hosts&id=' . ($hg_id > 0 ? $hg_id : '');
 $attrHost1 = array_merge(
     $attrHosts,
     array('defaultDatasetRoute' => $hostRoute)
 );
 $form->addElement('select2', 'hg_hosts', _("Linked Hosts"), array(), $attrHost1);
-
-$hostGrRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_hostgroup'
-    . '&action=defaultValues&target=hostgroups&field=hg_hg&id=' . $hg_id;
-$attrHostgroup1 = array_merge(
-    $attrHostgroups,
-    array('defaultDatasetRoute' => $hostGrRoute)
-);
-$form->addElement('select2', 'hg_hg', _("Linked Host Groups"), array(), $attrHostgroup1);
 
 /*
  * Extended information

--- a/www/lib/HTML/QuickForm/select2.php
+++ b/www/lib/HTML/QuickForm/select2.php
@@ -474,7 +474,7 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
      */
     public function setDefaultAjaxDatas()
     {
-        if (preg_match('/id=0?$/', $this->_defaultDatasetRoute)) {
+        if (preg_match('/id=$/', $this->_defaultDatasetRoute)) {
             // do not fetch data if id is not set
             // it happens when creating a new object
             return '';

--- a/www/lib/HTML/QuickForm/select2.php
+++ b/www/lib/HTML/QuickForm/select2.php
@@ -474,7 +474,7 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
      */
     public function setDefaultAjaxDatas()
     {
-        if (preg_match('/id=$/', $this->_defaultDatasetRoute)) {
+        if (preg_match('/id=0?$/', $this->_defaultDatasetRoute)) {
             // do not fetch data if id is not set
             // it happens when creating a new object
             return '';


### PR DESCRIPTION
## Description

Avoid error 400 in hg & connector forms

**Fixes** MON-663

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check error 400 in brower console when opening hg and connector forms