### PR TITLE
fix(test): return code 2 instead of 1 in api tests

### DIFF
--- a/tests/api/features/Acknowledgement.feature
+++ b/tests/api/features/Acknowledgement.feature
@@ -11,7 +11,7 @@ Feature:
     Given I am logged in
     And the following CLAPI import data:
     """
-    CMD;ADD;dummy_down;check;cat unknown_file
+    CMD;ADD;dummy_down;check;exit 2
     HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
     HOST;SETPARAM;test;check_command;dummy_down
     """

--- a/tests/api/features/MonitoringTimeline.feature
+++ b/tests/api/features/MonitoringTimeline.feature
@@ -11,7 +11,7 @@ Feature:
     Given I am logged in
     And the following CLAPI import data:
     """
-    CMD;ADD;dummy_down;check;cat unknown_file
+    CMD;ADD;dummy_down;check;exit 2
     HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
     HOST;SETPARAM;test;check_command;dummy_down
     """
@@ -35,7 +35,7 @@ Feature:
     Given I am logged in
     And the following CLAPI import data:
     """
-    CMD;ADD;dummy_critical;check;cat unknown_file
+    CMD;ADD;dummy_critical;check;exit 2
     HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
     SERVICE;ADD;test;test_service1;generic-service;
     SERVICE;SETPARAM;test;test_service1;check_command;dummy_critical

--- a/tests/api/features/MonitoringTimeline.feature
+++ b/tests/api/features/MonitoringTimeline.feature
@@ -35,10 +35,10 @@ Feature:
     Given I am logged in
     And the following CLAPI import data:
     """
-    CMD;ADD;dummy_critical;check;exit 2
+    CMD;ADD;dummy_code_2;check;exit 2
     HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
     SERVICE;ADD;test;test_service1;generic-service;
-    SERVICE;SETPARAM;test;test_service1;check_command;dummy_critical
+    SERVICE;SETPARAM;test;test_service1;check_command;dummy_code_2
     """
     And the configuration is generated and exported
     And I wait until service "test_service1" from host "test" is monitored
@@ -55,4 +55,4 @@ Feature:
 
     When I send a GET request to '/beta/monitoring/hosts/<hostId>/services/<serviceId>/timeline?search={"type":"event"}'
 
-    Then the JSON node "result[0].status.name" should be equal to the string "WARNING"
+    Then the JSON node "result[0].status.name" should be equal to the string "UNKNOWN"


### PR DESCRIPTION
## Description

According to nagios documentation, when `aggressive host checks` is disabled, host status code 2 means UP, but we need down status
https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI