### PR TITLE
fix(web): complete the Last step upgrade redirection

### DIFF
--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -118,7 +118,9 @@ if ($moveable) {
                 type: 'POST',
                 url: './step_upgrade/process/process_step5.php',
                 data: jQuery('input[name="send_statistics"]').serialize(),
-                success: () => javascript:self.location = "../index.php"
+                success: () => {
+                    javascript:self.location = "../index.php"
+                }
             })
         }
     </script>


### PR DESCRIPTION
During an update, the last step fails during the redirection because a javascript error is raised.
This fix allows to continue without any problem.

Refs: MON-6780

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
