### PR TITLE
fix(platformtopology): enable to add a remote server

### DIFF
--- a/bin/registerServerTopology.sh
+++ b/bin/registerServerTopology.sh
@@ -400,7 +400,7 @@ function request_to_remote() {
   fi
 
   # Prepare Remote Payload
-  REMOTE_PAYLOAD='{"isRemote":true,"centralServerAddress":"'"${TARGET_NODE_ADDRESS}"'","apiUsername":"'"${API_USERNAME}"'","apiCredentials":"'"${API_TARGET_PASSWORD}"'","apiScheme":"'"${PARSED_URL[SCHEME]}"'","apiPort":'"${PARSED_URL[PORT]}"',"apiPath":"'"${ROOT_CENTREON_FOLDER}"'",'"${PEER_VALIDATION}"
+  REMOTE_PAYLOAD='{"isRemote":true,"platformName":"'"${CURRENT_NODE_NAME}"'","centralServerAddress":"'"${TARGET_NODE_ADDRESS}"'","apiUsername":"'"${API_USERNAME}"'","apiCredentials":"'"${API_TARGET_PASSWORD}"'","apiScheme":"'"${PARSED_URL[SCHEME]}"'","apiPort":'"${PARSED_URL[PORT]}"',"apiPath":"'"${ROOT_CENTREON_FOLDER}"'",'"${PEER_VALIDATION}"
   if [[ -n PROXY_PAYLOAD ]]; then
     REMOTE_PAYLOAD="${REMOTE_PAYLOAD}""${PROXY_PAYLOAD}"
   fi

--- a/config/json_validator/latest/Centreon/PlatformInformation/Update.json
+++ b/config/json_validator/latest/Centreon/PlatformInformation/Update.json
@@ -4,6 +4,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "platformName": {
+      "type": "string"
+    },
     "isRemote": {
       "type": "boolean"
     },

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -4921,6 +4921,9 @@ components:
           type: boolean
           example: false
           description: "Usage of peer validation"
+        platformName:
+          type: string
+          description: "The name of the platform"
         proxy:
           type: object
           properties:

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15582,6 +15582,10 @@ msgstr "Une erreur est survenue lors de la mise à jour de la topology de la pla
 msgid "Your Central is linked to another remote(s), conversion in Remote isn't allowed"
 msgstr "Votre central est lié a d'autre remote(s), la conversion en Remote n'est pas autorisée"
 
+#: api/platform
+msgid "Platform name can't be empty"
+msgstr "Le nom de la plateforme ne peut pas être vide"
+
 #: api/platform/topology
 msgid "The address '%s' of '%s' is not valid or not resolvable"
 msgstr "L'adresse '%s' de la plateforme '%s' n'est pas valide ou ne peut être résolue"

--- a/src/Centreon/Application/Controller/PlatformController.php
+++ b/src/Centreon/Application/Controller/PlatformController.php
@@ -212,6 +212,8 @@ class PlatformController extends AbstractController
                     case 'peerValidation':
                         $platformInformationUpdate->setApiPeerValidation($platformValue);
                         break;
+                    case 'platformName':
+                        $platformInformationUpdate->setPlatformName($platformValue);
                 }
             }
 

--- a/src/Centreon/Application/Controller/PlatformController.php
+++ b/src/Centreon/Application/Controller/PlatformController.php
@@ -214,6 +214,7 @@ class PlatformController extends AbstractController
                         break;
                     case 'platformName':
                         $platformInformationUpdate->setPlatformName($platformValue);
+                        break;
                 }
             }
 

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformInformation;
 
+use InvalidArgumentException;
 use Security\Encryption;
 
 /**
@@ -150,7 +151,11 @@ class PlatformInformation
      */
     public function setPlatformName(?string $name): self
     {
-        $this->platformName = $name;
+        $this->platformName = filter_var($name, FILTER_SANITIZE_STRING);
+        if (empty($this->platformName)) {
+            throw new InvalidArgumentException(_("Platform name can't be empty"));
+        }
+
         return $this;
     }
 
@@ -225,7 +230,7 @@ class PlatformInformation
      */
     public function setApiUsername(?string $username): self
     {
-        $this->apiUsername = filter_var($username, FILTER_SANITIZE_STRING);
+        $this->apiUsername = $username;
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
@@ -46,6 +46,11 @@ class PlatformInformation
     private $appKey;
 
     /**
+     * @var string|null
+     */
+    private $platformName;
+
+    /**
      * @var bool platform type
      */
     private $isRemote = false;
@@ -128,6 +133,24 @@ class PlatformInformation
     public function setAppKey(?string $value): self
     {
         $this->appKey = $value;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPlatformName(): ?string
+    {
+        return $this->platformName;
+    }
+
+    /**
+     * @param string|null $name
+     * @return self
+     */
+    public function setPlatformName(?string $name): self
+    {
+        $this->platformName = $name;
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
@@ -225,7 +225,7 @@ class PlatformInformation
      */
     public function setApiUsername(?string $username): self
     {
-        $this->apiUsername = $username;
+        $this->apiUsername = filter_var($username, FILTER_SANITIZE_STRING);
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformInformation;
 
-use InvalidArgumentException;
 use Security\Encryption;
 
 /**
@@ -153,7 +152,7 @@ class PlatformInformation
     {
         $this->platformName = filter_var($name, FILTER_SANITIZE_STRING);
         if (empty($this->platformName)) {
-            throw new InvalidArgumentException(_("Platform name can't be empty"));
+            throw new \InvalidArgumentException(_("Platform name can't be empty"));
         }
 
         return $this;

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
@@ -89,7 +89,7 @@ class PlatformInformationService implements PlatformInformationServiceInterface
          * Convert the Remote to Central or opposite
          */
         try {
-            if ($platformInformationUpdate->isRemote() && !$currentPlatformInformation->isRemote()) {
+            if ($platformInformationUpdate->isRemote()) {
                 if ($platformInformationUpdate->getCentralServerAddress() !== null) {
                     $this->remoteServerService->convertCentralToRemote(
                         $platformInformationUpdate

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -131,7 +131,7 @@ class RemoteServerService implements RemoteServerServiceInterface
          */
         $topLevelPlatform->setParentAddress($platformInformation->getCentralServerAddress());
 
-        if($platformInformation->getPlatformName() !== null) {
+        if ($platformInformation->getPlatformName() !== null) {
             $topLevelPlatform->setName($platformInformation->getPlatformName());
         }
 

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -131,6 +131,10 @@ class RemoteServerService implements RemoteServerServiceInterface
          */
         $topLevelPlatform->setParentAddress($platformInformation->getCentralServerAddress());
 
+        if($platformInformation->getPlatformName() !== null) {
+            $topLevelPlatform->setName($platformInformation->getPlatformName());
+        }
+
         /**
          * Find any children platform and forward them to Central Parent.
          *
@@ -139,6 +143,7 @@ class RemoteServerService implements RemoteServerServiceInterface
         $platforms = $this->platformTopologyRepository->findChildrenPlatformsByParentId(
             $topLevelPlatform->getId()
         );
+
         /**
          * Insert the Top Level Platform at the beginning of array, as it need to be registered first.
          */


### PR DESCRIPTION
## Description

This PR fix an issue where it was impossible to register a remote on a Central, due to its name in database.

This PR is a quick fix for actual stable version, it will be also backported to the refactor works: https://github.com/centreon/centreon/tree/MON-6452-refacto-pfs

**Fixes** # MON-6810

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
