### PR TITLE
fix(apiv1): manage pagination on metrics listing

### DIFF
--- a/www/api/class/centreon_monitoring_metric.class.php
+++ b/www/api/class/centreon_monitoring_metric.class.php
@@ -107,6 +107,10 @@ class CentreonMonitoringMetric extends CentreonConfigurationObjects
                 throw new \InvalidArgumentException('Pagination parameters must be integers');
             }
 
+            if ($page < 1) {
+                throw new \InvalidArgumentException('Page number must be greater than zero');
+            }
+
             $offset = ($page - 1) * $limit;
             $query .= 'LIMIT :offset, :limit';
             $queryValues[':offset'] = [$offset, \PDO::PARAM_INT];

--- a/www/api/class/centreon_monitoring_metric.class.php
+++ b/www/api/class/centreon_monitoring_metric.class.php
@@ -98,6 +98,21 @@ class CentreonMonitoringMetric extends CentreonConfigurationObjects
         }
 
         $query .= ' ORDER BY `metric_name` COLLATE utf8_general_ci ';
+
+        if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
+            if (
+                filter_var(($limit = $this->arguments['page_limit'] ?? false), FILTER_VALIDATE_INT) === false
+                || filter_var(($page = $this->arguments['page'] ?? false), FILTER_VALIDATE_INT) === false
+            ) {
+                throw new \InvalidArgumentException('Pagination parameters must be integers');
+            }
+
+            $offset = ($page - 1) * $limit;
+            $query .= 'LIMIT :offset, :limit';
+            $queryValues[':offset'] = [$offset, \PDO::PARAM_INT];
+            $queryValues[':limit'] = [$limit, \PDO::PARAM_INT];
+        }
+
         $stmt = $this->pearDBMonitoring->prepare($query);
         foreach ($queryValues as $name => $parameters) {
             list($value, $type) = $parameters;

--- a/www/api/class/centreon_monitoring_metric.class.php
+++ b/www/api/class/centreon_monitoring_metric.class.php
@@ -101,8 +101,8 @@ class CentreonMonitoringMetric extends CentreonConfigurationObjects
 
         if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
             if (
-                filter_var(($limit = $this->arguments['page_limit'] ?? false), FILTER_VALIDATE_INT) === false
-                || filter_var(($page = $this->arguments['page'] ?? false), FILTER_VALIDATE_INT) === false
+                filter_var(($limit = $this->arguments['page_limit']), FILTER_VALIDATE_INT) === false
+                || filter_var(($page = $this->arguments['page']), FILTER_VALIDATE_INT) === false
             ) {
                 throw new \InvalidArgumentException('Pagination parameters must be integers');
             }


### PR DESCRIPTION
## Description

manage pagination on metrics listing
This allows lazy loading on metrics select2 in metaservice configuration page

**Fixes** MON-6655

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)