### PR TITLE
enh(resource): handle monitoring server name in resource status

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -165,3 +165,8 @@ Centreon\Domain\Monitoring\Resource:
             type: array<Centreon\Domain\Monitoring\ResourceGroup>
             groups:
                 - 'resource_details'
+        monitoringServerName:
+            type: string
+            groups:
+                - 'resource_main'
+                - 'resource_details'

--- a/doc/API/centreon-api-v2.1.yaml
+++ b/doc/API/centreon-api-v2.1.yaml
@@ -590,6 +590,7 @@ paths:
         * tries
         * last_check
         * information
+        * monitoring_server_name
 
         Only for **searching**:
 
@@ -4017,6 +4018,10 @@ components:
           example: null
         links:
           $ref: '#/components/schemas/Monitoring.ResourceLinks'
+        monitoring_server_name:
+          type: string
+          description: "Monitoring Server from which is monitored the Resource"
+          example: "Central"
         icon:
           type: object
           nullable: true

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -520,6 +520,7 @@ paths:
         * tries
         * last_check
         * information
+        * monitoring_server_name
 
         Only for **searching**:
 
@@ -4042,6 +4043,10 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Monitoring.ResourceGroup'
+            monitoring_server_name:
+              type: string
+              description: "Monitoring Server from which is monitored the Resource"
+              example: "Central"
             status:
               type: object
               properties:

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -92,9 +92,9 @@ class Resource
     protected $commandLine;
 
     /**
-     * @var string|null
+     * @var string
      */
-    private $pollerName;
+    private $monitoringServerName;
 
     /**
      * @var string|null
@@ -405,21 +405,20 @@ class Resource
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getPollerName(): ?string
+    public function getMonitoringServerName(): string
     {
-        return $this->pollerName;
+        return $this->monitoringServerName;
     }
 
-    /**
-     * @param string|null $pollerName
+   /**
+     * @param string $monitoringServerName
      * @return self
      */
-    public function setPollerName(?string $pollerName): self
+    public function setMonitoringServerName(string $monitoringServerName): self
     {
-        $this->pollerName = $pollerName;
-
+        $this->monitoringServerName = $monitoringServerName;
         return $this;
     }
 

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -126,11 +126,6 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      */
     public function enrichHostWithDetails(ResourceEntity $resource): void
     {
-        $host = $this->monitoringRepository->findOneHost($resource->getId());
-        if ($host !== null) {
-            $resource->setPollerName($host->getPollerName());
-        }
-
         $downtimes = $this->monitoringRepository->findDowntimes(
             $resource->getId(),
             0

--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -85,6 +85,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         'last_check' => 'resource.last_check',
         'h.group' => 'hg.name',
         'h.group.id' => 'hhg.hostgroup_id',
+        'monitoring_server_name' => 'resource.monitoring_server_name',
     ];
 
     /**
@@ -215,6 +216,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             . 'resource.parent_alias, resource.parent_fqdn, ' // parent
             . 'resource.parent_icon_name, resource.parent_icon_url, ' // parent icon
             . 'resource.action_url, resource.notes_url, ' // external urls
+            . 'resource.monitoring_server_name, ' // monitoring server
             // parent status
             . 'resource.parent_status_code, resource.parent_status_name, resource.parent_status_severity_code, '
             . 'resource.flapping, resource.percent_state_change, '
@@ -435,6 +437,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             s.icon_image AS `icon_url`,
             s.action_url AS `action_url`,
             s.notes_url AS `notes_url`,
+            i.name AS `monitoring_server_name`,
             s.command_line AS `command_line`,
             NULL AS `timezone`,
             sh.host_id AS `parent_id`,
@@ -505,6 +508,9 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
                 AND service_acl.service_id = s.service_id
                 AND service_acl.group_id IN (" . $this->accessGroupIdToString($this->accessGroups) . ")";
         }
+
+        // get monitoring server information
+        $sql .= " INNER JOIN `:dbstg`.`instances` AS i ON i.instance_id = sh.instance_id";
 
         // Join the service groups
         $sql .= " LEFT JOIN `:dbstg`.`services_servicegroups` AS ssg"
@@ -639,6 +645,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             h.icon_image AS `icon_url`,
             h.action_url AS `action_url`,
             h.notes_url AS `notes_url`,
+            i.name AS `monitoring_server_name`,
             h.command_line AS `command_line`,
             h.timezone AS `timezone`,
             NULL AS `parent_id`,
@@ -693,6 +700,9 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
                   AND host_acl.service_id IS NULL
                   AND host_acl.group_id IN (" . $this->accessGroupIdToString($this->accessGroups) . ")";
         }
+
+        // get monitoring server information
+        $sql .= " INNER JOIN `:dbstg`.`instances` AS i ON i.instance_id = h.instance_id";
 
         // get Severity level, name, icon
         $sql .= ' LEFT JOIN `:dbstg`.`customvariables` AS host_cvl ON host_cvl.host_id = h.host_id


### PR DESCRIPTION
This PR intends to add the monitoring_server_name information to the API in order to be displayed in resource status.
It replaces the "pollerName" info which is now also displayed for services.

/!\ FE should
- Handle new parameter (search and display) in the listing AND the detail @bdauria 

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- GET on /monitoring/resources: Each resource should have a monitoring_server_name defined

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
