### PR TITLE
fix(conf): Fix Fatal Error in conf import.

### DIFF
--- a/www/class/config-generate-remote/PlatformTopology.php
+++ b/www/class/config-generate-remote/PlatformTopology.php
@@ -21,7 +21,7 @@
 
 namespace ConfigGenerateRemote;
 
-use Centreon\Domain\PlatformTopology\Platform as PlatformEntity;
+use Centreon\Domain\PlatformTopology\Model\PlatformRegistered;
 use Exception;
 use PDO;
 use ConfigGenerateRemote\Abstracts\AbstractObject;
@@ -71,7 +71,7 @@ class PlatformTopology extends AbstractObject
 
         $result = $this->stmtPlatformTopology->fetchAll(PDO::FETCH_ASSOC);
         foreach ($result as $entry) {
-            if ($entry['type'] === PlatformEntity::TYPE_REMOTE) {
+            if ($entry['type'] === PlatformRegistered::TYPE_REMOTE) {
                 $entry['parent_id'] = null;
             }
             $this->generateObjectInFile($entry);


### PR DESCRIPTION
## Description

This pr intends to fix  a PHP Fatal Error in conf import.

**Fixes** # MON-7022

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
