### PR TITLE
fix(Resource-status/Details): Fix display more status information

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/ExpandableCard.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/ExpandableCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { flip, includes, isEmpty, pipe, reject, slice } from 'ramda';
+import { isEmpty, pipe, reject, slice } from 'ramda';
 
 import {
   Typography,

--- a/www/front_src/src/Resources/Details/tabs/Details/ExpandableCard.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/ExpandableCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
+import { flip, includes, isEmpty, pipe, reject, slice } from 'ramda';
 
 import {
   Typography,
@@ -56,8 +57,8 @@ const ExpandableCard = ({
   const [outputExpanded, setOutputExpanded] = React.useState(false);
 
   const lines = content.split(/\n|\\n/);
-  const threeFirstlines = lines.slice(0, 3);
-  const lastlines = lines.slice(2, lines.length);
+  const threeFirstLines = lines.slice(0, 3);
+  const lastLines = pipe(slice(3, lines.length), reject(isEmpty))(lines);
 
   const toggleOutputExpanded = (): void => {
     setOutputExpanded(!outputExpanded);
@@ -80,10 +81,10 @@ const ExpandableCard = ({
         >
           {title}
         </Typography>
-        {threeFirstlines.map(Line)}
-        {outputExpanded && lastlines.map(Line)}
+        {threeFirstLines.map(Line)}
+        {outputExpanded && lastLines.map(Line)}
       </CardContent>
-      {lastlines.length > 0 && (
+      {lastLines.length > 0 && (
         <>
           <Divider />
           <CardActions>


### PR DESCRIPTION
## Description

This prevents the more button from displaying when the last line ends up with a new line character. It also fixes the duplicated lines when the more button is pressed:

https://www.loom.com/share/03074d6826cf4cb5a4bfefd11880c7d9

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>
- Submit a status with three lines (using \n characters), ending with a new line  (\n)
- Make sure the More button is not displayed in the details panel, on the status information card
- Submit a status with more than three lines
- Make sure no line is duplicated when the More button is pressed, in the details panel on the status information card
