### PR TITLE
Fix(UI): Details panel header is broken when display a severity level

### DIFF
--- a/www/front_src/src/Resources/Details/Header.tsx
+++ b/www/front_src/src/Resources/Details/Header.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { hasPath } from 'ramda';
+import { hasPath, isNil, not } from 'ramda';
 
-import { Grid, Typography, makeStyles } from '@material-ui/core';
+import { Grid, Typography, makeStyles, Theme } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import CopyIcon from '@material-ui/icons/FileCopy';
 
@@ -28,15 +28,24 @@ import SelectableResourceName from './tabs/Details/SelectableResourceName';
 
 import { DetailsSectionProps } from '.';
 
-const useStyles = makeStyles((theme) => ({
-  header: {
+interface MakeStylesProps {
+  displaySeverity: boolean;
+}
+
+const useStyles = makeStyles<Theme, MakeStylesProps>((theme) => ({
+  header: ({ displaySeverity }) => ({
     alignItems: 'center',
     display: 'grid',
     gridGap: theme.spacing(2),
-    gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+    gridTemplateColumns: `${
+      displaySeverity ? 'auto' : ''
+    } auto minmax(0, 1fr) auto`,
     height: 43,
     padding: theme.spacing(0, 1),
-  },
+  }),
+}));
+
+const useStylesHeaderContent = makeStyles((theme) => ({
   parent: {
     alignItems: 'center',
     display: 'grid',
@@ -68,7 +77,7 @@ type Props = {
 const HeaderContent = ({ details, onSelectParent }: Props): JSX.Element => {
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
-  const classes = useStyles();
+  const classes = useStylesHeaderContent();
 
   const copyResourceLink = (): void => {
     try {
@@ -91,9 +100,9 @@ const HeaderContent = ({ details, onSelectParent }: Props): JSX.Element => {
 
   return (
     <>
-      {details.severity_level && (
+      {details?.severity_level && (
         <StatusChip
-          label={details.severity_level.toString()}
+          label={details?.severity_level.toString()}
           severityCode={SeverityCode.None}
         />
       )}
@@ -131,7 +140,9 @@ const HeaderContent = ({ details, onSelectParent }: Props): JSX.Element => {
 };
 
 const Header = ({ details, onSelectParent }: Props): JSX.Element => {
-  const classes = useStyles();
+  const classes = useStyles({
+    displaySeverity: not(isNil(details?.severity_level)),
+  });
 
   return (
     <div className={classes.header}>


### PR DESCRIPTION
## Description

This fixes details panel header display when a resource has a Severity

![severity_details_panel-header](https://user-images.githubusercontent.com/12515407/113838936-8ad0f680-978f-11eb-93b9-4e2af2f1b1bc.PNG)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Apply a severity level on a Resource
- Click on the Resource row to display the details panel
- -> The panel header should looks as above. That mean the status chip is no longer broken

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
