### PR TITLE
Fix(UI): Selected values are not translated

### DIFF
--- a/www/front_src/src/Resources/Filter/Criterias/Criteria.tsx
+++ b/www/front_src/src/Resources/Filter/Criterias/Criteria.tsx
@@ -59,7 +59,6 @@ const CriteriaContent = ({
     label: t(label),
     limitTags,
     openText: `${t(labelOpen)} ${t(label)}`,
-    value,
   };
 
   if (isNil(options)) {
@@ -71,23 +70,28 @@ const CriteriaContent = ({
       });
     return (
       <MultiConnectedAutocompleteField
+        {...commonProps}
         field="name"
         getEndpoint={getEndpoint}
+        value={value}
         onChange={(_, updatedValue) => {
           changeCriteria(updatedValue);
         }}
-        {...commonProps}
       />
     );
   }
 
+  const translatedValues = getTranslated(value);
+  const translatedOptions = getTranslated(options);
+
   return (
     <MultiAutocompleteField
-      options={getTranslated(options)}
+      {...commonProps}
+      options={translatedOptions}
+      value={translatedValues}
       onChange={(_, updatedValue) => {
         changeCriteria(getUntranslated(updatedValue));
       }}
-      {...commonProps}
     />
   );
 };


### PR DESCRIPTION
## Description

This fixes some autocomplete fields value that are not translated. This impacts the "Resource", "State" and "Status" filters
https://www.loom.com/share/7ddc11117ec54c0b83abedf9d43d6ebb

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Update your language to French or Spanish or Portuguese
- Go to Resource Status
- Select some values in "Resource", "State" and "Status"
- -> The selected values are translated

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
