### PR TITLE
fix(resources): add uuid to build uris

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -695,7 +695,7 @@ class MonitoringResourceController extends AbstractController
                 'type' => ResourceEntity::TYPE_SERVICE,
                 'id' => $serviceId,
                 'tab' => $tab,
-                'uuid' => 's'. $serviceId
+                'uuid' => 's' . $serviceId
             ]),
         ]);
     }

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -657,6 +657,7 @@ class MonitoringResourceController extends AbstractController
                 'type' => ResourceEntity::TYPE_HOST,
                 'id' => $hostId,
                 'tab' => $tab,
+                'uuid' => 'h' . $hostId
             ]),
         ]);
     }
@@ -694,6 +695,7 @@ class MonitoringResourceController extends AbstractController
                 'type' => ResourceEntity::TYPE_SERVICE,
                 'id' => $serviceId,
                 'tab' => $tab,
+                'uuid' => 's'. $serviceId
             ]),
         ]);
     }

--- a/tests/php/Centreon/Application/Controller/MonitoringResourceControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/MonitoringResourceControllerTest.php
@@ -229,7 +229,7 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildHostDetailsUri(1)),
-            '/monitoring/resources?details={"type":"host","id":1,"tab":"details"}'
+            '/monitoring/resources?details={"type":"host","id":1,"tab":"details","uuid":"h1"}'
         );
     }
 
@@ -247,7 +247,7 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildHostUri(1, 'graph')),
-            '/monitoring/resources?details={"type":"host","id":1,"tab":"graph"}'
+            '/monitoring/resources?details={"type":"host","id":1,"tab":"graph","uuid":"h1"}'
         );
     }
 
@@ -265,7 +265,7 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildServiceDetailsUri(1, 2)),
-            '/monitoring/resources?details={"parentType":"host","parentId":1,"type":"service","id":2,"tab":"details"}'
+            '/monitoring/resources?details={"parentType":"host","parentId":1,"type":"service","id":2,"tab":"details","uuid":"s2"}'
         );
     }
 
@@ -283,7 +283,7 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildServiceUri(1, 2, 'timeline')),
-            '/monitoring/resources?details={"parentType":"host","parentId":1,"type":"service","id":2,"tab":"timeline"}'
+            '/monitoring/resources?details={"parentType":"host","parentId":1,"type":"service","id":2,"tab":"timeline","uuid":"s2"}'
         );
     }
 }

--- a/tests/php/Centreon/Application/Controller/MonitoringResourceControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/MonitoringResourceControllerTest.php
@@ -265,8 +265,8 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildServiceDetailsUri(1, 2)),
-            '/monitoring/resources?details=
-            {"parentType":"host","parentId":1,"type":"service","id":2,"tab":"details","uuid":"s2"}'
+            '/monitoring/resources?details=' .
+            '{"parentType":"host","parentId":1,"type":"service","id":2,"tab":"details","uuid":"s2"}'
         );
     }
 
@@ -284,8 +284,8 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildServiceUri(1, 2, 'timeline')),
-            '/monitoring/resources?details=
-            {"parentType":"host","parentId":1,"type":"service","id":2,"tab":"timeline","uuid":"s2"}'
+            '/monitoring/resources?details=' .
+            '{"parentType":"host","parentId":1,"type":"service","id":2,"tab":"timeline","uuid":"s2"}'
         );
     }
 }

--- a/tests/php/Centreon/Application/Controller/MonitoringResourceControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/MonitoringResourceControllerTest.php
@@ -265,7 +265,8 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildServiceDetailsUri(1, 2)),
-            '/monitoring/resources?details={"parentType":"host","parentId":1,"type":"service","id":2,"tab":"details","uuid":"s2"}'
+            '/monitoring/resources?details=
+            {"parentType":"host","parentId":1,"type":"service","id":2,"tab":"details","uuid":"s2"}'
         );
     }
 
@@ -283,7 +284,8 @@ class MonitoringResourceControllerTest extends TestCase
 
         $this->assertEquals(
             urldecode($resourceController->buildServiceUri(1, 2, 'timeline')),
-            '/monitoring/resources?details={"parentType":"host","parentId":1,"type":"service","id":2,"tab":"timeline","uuid":"s2"}'
+            '/monitoring/resources?details=
+            {"parentType":"host","parentId":1,"type":"service","id":2,"tab":"timeline","uuid":"s2"}'
         );
     }
 }


### PR DESCRIPTION
## Description

Due to changes regarding resource status, redirection links from old pages were no longer working because uuid information was missing when building service/host details uris

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for tests

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
