### PR TITLE
Fix(UI): Graph options are not updated directly

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -674,7 +674,6 @@ const memoProps = [
   'timeline',
   'tooltipPosition',
   'resource',
-  'eventAnnotationsActive',
   'loading',
   'canAdjustTimePeriod',
   'displayTooltipValues',

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -677,6 +677,8 @@ const memoProps = [
   'eventAnnotationsActive',
   'loading',
   'canAdjustTimePeriod',
+  'displayTooltipValues',
+  'displayEventAnnotations',
 ];
 
 const MemoizedGraphContent = memoizeComponent<GraphContentProps>({

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles<Theme, { panelWidth: number }>((theme) => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
     justifyContent: 'center',
-    maxHeight: theme.spacing(15),
+    maxHeight: theme.spacing(16),
     overflowY: 'auto',
     width: '100%',
   },

--- a/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -16,7 +16,7 @@ import IconColumn from './IconColumn';
 const useStyles = makeStyles((theme) => ({
   graph: {
     display: 'block',
-    maxHeight: 280,
+    maxHeight: 288,
     overflow: 'auto',
     padding: theme.spacing(2),
     width: 575,


### PR DESCRIPTION
## Description

This fixes graph options that are not updated directly in the graph (until the graph is refreshed)
https://www.loom.com/share/2d55d6e99d5b40e49c54f6c2ba80530c

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a service with some data
- Click on the service row to open details panel in Resource Status
- Pause the listing refresh
- Select the "Graph" tab
- Update the "Display metric values tooltip" switch in the graph options
- -> The metric values tooltip is displayed directly

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
