### PR TITLE
fix(massive change) keep same variable data select structure from beginning to end

### DIFF
--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2298,9 +2298,10 @@ function getSelectOption()
 {
     $stringToArray = function (string $value): array {
         if (strpos($value, ',') !== false) {
-            return explode(',', $value);
+            $value = explode(',', rtrim($value, ','));
+            return array_flip($value);
         }
-        return [$value];
+        return [$value => '1'];
     };
     if (isset($_GET["select"])) {
         return is_array($_GET["select"])

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1210,7 +1210,7 @@ if ($form->validate() && $from_list_menu == false) {
         }
         updateHostInDB($hostObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        foreach ($select as $hostIdToUpdate) {
+        foreach (array_keys($select) as $hostIdToUpdate) {
             updateHostInDB($hostIdToUpdate, true);
         }
     }

--- a/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -997,10 +997,8 @@ if ($form->validate() && $from_list_menu == false) {
         }
         updateHostInDB($hostObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        foreach ($select as $key => $value) {
-            if ($value) {
-                updateHostInDB($value, true);
-            }
+        foreach (array_keys($select) as $hostTemplateIdToUpdate) {
+            updateHostInDB($hostTemplateIdToUpdate, true);
         }
     }
     $o = null;

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1171,7 +1171,7 @@ if ($form->validate() && $from_list_menu == false) {
         }
         updateServiceInDB($serviceObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        foreach ($select as $serviceIdToUpdate) {
+        foreach (array_keys($select) as $serviceIdToUpdate) {
             updateServiceInDB($serviceIdToUpdate, true);
         }
     }

--- a/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -1041,10 +1041,8 @@ if ($form->validate() && $from_list_menu == false) {
         }
         updateServiceInDB($serviceObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        foreach ($select as $value) {
-            if ($value) {
-                updateServiceInDB($value, true);
-            }
+        foreach (array_keys($select) as $svcTemplateIdToUpdate) {
+            updateServiceInDB($svcTemplateIdToUpdate, true);
         }
     }
     $action = $form->getSubmitValue("action");


### PR DESCRIPTION
## Description

After doing massive changes on hosts or services in the GUI, I can’t generate the configuration. I have error messages.
This is because some host or service templates became simples hosts or services.
From listing to update form, the data structure change of id in key to id in value.
[821=> 1,580 => 1]  to [0=> 821,1 => 580]

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

    -In Centreon 20.10.3 (also on 20.10.4 and probably all 20.10 and some 20.04) I install at least the base generic plugin pack and create at least two hosts
    -I select them in the Configuration > Hosts menu
    -I change some parameter (for example the SNMP community)
    -I click twice on Save

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
