### PR TITLE
fix(filters): adapt filter to new format

### DIFF
--- a/www/install/php/Update-21.04.0-beta.1.php
+++ b/www/install/php/Update-21.04.0-beta.1.php
@@ -18,3 +18,88 @@
  * For more information : contact@centreon.com
  *
  */
+
+include_once __DIR__ . "/../../class/centreonLog.class.php";
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 21.04.0-beta.1: ';
+
+$pearDB = new CentreonDB('centreon', 3, false);
+
+$criteriasConcordanceArray = [
+    'states' => [
+        'acknowledged' => 'Acknowledged',
+        'in_downtime' => 'In downtime',
+        'unhandled_problems' => 'Unhandled',
+    ],
+    'resource_types' => [
+        'host' => 'Host',
+        'service' => 'Service',
+    ],
+    'statuses' => [
+        'OK' => 'Ok',
+        'UP' => 'Up',
+        'WARNING' => 'Warning',
+        'DOWN' => 'Down',
+        'CRITICAL' => 'Critical',
+        'UNREACHABLE' => 'Unreachable',
+        'UNKNOWN' => 'Unknown',
+        'PENDING' => 'Pending'
+    ],
+];
+
+try {
+    $pearDB->beginTransaction();
+    /**
+     * Retrieve user filters
+     */
+    $statement = $pearDB->query(
+        "SELECT `id`, `criterias` FROM `user_filter`"
+    );
+
+    $translatedFilters = [];
+
+    while ($filter = $statement->fetch()) {
+        $id = $filter['id'];
+        $decodedCriterias = json_decode($filter['criterias'], true);
+        // Adding the default sorting in the criterias
+        $decodedCriterias[] = [
+            'name' => 'sort',
+            'type' => 'array',
+            'value' => [
+                'status_severity_code' => "asc"
+            ],
+        ];
+        foreach ($decodedCriterias as $criteriaKey => $criteria) {
+            $name = $criteria['name'];
+            // Checking if the filter contains criterias we want to migrate
+            if (array_key_exists($name, $criteriasConcordanceArray) === true) {
+                foreach ($criteria['value'] as $index => $value) {
+                    $decodedCriterias[$criteriaKey]['value'][$index]['name'] = $criteriasConcordanceArray[$name][$value['id']];
+                }
+            }
+            $translatedFilters[$id] = $decodedCriterias;
+        }
+
+        /**
+         * UPDATE SQL request on the filters
+         */
+        foreach ($translatedFilters as $id => $criterias) {
+            $query = "UPDATE `user_filter` SET `criterias` = '" . json_encode($criterias) . "' WHERE `id` = " . $id;
+            $stmt = $pearDB->query($query);
+        }
+
+        $pearDB->commit();
+    }
+} catch (\Exception $e) {
+    $pearDB->rollBack();
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage .
+        " - Code : " . (int)$e->getCode() .
+        " - Error : " . $e->getMessage() .
+        " - Trace : " . $e->getTraceAsString()
+    );
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int)$e->getCode(), $e);
+}


### PR DESCRIPTION
This PR intends to migrate all user existing filters so that those filter can be used in resource status.

Before: filters were saved including the locale. It means that when setting "Hôte" as resource_type filter it was saved "Hôte".

It has been decided that from now on all filters should saved in English that is the purpose of the migration script provided in this PR.

It also intends to add to the criterias a default sorting.

`{
  "name": "sort",
  "type": "array",
  "value": ["status_severity_code", "asc"]
}`

The script will be adapted during cherry-pick on 20.10.x

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Make sure to save a "old" filter (20.10.x stable for example) so that you get in the database filters saved with the "locale"
- Just do an update of centreon-web with this migration script and check that everything is still functional and that filters are now in english in the db and that the default sorting has been added.
- 
## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
