### PR TITLE
fix(monitoring): issue with command line for meta service

### DIFF
--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -387,12 +387,8 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
 
         $configurationCommand = $this->serviceConfiguration->findCommandLine($monitoringService->getId());
         if (empty($configurationCommand)) {
-            // If there is no command line defined in the configuration, it's useless to continue.
-            $service = $this->serviceConfiguration->findService($monitoringService->getId());
-            if (
-                $service !== null
-                && $service->getServiceType() === \Centreon\Domain\ServiceConfiguration\Service::TYPE_META_SERVICE
-            ) {
+            // Meta Service case
+            if (preg_match('/meta_[0-9]+/', $monitoringService->getDescription())) {
                 // For META SERVICE we can define the configuration command line with the monitoring command line
                 $monitoringService->setCommandLine($monitoringCommand);
                 return;

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -388,7 +388,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
         $configurationCommand = $this->serviceConfiguration->findCommandLine($monitoringService->getId());
         if (empty($configurationCommand)) {
             // Meta Service case
-            if (preg_match('/meta_[0-9]+/', $monitoringService->getDescription())) {
+            if (preg_match('/^meta_[0-9]+$/', $monitoringService->getDescription())) {
                 // For META SERVICE we can define the configuration command line with the monitoring command line
                 $monitoringService->setCommandLine($monitoringCommand);
                 return;


### PR DESCRIPTION
## Description

This PR intends to fix an issue with Meta Services details on legacy pages. The hide password command was trying to get the Meta Service configuration though findService method which uses centreon.service table.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a Meta Service
- Generate, push and reload configuration
- Go to Monitoring -> Status details -> Services - Meta detail
- CommandLine should be displayed

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
