### PR TITLE
fix(monitoring): Use new query parameter format for resource status l…

### DIFF
--- a/www/include/monitoring/status/Hosts/host.php
+++ b/www/include/monitoring/status/Hosts/host.php
@@ -191,18 +191,28 @@ $resourcesStatusLabel = _('Resources Status');
 
 $filter = [
     'criterias' => [
-        'resourceTypes' => [
-            [
-                'id' => 'host',
-                'name' => 'Host'
+        [
+            'name' => 'resource_types',
+            'value' => [
+                [
+                    'id' => 'host',
+                    'name' => 'Host'
+                ]
             ]
         ],
-        'states' => [
-            [
-                'id' => 'unhandled_problems',
-                'name' => 'Unhandled'
+        [
+            'name' => 'states',
+            'value' => [
+                [
+                    'id' => 'unhandled_problems',
+                    'name' => 'Unhandled'
+                ]
             ]
         ],
+        [
+            'name' => 'search',
+            'value' => ''
+        ]
     ]
 ];
 

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -221,18 +221,28 @@ $resourcesStatusLabel = _('Resources Status');
 
 $filter = [
     'criterias' => [
-        'resourceTypes' => [
-            [
-                'id' => 'service',
-                'name' => 'Service'
+        [
+            'name' => 'resource_types',
+            'value' => [
+                [
+                    'id' => 'service',
+                    'name' => 'Service'
+                ]
             ]
         ],
-        'states' => [
-            [
-                'id' => 'unhandled_problems',
-                'name' => 'Unhandled'
+        [
+            'name' => 'states',
+            'value' => [
+                [
+                    'id' => 'unhandled_problems',
+                    'name' => 'Unhandled'
+                ]
             ]
         ],
+        [
+            'name' => 'search',
+            'value' => ''
+        ]
     ]
 ];
 


### PR DESCRIPTION
…inks

This PR intends to adapt redirection links to the resource status page that exist in the Deprecated pages using the new query parameter format for resource status links

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the "old" pages Monitoring -> Service Details and click the Resource Status link depredation message
- Go to the "old" pages Monitoring -> Host Details and click the Resource Status link depredation message


## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
