### PR TITLE
fix(monitoring): replace properly snmp macro values in command line

### DIFF
--- a/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+++ b/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
@@ -241,9 +241,12 @@ class HostConfigurationService implements HostConfigurationServiceInterface
             $matchedMacros = $matches[0];
 
             foreach ($matchedMacros as $matchedMacroName) {
-                $hostMacros[$matchedMacroName] = (new HostMacro())
-                    ->setName($matchedMacroName)
-                    ->setValue('');
+                // snmp macros are not custom macros
+                if (!in_array($matchedMacroName, ['$_HOSTSNMPCOMMUNITY$', '$_HOSTSNMPVERSION$'])) {
+                    $hostMacros[$matchedMacroName] = (new HostMacro())
+                        ->setName($matchedMacroName)
+                        ->setValue('');
+                }
             }
 
             $linkedHostMacros = $this->findOnDemandHostMacros($hostId, true);


### PR DESCRIPTION
## Description

replace properly snmp macro values in command line

**Fixes** MON-6589 MON-6204

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check command line in resource status page when it contains macro password and snmp macros
Command line should be displayed with macro password replaced by `****`