### PR TITLE
fix(pollers): Fatal error when deleting a poller.

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -34,7 +34,7 @@
  *
  */
 
-use Centreon\Domain\PlatformTopology\Platform;
+use Centreon\Domain\PlatformTopology\Model\PlatformRegistered;
 
 if (!isset($centreon)) {
     exit();
@@ -261,7 +261,7 @@ function deleteServerInDB(array $serverIds): void
         //If the deleted platform is a remote, reassign the parent_id of its children to the top level platform
         if (
             ($platformInTopology = $statement->fetch(\PDO::FETCH_ASSOC))
-            && $platformInTopology['type'] === Platform::TYPE_REMOTE
+            && $platformInTopology['type'] === PlatformRegistered::TYPE_REMOTE
         ) {
             $statement = $pearDB->query('SELECT id FROM `platform_topology` WHERE parent_id IS NULL');
             if ($topPlatform = $statement->fetch(\PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
## Description

Fix an issue where PHP Fatal Error appears in log while deleting a Poller.

**Fixes** # MON-6882

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
