### PR TITLE
fix(ui): Adapt graph scale for b/s unit

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
+++ b/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
@@ -25,6 +25,7 @@ const formatMetricValue = ({
     'o',
     'octets',
     'b/s',
+    'b',
   ];
 
   const base1024 = base2Units.includes(unit) || Number(base) === 1024;

--- a/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
+++ b/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
@@ -24,6 +24,7 @@ const formatMetricValue = ({
     'B/sec',
     'o',
     'octets',
+    'b/s',
   ];
 
   const base1024 = base2Units.includes(unit) || Number(base) === 1024;


### PR DESCRIPTION
## Description

My traffic graphs aren’t human-readable on the resource status page.

The scale uses m (million) or b (billion) in place of M (mega) or G (Giga). 


## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Add a service Traffic with a high usage of bandwidth (Mb/s of Gb/s)
=> Graph scale uses M (mega) or G (Giga). 




