### PR TITLE
fix(API): remove all children platform from remote after reconversion

### DIFF
--- a/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+++ b/src/Centreon/Domain/RemoteServer/RemoteServerService.php
@@ -211,6 +211,7 @@ class RemoteServerService implements RemoteServerServiceInterface
             if ($childrenPlatform->getServerId() !== null) {
                 $this->monitoringServerService->deleteServer($childrenPlatform->getServerId());
             }
+            $this->platformTopologyRepository->deletePlatform($childrenPlatform->getId());
         }
 
         /**


### PR DESCRIPTION
## Description

This PR intends to remove all children platform from topology when a Remote Server is converted back to Central.

**Fixes** # MON-7002

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
