### PR TITLE
fix(notice) dont cast before empty check

### DIFF
--- a/src/Centreon/Domain/Gorgone/ConfigurationLoader.php
+++ b/src/Centreon/Domain/Gorgone/ConfigurationLoader.php
@@ -72,7 +72,7 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return (string) $this->gorgoneParameters[self::GORGONE_API_ADDRESS] ?? null;
+        return $this->gorgoneParameters[self::GORGONE_API_ADDRESS] ?? null;
     }
 
     /**
@@ -83,7 +83,7 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return (int) $this->gorgoneParameters[self::GORGONE_API_PORT] ?? null;
+        return $this->gorgoneParameters[self::GORGONE_API_PORT] ?? null;
     }
 
     /**
@@ -94,7 +94,7 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return (string) $this->gorgoneParameters[self::GORGONE_API_USERNAME] ?? null;
+        return $this->gorgoneParameters[self::GORGONE_API_USERNAME] ?? null;
     }
 
     /**
@@ -105,7 +105,7 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return (string) $this->gorgoneParameters[self::GORGONE_API_PASSWORD] ?? null;
+        return $this->gorgoneParameters[self::GORGONE_API_PASSWORD] ?? null;
     }
 
     /**
@@ -116,7 +116,7 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return (bool) $this->gorgoneParameters[self::GORGONE_API_SSL] ?? false;
+        return (bool) ($this->gorgoneParameters[self::GORGONE_API_SSL] ?? false);
     }
 
     /**
@@ -127,7 +127,7 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return (bool) $this->gorgoneParameters[self::GORGONE_API_CERTIFICATE_SELF_SIGNED] ?? false;
+        return (bool) ($this->gorgoneParameters[self::GORGONE_API_CERTIFICATE_SELF_SIGNED] ?? false);
     }
 
     /**

--- a/src/Centreon/Domain/Gorgone/ConfigurationLoader.php
+++ b/src/Centreon/Domain/Gorgone/ConfigurationLoader.php
@@ -83,7 +83,9 @@ class ConfigurationLoader implements ConfigurationLoaderApiInterface
         if (!$this->isOptionsLoaded) {
             $this->loadConfiguration();
         }
-        return $this->gorgoneParameters[self::GORGONE_API_PORT] ?? null;
+        return isset($this->gorgoneParameters[self::GORGONE_API_PORT])
+            ? (int) $this->gorgoneParameters[self::GORGONE_API_PORT]
+            : null;
     }
 
     /**


### PR DESCRIPTION
## Description

dont cast before empty check

[07-Apr-2021 11:57:52 UTC] PHP Notice:  Undefined index: gorgone_api_username in /usr/share/centreon/src/Centreon/Domain/Gorgone/ConfigurationLoader.php on line 97
[07-Apr-2021 11:57:52 UTC] PHP Notice:  Undefined index: gorgone_api_password in /usr/share/centreon/src/Centreon/Domain/Gorgone/ConfigurationLoader.php on line 108

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

