### PR TITLE
fix(Resource-status): Various fixes

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14673,23 +14673,29 @@ msgstr ""
 #  msgid "Backward"
 #  msgstr ""
 
-msgid "Graph options"
-msgstr ""
+#  msgid "Graph options"
+#  msgstr ""
 
-msgid "Display tooltips"
-msgstr ""
-
-msgid "Check duration"
-msgstr ""
+#  msgid "Display tooltips"
+#  msgstr ""
 
 #  msgid "Check duration"
 #  msgstr ""
 
-#  msgid "Notifications enabled"
+#  msgid "Check duration"
 #  msgstr ""
 
 #  msgid "Notifications disabled"
 #  msgstr ""
 
-#  msgid "Checks disabled"
+#  msgid "All checks are disabled"
+#  msgstr ""
+
+#  msgid "Only passive checks are enabled"
+#  msgstr ""
+
+#  msgid "Mandatory data to create the entity '%s' is missing"
+#  msgstr ""
+
+#  msgid "At least one column must be selected"
 #  msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16108,14 +16108,17 @@ msgstr "Afficher l’info-bulle des valeurs de métriques"
 msgid "Check duration"
 msgstr "Temps d'exécution"
 
-msgid "Notifications enabled"
-msgstr "Notifications activées"
-
 msgid "Notifications disabled"
 msgstr "Notifications désactivées"
 
-msgid "Checks disabled"
-msgstr "Contrôles désactivés"
+msgid "All checks are disabled"
+msgstr "Tous les contrôles sont désactivés"
+
+msgid "Only passive checks are enabled"
+msgstr "Seulement les contrôles passifs sont activés"
 
 msgid "Mandatory data to create the entity '%s' is missing"
 msgstr "Les données obligatoires pour créer l'entité '%s' sont manquantes"
+
+msgid "At least one column must be selected"
+msgstr "Au moins une colonne doit être sélectionnée"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15116,23 +15116,26 @@ msgstr ""
 #  msgid "Backward"
 #  msgstr ""
 
-msgid "Graph options"
-msgstr ""
-
-msgid "Display metric values tooltip"
-msgstr ""
-
-msgid "Check duration"
-msgstr ""
-
-#  msgid "Check duration"
+#  msgid "Graph options"
 #  msgstr ""
 
-#  msgid "Notifications enabled"
+#  msgid "Display metric values tooltip"
+#  msgstr ""
+
+#  msgid "Check duration"
 #  msgstr ""
 
 #  msgid "Notifications disabled"
 #  msgstr ""
 
-#  msgid "Checks disabled"
+#  msgid "All checks are disabled"
+#  msgstr ""
+
+#  msgid "Only passive checks are enabled"
+#  msgstr ""
+
+#  msgid "Mandatory data to create the entity '%s' is missing"
+#  msgstr ""
+
+#  msgid "At least one column must be selected"
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15117,23 +15117,29 @@ msgstr ""
 #  msgid "Backward"
 #  msgstr ""
 
-msgid "Graph options"
-msgstr ""
+#  msgid "Graph options"
+#  msgstr ""
 
-msgid "Display metric values tooltip"
-msgstr ""
-
-msgid "Check duration"
-msgstr ""
+#  msgid "Display metric values tooltip"
+#  msgstr ""
 
 #  msgid "Check duration"
 #  msgstr ""
 
-#  msgid "Notifications enabled"
+#  msgid "Check duration"
 #  msgstr ""
 
 #  msgid "Notifications disabled"
 #  msgstr ""
 
-#  msgid "Checks disabled"
+#  msgid "All checks are disabled"
+#  msgstr ""
+
+#  msgid "Only passive checks are enabled"
+#  msgstr ""
+
+#  msgid "Mandatory data to create the entity '%s' is missing"
+#  msgstr ""
+
+#  msgid "At least one column must be selected"
 #  msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1181,12 +1181,12 @@
     },
     "@centreon/frontend-core": {
       "version": "github:centreon/frontend-core#6079299b5e4b7608813bfa40df90f724ace6bbe9",
-      "from": "github:centreon/frontend-core",
+      "from": "github:centreon/frontend-core#6079299b5e4b7608813bfa40df90f724ace6bbe9",
       "dev": true
     },
     "@centreon/ui": {
-      "version": "github:centreon/centreon-ui#d9159da3f4e9698be3b506a2549dfa8aaff9b9d5",
-      "from": "github:centreon/centreon-ui",
+      "version": "github:centreon/centreon-ui#1d13f9feb6415ce4de66780ae58f94885007f328",
+      "from": "github:centreon/centreon-ui#fix-listing-header-shift",
       "requires": {
         "@centreon/ui-context": "github:centreon/ui-context",
         "@dnd-kit/core": "^1.1.0",
@@ -1289,9 +1289,9 @@
       },
       "dependencies": {
         "@dnd-kit/core": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-2.0.2.tgz",
-          "integrity": "sha512-7yB7z5Cpz+b4R90lw7jGfVosoC+cz9fyw+VRDRsUsG8XvRkKO97LH8S2fCzEHaTFmABt0pZkNxYiN3FDAeEmqQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-2.1.1.tgz",
+          "integrity": "sha512-fGW1S0fnZeF50RHOyWWLPaG1bxTmt9suKnUFsU593PWAcjDXyauiVP6bQpIW39pvLIIly9fiLwyj2JhdCGRy7w==",
           "requires": {
             "@dnd-kit/accessibility": "^1.0.2",
             "@dnd-kit/utilities": "^1.0.2",
@@ -2466,9 +2466,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.30.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.1.tgz",
-      "integrity": "sha512-RQUvqqq2lxTCOffhSNxpX/9fCoR+nwuQPmG5uhuuEH5KBAzNf2bK3OzBoWjm5zKM78SLjnGRAKt8hRjQA4E46A==",
+      "version": "7.30.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.3.tgz",
+      "integrity": "sha512-7JhIg2MW6WPwyikH2iL3o7z+FTVgSOd2jqCwTAHqK7Qal2gRRYiUQyURAxtbK9VXm/UTyG9bRihv8C5Tznr2zw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -2621,9 +2621,9 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.5.tgz",
-      "integrity": "sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
+      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
@@ -2631,9 +2631,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.0.16",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.0.16.tgz",
-      "integrity": "sha512-plXL8lGR2H0xm0fHE0Dfz37ke2UtBI1wAmaWIo6BP7+pGt+BxdBQrITHAMGcac0a3PtBi5CXNPth8S53ISO1Ew==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.1.tgz",
+      "integrity": "sha512-B4roX+0mpXKGj8ndd38YoIo3IV9pmTTWxr/2cOke5apTtrNabEUE0KMBccpcAcYlfPcr7uMu+dxeeC3HdXd9qQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
@@ -2755,9 +2755,9 @@
       "integrity": "sha512-DExNQkaHd1F3dFPvGA/Aw2NGyjMln6E9QzsiqOcBgnE+VInYnFBHBBySbZQts6z6xD+5jTfKCP7M4OqMyVjdwQ=="
     },
     "@types/eslint": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
-      "integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
+      "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5350,9 +5350,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001204",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ=="
+      "version": "1.0.30001205",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
+      "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -5468,9 +5468,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.0.tgz",
+      "integrity": "sha512-UUf/S3eeczXBjHPpSnrZ1ZyxH3KmLW8nVYFUWIZA/dixYMIQr7l94yYKxaAkmPk7HO9dlT6gFqAPZC02tTdfQw=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -5847,14 +5847,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ=="
     },
     "core-js-compat": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",
-      "integrity": "sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.0.tgz",
+      "integrity": "sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==",
       "requires": {
         "browserslist": "^4.16.3",
         "semver": "7.0.0"
@@ -5868,9 +5868,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
-      "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.10.0.tgz",
+      "integrity": "sha512-CC582enhrFZStO4F8lGI7QL3SYx7/AIRc+IdSi3btrQGrVsTawo5K/crmKbRrQ+MOMhNX4v+PATn0k2NN6wI7A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6126,13 +6126,13 @@
           "dev": true
         },
         "postcss": {
-          "version": "8.2.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-          "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+          "version": "8.2.9",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+          "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
           "dev": true,
           "requires": {
             "colorette": "^1.2.2",
-            "nanoid": "^3.1.20",
+            "nanoid": "^3.1.22",
             "source-map": "^0.6.1"
           }
         },
@@ -6409,9 +6409,9 @@
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
-          "integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
           "requires": {
             "mdn-data": "2.0.14",
             "source-map": "^0.6.1"
@@ -7089,9 +7089,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.702",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.702.tgz",
-      "integrity": "sha512-qJVUKFWQnF6wP7MmTngDkmm8/KPzaiTXNFOAg5j7DSa6J7kPou7mTBqC8jpUOxauQWwHR3pn4dMRdV8IE1xdtA=="
+      "version": "1.3.704",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz",
+      "integrity": "sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -12497,9 +12497,9 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memfs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.0.tgz",
-      "integrity": "sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.1.tgz",
+      "integrity": "sha512-Y5vcpQzWTime4fBTr/fEnxXUxEYUgKbDlty1WX0gaa4ae14I6KmvK1S8HtXOX0elKAE6ENZJctkGtbTFYcRIUw==",
       "dev": true,
       "requires": {
         "fs-monkey": "1.0.1"
@@ -14913,12 +14913,12 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "8.2.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-          "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+          "version": "8.2.9",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+          "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
           "requires": {
             "colorette": "^1.2.2",
-            "nanoid": "^3.1.20",
+            "nanoid": "^3.1.22",
             "source-map": "^0.6.1"
           }
         }
@@ -18851,9 +18851,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.1.tgz",
-          "integrity": "sha512-46ZA4TalFcLLqX1dEU3dhdY38wAtDydJ4e7QQTVekLUTzXkb1LfqU6VOBXC/a9wiv4T094WURqJH6ZitF92Kqw==",
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.3.tgz",
+          "integrity": "sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -20082,9 +20082,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
-      "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.29.0.tgz",
+      "integrity": "sha512-su24GKXk+Rh3Y/0XP6lOfF9Xgura4rXwwD7LA/5XD+SdhLvQIl09zoI8z6JeuYY/E+Jm4qyCiDByrivyt34PeA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,8 +1185,8 @@
       "dev": true
     },
     "@centreon/ui": {
-      "version": "github:centreon/centreon-ui#1d13f9feb6415ce4de66780ae58f94885007f328",
-      "from": "github:centreon/centreon-ui#fix-listing-header-shift",
+      "version": "github:centreon/centreon-ui#334152cb36905e55767669cd41bc1c702133673f",
+      "from": "github:centreon/centreon-ui",
       "requires": {
         "@centreon/ui-context": "github:centreon/ui-context",
         "@dnd-kit/core": "^1.1.0",
@@ -6222,9 +6222,9 @@
           },
           "dependencies": {
             "domelementtype": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-              "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
             }
           }
         },
@@ -6950,9 +6950,9 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domexception": {
       "version": "2.0.1",
@@ -6970,11 +6970,11 @@
       }
     },
     "domhandler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+      "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
       "requires": {
-        "domelementtype": "^2.1.0"
+        "domelementtype": "^2.2.0"
       }
     },
     "dompurify": {
@@ -6983,13 +6983,13 @@
       "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
     },
     "domutils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
-      "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+      "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
       "requires": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.1.0"
       }
     },
     "dot-case": {
@@ -9349,6 +9349,16 @@
       "requires": {
         "domhandler": "4.0.0",
         "htmlparser2": "6.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+          "requires": {
+            "domelementtype": "^2.1.0"
+          }
+        }
       }
     },
     "html-encoding-sniffer": {
@@ -16961,9 +16971,9 @@
           },
           "dependencies": {
             "domelementtype": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-              "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
             },
             "entities": {
               "version": "2.2.0",
@@ -20082,9 +20092,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.29.0.tgz",
-      "integrity": "sha512-su24GKXk+Rh3Y/0XP6lOfF9Xgura4rXwwD7LA/5XD+SdhLvQIl09zoI8z6JeuYY/E+Jm4qyCiDByrivyt34PeA==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
+      "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@centreon/ui": "github:centreon/centreon-ui#fix-listing-header-shift",
+    "@centreon/ui": "github:centreon/centreon-ui",
     "@centreon/ui-context": "github:centreon/ui-context",
     "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "4.11.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.13.0",
-    "@centreon/frontend-core": "github:centreon/frontend-core",
+    "@centreon/frontend-core": "github:centreon/frontend-core#6079299b5e4b7608813bfa40df90f724ace6bbe9",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@svgr/webpack": "^5.5.0",
     "@testing-library/jest-dom": "^5.11.10",
@@ -83,7 +83,7 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@centreon/ui": "github:centreon/centreon-ui",
+    "@centreon/ui": "github:centreon/centreon-ui#fix-listing-header-shift",
     "@centreon/ui-context": "github:centreon/ui-context",
     "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "4.11.3",

--- a/www/front_src/src/Resources/Filter/Criterias/CriteriasMultiSelect.tsx
+++ b/www/front_src/src/Resources/Filter/Criterias/CriteriasMultiSelect.tsx
@@ -16,13 +16,13 @@ import {
 
 import AddIcon from '@material-ui/icons/AddCircle';
 
-import { IconPopoverAutocompleteField, useMemoComponent } from '@centreon/ui';
-
 import {
-  labelCriterias,
-  labelNewFilter,
-  labelSelectCriterias,
-} from '../../translatedLabels';
+  IconPopoverMultiSelectField,
+  SelectEntry,
+  useMemoComponent,
+} from '@centreon/ui';
+
+import { labelNewFilter, labelSelectCriterias } from '../../translatedLabels';
 import { useResourceContext } from '../../Context';
 import { FilterState } from '../useFilter';
 import { allFilter } from '../models';
@@ -58,7 +58,7 @@ const CriteriasMultiSelectContent = ({
       name: t(selectableCriterias[name].label),
     }));
 
-  const changeSelectedCriterias = (_, updatedCriterias) => {
+  const changeSelectedCriterias = (updatedCriterias: Array<SelectEntry>) => {
     const { criterias } = filter;
     const updatedNames = map(prop('id'), updatedCriterias) as Array<string>;
 
@@ -94,9 +94,8 @@ const CriteriasMultiSelectContent = ({
   };
 
   return (
-    <IconPopoverAutocompleteField
+    <IconPopoverMultiSelectField
       title={t(labelSelectCriterias)}
-      label={t(labelCriterias)}
       options={options}
       onChange={changeSelectedCriterias}
       value={selectedCriterias}

--- a/www/front_src/src/Resources/Listing/columns/Checks.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Checks.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { string } from 'yargs';
 
 import SyncDisabledIcon from '@material-ui/icons/SyncDisabled';
 import SyncProblemIcon from '@material-ui/icons/SyncProblem';

--- a/www/front_src/src/Resources/Listing/columns/Checks.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Checks.tsx
@@ -1,22 +1,46 @@
 import * as React from 'react';
 
+import { useTranslation } from 'react-i18next';
+import { string } from 'yargs';
+
 import SyncDisabledIcon from '@material-ui/icons/SyncDisabled';
+import SyncProblemIcon from '@material-ui/icons/SyncProblem';
 import { Tooltip } from '@material-ui/core';
 
 import { ComponentColumnProps } from '@centreon/ui';
 
-import { labelChecksDisabled } from '../../translatedLabels';
+import {
+  labelChecksDisabled,
+  labelOnlyPassiveChecksEnabled,
+} from '../../translatedLabels';
 
 import IconColumn from './IconColumn';
 
+interface ColumnProps {
+  Icon: (props) => JSX.Element;
+  title: string;
+}
+
+const Column = ({ Icon, title }: ColumnProps): JSX.Element => {
+  return (
+    <IconColumn>
+      <Tooltip title={title}>
+        <Icon color="primary" fontSize="small" />
+      </Tooltip>
+    </IconColumn>
+  );
+};
+
 const ChecksColumn = ({ row }: ComponentColumnProps): JSX.Element | null => {
+  const { t } = useTranslation();
+
   if (row.passive_checks === false && row.active_checks === false) {
+    return <Column Icon={SyncDisabledIcon} title={t(labelChecksDisabled)} />;
+  }
+
+  if (row.active_checks === false) {
     return (
-      <IconColumn>
-        <Tooltip title={labelChecksDisabled}>
-          <SyncDisabledIcon color="primary" fontSize="small" />
-        </Tooltip>
-      </IconColumn>
+      <Column Icon={SyncProblemIcon} title={t(labelOnlyPassiveChecksEnabled)} />
     );
   }
 

--- a/www/front_src/src/Resources/Listing/columns/Notification.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Notification.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
 
-import NotificationsIcon from '@material-ui/icons/Notifications';
+import { useTranslation } from 'react-i18next';
+
 import NotificationsOffIcon from '@material-ui/icons/NotificationsOff';
 import { Tooltip } from '@material-ui/core';
 
 import { ComponentColumnProps } from '@centreon/ui';
 
-import {
-  labelNotificationDisabled,
-  labelNotificationEnabled,
-} from '../../translatedLabels';
+import { labelNotificationDisabled } from '../../translatedLabels';
 
 import IconColumn from './IconColumn';
 
@@ -27,22 +25,23 @@ const NotificationTooltip = ({
   return <Tooltip title={title}>{icon}</Tooltip>;
 };
 
-const NotificationColumn = ({ row }: ComponentColumnProps): JSX.Element => {
-  return (
-    <IconColumn>
-      {row.notification_enabled ? (
-        <NotificationTooltip
-          Icon={NotificationsIcon}
-          title={labelNotificationEnabled}
-        />
-      ) : (
+const NotificationColumn = ({
+  row,
+}: ComponentColumnProps): JSX.Element | null => {
+  const { t } = useTranslation();
+
+  if (row.notification_enabled === false) {
+    return (
+      <IconColumn>
         <NotificationTooltip
           Icon={NotificationsOffIcon}
-          title={labelNotificationDisabled}
+          title={t(labelNotificationDisabled)}
         />
-      )}
-    </IconColumn>
-  );
+      </IconColumn>
+    );
+  }
+
+  return null;
 };
 
 export default NotificationColumn;

--- a/www/front_src/src/Resources/Listing/columns/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/index.tsx
@@ -95,7 +95,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     Component: SeverityColumn,
     sortField: 'severity_level',
     sortable: true,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'status',
@@ -117,7 +116,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     Component: ResourceColumn,
     sortField: 'name',
     sortable: true,
-    width: 'minmax(20px,max-content)',
   },
   {
     id: 'parent_resource',
@@ -127,7 +125,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     Component: ParentResourceColumn,
     sortField: 'parent_name',
     sortable: true,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'notes_url',
@@ -136,7 +133,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: NotesUrlColumn,
     sortable: false,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'action_url',
@@ -145,7 +141,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: ActionUrlColumn,
     sortable: false,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'graph',
@@ -154,7 +149,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: GraphColumn({ onClick: actions.onDisplayGraph }),
     sortable: false,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'duration',
@@ -163,21 +157,18 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getFormattedString: ({ duration }): string => duration,
     sortField: 'last_status_change',
     sortable: true,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'tries',
     label: t(labelTries),
     type: ColumnType.string,
     getFormattedString: ({ tries }): string => tries,
-    width: 'max-content',
     sortable: true,
   },
   {
     id: 'last_check',
     label: t(labelLastCheck),
     type: ColumnType.string,
-    width: 'max-content',
     getFormattedString: ({ last_check }): string => last_check,
     sortable: true,
   },
@@ -201,7 +192,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: StateColumn,
     sortable: false,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'alias',
@@ -209,7 +199,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.string,
     getFormattedString: ({ alias }): string => alias,
     sortable: true,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'fqdn',
@@ -217,7 +206,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.string,
     getFormattedString: ({ fqdn }): string => fqdn,
     sortable: true,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'monitoring_server_name',
@@ -226,7 +214,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.string,
     getFormattedString: ({ monitoring_server_name }): string =>
       monitoring_server_name,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'notification',
@@ -234,7 +221,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.component,
     getRenderComponentOnRowUpdateCondition: T,
     Component: NotificationColumn,
-    width: 'minmax(auto,max-content)',
   },
   {
     id: 'checks',
@@ -242,7 +228,6 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.component,
     getRenderComponentOnRowUpdateCondition: T,
     Component: ChecksColumn,
-    width: 'minmax(auto,max-content)',
   },
 ];
 

--- a/www/front_src/src/Resources/Listing/columns/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/index.tsx
@@ -95,6 +95,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     Component: SeverityColumn,
     sortField: 'severity_level',
     sortable: true,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'status',
@@ -116,6 +117,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     Component: ResourceColumn,
     sortField: 'name',
     sortable: true,
+    width: 'minmax(20px,max-content)',
   },
   {
     id: 'parent_resource',
@@ -125,6 +127,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     Component: ParentResourceColumn,
     sortField: 'parent_name',
     sortable: true,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'notes_url',
@@ -133,6 +136,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: NotesUrlColumn,
     sortable: false,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'action_url',
@@ -141,6 +145,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: ActionUrlColumn,
     sortable: false,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'graph',
@@ -149,6 +154,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: GraphColumn({ onClick: actions.onDisplayGraph }),
     sortable: false,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'duration',
@@ -157,18 +163,21 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getFormattedString: ({ duration }): string => duration,
     sortField: 'last_status_change',
     sortable: true,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'tries',
     label: t(labelTries),
     type: ColumnType.string,
     getFormattedString: ({ tries }): string => tries,
+    width: 'max-content',
     sortable: true,
   },
   {
     id: 'last_check',
     label: t(labelLastCheck),
     type: ColumnType.string,
+    width: 'max-content',
     getFormattedString: ({ last_check }): string => last_check,
     sortable: true,
   },
@@ -177,7 +186,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     label: t(labelInformation),
     type: ColumnType.string,
     sortable: false,
-    width: '1fr',
+    width: 'minmax(50px, 1fr)',
     getFormattedString: pipe(
       propOr('', 'information'),
       split('\n'),
@@ -192,6 +201,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     getRenderComponentOnRowUpdateCondition: T,
     Component: StateColumn,
     sortable: false,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'alias',
@@ -199,6 +209,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.string,
     getFormattedString: ({ alias }): string => alias,
     sortable: true,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'fqdn',
@@ -206,6 +217,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.string,
     getFormattedString: ({ fqdn }): string => fqdn,
     sortable: true,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'monitoring_server_name',
@@ -214,6 +226,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.string,
     getFormattedString: ({ monitoring_server_name }): string =>
       monitoring_server_name,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'notification',
@@ -221,6 +234,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.component,
     getRenderComponentOnRowUpdateCondition: T,
     Component: NotificationColumn,
+    width: 'minmax(auto,max-content)',
   },
   {
     id: 'checks',
@@ -228,6 +242,7 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     type: ColumnType.component,
     getRenderComponentOnRowUpdateCondition: T,
     Component: ChecksColumn,
+    width: 'minmax(auto,max-content)',
   },
 ];
 

--- a/www/front_src/src/Resources/Listing/index.tsx
+++ b/www/front_src/src/Resources/Listing/index.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
 
-import { equals } from 'ramda';
+import { equals, T } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { useTheme, fade } from '@material-ui/core';
 
-import { MemoizedListing as Listing } from '@centreon/ui';
+import {
+  MemoizedListing as Listing,
+  Severity,
+  useSnackbar,
+} from '@centreon/ui';
 
 import { graphTabId } from '../Details/tabs';
 import { rowColorConditions } from '../colors';
 import { useResourceContext } from '../Context';
 import Actions from '../Actions';
 import { Resource, SortOrder } from '../models';
+import { labelSelectAtLeastOneColumn } from '../translatedLabels';
 
 import { getColumns, defaultSelectedColumnIds } from './columns';
 import useLoadResources from './useLoadResources';
@@ -19,6 +24,7 @@ import useLoadResources from './useLoadResources';
 const ResourceListing = (): JSX.Element => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const { showMessage } = useSnackbar();
 
   const {
     listing,
@@ -105,13 +111,26 @@ const ResourceListing = (): JSX.Element => {
     setSelectedColumnIds(defaultSelectedColumnIds);
   };
 
+  const selectColumns = (updatedColumnIds: Array<string>): void => {
+    if (updatedColumnIds.length === 0) {
+      showMessage({
+        message: t(labelSelectAtLeastOneColumn),
+        severity: Severity.warning,
+      });
+
+      return;
+    }
+
+    setSelectedColumnIds(updatedColumnIds);
+  };
+
   return (
     <Listing
       checkable
       actions={<Actions onRefresh={initAutorefreshAndLoad} />}
       loading={loading}
       columns={columns}
-      onSelectColumns={setSelectedColumnIds}
+      onSelectColumns={selectColumns}
       columnConfiguration={{
         sortable: true,
         selectedColumnIds,

--- a/www/front_src/src/Resources/Listing/index.tsx
+++ b/www/front_src/src/Resources/Listing/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { equals, T } from 'ramda';
+import { equals } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { useTheme, fade } from '@material-ui/core';

--- a/www/front_src/src/Resources/Listing/useListing.ts
+++ b/www/front_src/src/Resources/Listing/useListing.ts
@@ -11,6 +11,7 @@ import ApiNotFoundMessage from './ApiNotFoundMessage';
 import { listResources } from './api';
 import { defaultSelectedColumnIds } from './columns';
 import {
+  clearCachedColumnIds,
   getStoredOrDefaultColumnIds,
   storeColumnIds,
 } from './columns/storedColumnIds';
@@ -44,6 +45,12 @@ const useListing = (): ListingState => {
   React.useEffect(() => {
     storeColumnIds(selectedColumnIds);
   }, [selectedColumnIds]);
+
+  React.useEffect(() => {
+    return (): void => {
+      clearCachedColumnIds();
+    };
+  });
 
   const { sendRequest, sending } = useRequest<ResourceListing>({
     request: listResources,

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -204,6 +204,9 @@ export const labelGraphOptions = 'Graph options';
 export const labelDisplayTooltips = 'Display metric values tooltip';
 export const labelAction = 'Action';
 export const labelNotes = 'Notes';
-export const labelChecksDisabled = 'Checks disabled';
+export const labelChecksDisabled = 'All checks are disabled';
+export const labelOnlyPassiveChecksEnabled = 'Only passive checks are enabled';
 export const labelNotificationDisabled = 'Notifications disabled';
 export const labelNotificationEnabled = 'Notifications enabled';
+export const labelSelectAtLeastOneColumn =
+  'At least one column must be selected';


### PR DESCRIPTION
## Description

This fixes:
- The columns configuration not being saved when leaving the page
- The possibility to unselect all columns (at least one must be selected)
- The Resources with only passive checks not being displayed in the "checks" column
- The visibility of Resources with enabled notification in the "netofiication" column
- Tre information column collapsing (minimum width set)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x (master)
