### PR TITLE
fix(chore): set default value if unable to compare versions

### DIFF
--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -75,7 +75,9 @@ if ($handle = opendir('../php')) {
 }
 
 $majors = preg_match('/^(\d+\.\d+)/', $next, $matches);
-
+if (!isset($matches[1])) {
+    $matches[1] = "current";
+}
 $releaseNoteLink = "https://documentation.centreon.com/" . $matches[1] . '/en/releases/centreon-core.html';
 
 $title = _('Release notes');


### PR DESCRIPTION
## Description

Set the default documentation link to "current" if unable to define it from the versions comparaison
```
[02-Mar-2021 09:05:56 Europe/Paris] PHP Notice:  Undefined offset: 1 in /usr/share/centreon/www/install/step_upgrade/step3.php on line 79
[02-Mar-2021 09:05:56 Europe/Paris] PHP Stack trace:
[02-Mar-2021 09:05:56 Europe/Paris] PHP   1. {main}() /usr/share/centreon/www/install/step_upgrade/step3.php:0
```

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
