### PR TITLE
fix(chore) move optimization config to webpack.config.prod

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,6 @@ module.exports = merge(baseConfig, extractCssConfig, {
       react: path.resolve('./node_modules/react'),
     },
   },
-  optimization: {
-    runtimeChunk: true,
-  },
   plugins: [
     new HtmlWebpackPlugin({
       alwaysWriteToDisk: true,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,4 +9,7 @@ module.exports = merge(baseConfig, {
     maxEntrypointSize: 1500000,
     hints: 'error',
   },
+  optimization: {
+    runtimeChunk: true,
+  },
 });


### PR DESCRIPTION
## Description
move webpack optimisation to production only, this will remove the webpack error :
`webpack_export__ is not defined`


**Fixes** # (issue)
`webpack_export__ is not defined`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

run `npm run start:dev` in centreon
## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
