### PR TITLE
fix(eventLogs): export logs fixed when filtered on output

### DIFF
--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -206,7 +206,6 @@ if (isset($sid) && $sid) {
 // binding limit value
 $limit = $inputs['limit'];
 $num = $inputs['num'];
-$queryValues['limit'] = [\PDO::PARAM_INT => $limit];
 
 $StartDate = isset($inputs["StartDate"]) ? htmlentities($inputs["StartDate"]) : "";
 $EndDate = isset($inputs["EndDate"]) ? $EndDate = htmlentities($inputs["EndDate"]) : "";
@@ -400,8 +399,8 @@ $flag_begin = 0;
 
 $whereOutput = "";
 if (isset($output) && $output != "") {
-    $queryValues['whereOutput'] = [\PDO::PARAM_STR => '%' . CentreonUtils::escapeSecure($output) . '%'];
-    $whereOutput = " AND logs.output like :whereOutput";
+    $queryValues[':output'] = [\PDO::PARAM_STR => '%' . $output . '%'];
+    $whereOutput = " AND logs.output like :output ";
 }
 
 $innerJoinEngineLog = "";
@@ -674,6 +673,7 @@ if (isset($req) && $req) {
 
     $limitReq = "";
     if ($export !== "1") {
+        $queryValues['limit'] = [\PDO::PARAM_INT => $limit];
         $offset = $num * $limit;
         $queryValues['offset'] = [\PDO::PARAM_INT => $offset];
         $limitReq = " LIMIT :offset, :limit";

--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -673,9 +673,9 @@ if (isset($req) && $req) {
 
     $limitReq = "";
     if ($export !== "1") {
-        $queryValues['limit'] = [\PDO::PARAM_INT => $limit];
         $offset = $num * $limit;
         $queryValues['offset'] = [\PDO::PARAM_INT => $offset];
+        $queryValues['limit'] = [\PDO::PARAM_INT => $limit];
         $limitReq = " LIMIT :offset, :limit";
     }
     $stmt = $pearDBO->prepare($req . $limitReq);


### PR DESCRIPTION
This PR intends to fix an issue when exporting logs from Monitoring -> Logs -> EventLogs with a filter on output.
Without the patch you will get a 500 internal error due to bad value binding of limit (which should not be binded when exporting).

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to Monitoring -> Logs -> Event Logs
- Get some logs from Host / service and so on...
- Use the output filter (and get some results from it)
- Click the export button (CSV or XML as you want, both should work)
- The export process should work and the CSV file consistent with what you've decided to export

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
