### PR TITLE
fix(sec): use openssl_random_pseudo_bytes to generate csrf token

### DIFF
--- a/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+++ b/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
@@ -85,7 +85,7 @@ class HTML_QuickFormCustom extends HTML_QuickForm
      */
     public function createSecurityToken()
     {
-        $token = md5(uniqid());
+        $token = bin2hex(openssl_random_pseudo_bytes(16));
 
         if (false === isset($_SESSION['x-centreon-token']) &&
             (isset($_SESSION['x-centreon-token']) &&

--- a/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+++ b/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
@@ -87,9 +87,9 @@ class HTML_QuickFormCustom extends HTML_QuickForm
     {
         $token = bin2hex(openssl_random_pseudo_bytes(16));
 
-        if (false === isset($_SESSION['x-centreon-token']) &&
-            (isset($_SESSION['x-centreon-token']) &&
-                false === is_array($_SESSION['x-centreon-token']))
+        if (
+            !isset($_SESSION['x-centreon-token'])
+            || (isset($_SESSION['x-centreon-token']) && !is_array($_SESSION['x-centreon-token']))
         ) {
             $_SESSION['x-centreon-token'] = array();
             $_SESSION['x-centreon-token-generated-at'] = array();

--- a/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+++ b/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
@@ -87,10 +87,7 @@ class HTML_QuickFormCustom extends HTML_QuickForm
     {
         $token = bin2hex(openssl_random_pseudo_bytes(16));
 
-        if (
-            !isset($_SESSION['x-centreon-token'])
-            || (isset($_SESSION['x-centreon-token']) && !is_array($_SESSION['x-centreon-token']))
-        ) {
+        if (!isset($_SESSION['x-centreon-token']) || !is_array($_SESSION['x-centreon-token'])) {
             $_SESSION['x-centreon-token'] = array();
             $_SESSION['x-centreon-token-generated-at'] = array();
         }


### PR DESCRIPTION
## Description

use openssl_random_pseudo_bytes to generate csrf token (to avoid predictable token)

**Fixes** MON-6772

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check forms still work