### PR TITLE
fix(sec): avoid to display macro password in specific case

### DIFF
--- a/src/Centreon/Domain/Monitoring/CommandLineTrait.php
+++ b/src/Centreon/Domain/Monitoring/CommandLineTrait.php
@@ -135,7 +135,6 @@ trait CommandLineTrait
             $macroPattern .= preg_quote($commandSection, '/') . $macroMatcher;
         }
         $macroPattern .= '$';
-        var_dump($macroPattern);
 
         // if two macros are glued or separated by spaces, regex cannot detect properly password string
         if (preg_match('/\(\.\*\)\s*\(\.\*\)/', $macroPattern)) {

--- a/src/Centreon/Domain/Monitoring/CommandLineTrait.php
+++ b/src/Centreon/Domain/Monitoring/CommandLineTrait.php
@@ -135,9 +135,10 @@ trait CommandLineTrait
             $macroPattern .= preg_quote($commandSection, '/') . $macroMatcher;
         }
         $macroPattern .= '$';
+        var_dump($macroPattern);
 
-        // if two macros are glued, regex cannot detect properly password string
-        if (str_contains($macroPattern, '(.*)(.*)')) {
+        // if two macros are glued or separated by spaces, regex cannot detect properly password string
+        if (preg_match('/\(\.\*\)\s*\(\.\*\)/', $macroPattern)) {
             throw MonitoringServiceException::macroPasswordNotDetected();
         }
 

--- a/tests/php/Centreon/Domain/Monitoring/CommandLineTraitTest.php
+++ b/tests/php/Centreon/Domain/Monitoring/CommandLineTraitTest.php
@@ -72,7 +72,7 @@ class CommandLineTraitTest extends TestCase
 
         $this->configurationCommand = '$USER1$/plugin.pl --a="' . $this->hostMacroWithoutSpace->getName() . '" '
             . $this->serviceMacroWithoutSpace->getName() . ' '
-            . '-b ' . $this->hostMacroWithSpace->getName() . ' '
+            . '-b "' . $this->hostMacroWithSpace->getName() . '" '
             . $this->serviceMacroWithSpace->getName() . ' -f $_SERVICEEXTRAOPTIONS$';
 
         $this->replacementValue = '*****';
@@ -94,7 +94,7 @@ class CommandLineTraitTest extends TestCase
 
         $monitoringCommand = '/centreon/plugins/plugin.pl --a="' . $this->hostMacroWithoutSpace->getValue() . '" '
             . $this->serviceMacroWithoutSpace->getValue() . ' '
-            . '-b ' . $this->hostMacroWithSpace->getValue() . ' '
+            . '-b "' . $this->hostMacroWithSpace->getValue() . '" '
             . $this->serviceMacroWithSpace->getValue() . ' -f extra options';
         $result = $this->buildCommandLineFromConfiguration(
             $this->configurationCommand,
@@ -127,7 +127,7 @@ class CommandLineTraitTest extends TestCase
 
         $monitoringCommand = '/centreon/plugins/plugin.pl --a="' . $this->replacementValue . '" '
             . $this->replacementValue . ' '
-            . '-b ' . $this->replacementValue . ' '
+            . '-b "' . $this->replacementValue . '" '
             . $this->replacementValue . ' -f extra options';
         $result = $this->buildCommandLineFromConfiguration(
             $this->configurationCommand,
@@ -176,7 +176,7 @@ class CommandLineTraitTest extends TestCase
 
         $monitoringCommand = '/centreon/plugins/plugin.pl --a="' . $this->replacementValue . '" '
             . $this->replacementValue . ' '
-            . '-b ' . $this->replacementValue . ' '
+            . '-b "' . $this->replacementValue . '" '
             . $this->replacementValue . ' -f extra options';
 
         $this->expectException(MonitoringServiceException::class);


### PR DESCRIPTION
## Description

Fix macro password displayed in command line when multiple macros are separated by spaces and one of these is not defined

**Fixes** MON-6204 MON-6589

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)