### PR TITLE
fix(platformtopology): enable to add a remote server

### DIFF
--- a/bin/registerServerTopology.sh
+++ b/bin/registerServerTopology.sh
@@ -400,7 +400,7 @@ function request_to_remote() {
   fi
 
   # Prepare Remote Payload
-  REMOTE_PAYLOAD='{"isRemote":true,"centralServerAddress":"'"${TARGET_NODE_ADDRESS}"'","apiUsername":"'"${API_USERNAME}"'","apiCredentials":"'"${API_TARGET_PASSWORD}"'","apiScheme":"'"${PARSED_URL[SCHEME]}"'","apiPort":'"${PARSED_URL[PORT]}"',"apiPath":"'"${ROOT_CENTREON_FOLDER}"'",'"${PEER_VALIDATION}"
+  REMOTE_PAYLOAD='{"isRemote":true,"platformName":"'"${CURRENT_NODE_NAME}"'","centralServerAddress":"'"${TARGET_NODE_ADDRESS}"'","apiUsername":"'"${API_USERNAME}"'","apiCredentials":"'"${API_TARGET_PASSWORD}"'","apiScheme":"'"${PARSED_URL[SCHEME]}"'","apiPort":'"${PARSED_URL[PORT]}"',"apiPath":"'"${ROOT_CENTREON_FOLDER}"'",'"${PEER_VALIDATION}"
   if [[ -n PROXY_PAYLOAD ]]; then
     REMOTE_PAYLOAD="${REMOTE_PAYLOAD}""${PROXY_PAYLOAD}"
   fi

--- a/config/json_validator/latest/Centreon/PlatformInformation/Update.json
+++ b/config/json_validator/latest/Centreon/PlatformInformation/Update.json
@@ -4,6 +4,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "platformName": {
+      "type": "string"
+    },
     "isRemote": {
       "type": "boolean"
     },

--- a/doc/API/centreon-api-v2.1.yaml
+++ b/doc/API/centreon-api-v2.1.yaml
@@ -4918,6 +4918,9 @@ components:
     Platform.Full:
       type: object
       properties:
+        platformName:
+          type: string
+          description: "The name of the platform"
         isRemote:
           type: boolean
           example: true

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -4885,6 +4885,9 @@ components:
     Platform.Full:
       type: object
       properties:
+        platformName:
+          type: string
+          description: "The name of the platform"
         isRemote:
           type: boolean
           example: true

--- a/src/Centreon/Domain/PlatformInformation/Model/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/Model/PlatformInformation.php
@@ -36,6 +36,11 @@ class PlatformInformation
     private $isRemote;
 
     /**
+     * @var string|null
+     */
+    private $platformName;
+
+    /**
      * @var string|null central's address
      */
     private $centralServerAddress;
@@ -97,6 +102,24 @@ class PlatformInformation
     public function setRemote(bool $isRemote): self
     {
         $this->isRemote = $isRemote;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPlatformName(): ?string
+    {
+        return $this->platformName;
+    }
+
+    /**
+     * @param string|null $name
+     * @return self
+     */
+    public function setPlatformName(?string $name): self
+    {
+        $this->platformName = filter_var($name, FILTER_SANITIZE_STRING);
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformInformation/Model/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/Model/PlatformInformation.php
@@ -120,6 +120,9 @@ class PlatformInformation
     public function setPlatformName(?string $name): self
     {
         $this->platformName = filter_var($name, FILTER_SANITIZE_STRING);
+        if (empty($this->platformName)) {
+            throw new \InvalidArgumentException(_("Platform name can't be empty"));
+        }
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
+++ b/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
@@ -76,6 +76,8 @@ class PlatformInformationFactory
                     break;
                 case 'peerValidation':
                     $platformInformation->setApiPeerValidation($value);
+                case 'platformName':
+                    $platformInformation->setPlatformName($value);
                     break;
             }
         }

--- a/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
+++ b/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
@@ -76,6 +76,7 @@ class PlatformInformationFactory
                     break;
                 case 'peerValidation':
                     $platformInformation->setApiPeerValidation($value);
+                    break;
                 case 'platformName':
                     $platformInformation->setPlatformName($value);
                     break;

--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -137,6 +137,9 @@ class RemoteServerService implements RemoteServerServiceInterface
          */
         $topLevelPlatform->setParentAddress($platformInformation->getCentralServerAddress());
 
+        if ($platformInformation->getPlatformName() !== null) {
+            $topLevelPlatform->setName($platformInformation->getPlatformName());
+        }
         /**
          * Find any children platform and forward them to Central Parent.
          */


### PR DESCRIPTION
## Description

This PR fix an issue where it was impossible to register a remote on a Central, due to its name in database.

This PR is up to date with the current refactoring (will be merge on the refacto dev branch).

**Fixes** # MON-6810


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
