### PR TITLE
fix(broker configuration): empty broker output

### DIFF
--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -837,21 +837,22 @@ class CentreonConfigCentreonBroker
      */
     public function updateCentreonBrokerInfos($id, $values)
     {
-
         // exclude multiple parameters load with broker js hook
         $condition = '';
-        foreach ($values['output'] as $key => $output) {
-            if (array_key_exists('lua_parameter__value_#index#', $output)) {
-                $condition .= ' AND config_key NOT LIKE "lua_parameter_%"';
-                unset($values['output'][$key]['lua_parameter__value_#index#']);
-                unset($values['output'][$key]['lua_parameter__name_#index#']);
-                unset($values['output'][$key]['lua_parameter__type_#index#']);
+        if ($values['output'] !== null) {
+            foreach ($values['output'] as $key => $output) {
+                if (array_key_exists('lua_parameter__value_#index#', $output)) {
+                    $condition .= ' AND config_key NOT LIKE "lua_parameter_%"';
+                    unset($values['output'][$key]['lua_parameter__value_#index#']);
+                    unset($values['output'][$key]['lua_parameter__name_#index#']);
+                    unset($values['output'][$key]['lua_parameter__type_#index#']);
+                }
             }
-        }
 
-        // Clean the informations for this id
-        $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = ' . (int)$id . $condition;
-        $this->db->query($query);
+            // Clean the informations for this id
+            $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = ' . (int)$id . $condition;
+            $this->db->query($query);
+        }
 
         $groups_infos = array();
         $groups_infos_multiple = array();

--- a/www/include/configuration/configCentreonBroker/formCentreonBroker.ihtml
+++ b/www/include/configuration/configCentreonBroker/formCentreonBroker.ihtml
@@ -123,6 +123,22 @@
 
 <script type="text/javascript">
 
+    var infos = new Infos();
+    var uniqueType = new Array();
+    {/literal}
+        {foreach from=$tabs item=tab}
+            infos.setPos("{$tab.id}", {$tab.nb});
+        {/foreach}
+        {foreach from=$tabs item=tab}
+            {foreach from=$tab.blocks item=block}
+                {if $block.unique == 1}
+                    uniqueType["{$block.id}"] = true;
+                {else}
+                    uniqueType["{$block.id}"] = false;
+                {/if}
+            {/foreach}
+        {/foreach}
+    {literal}
 
     jQuery('#Form').centreonValidate();
 
@@ -149,24 +165,6 @@ function Infos() {
     };
 
 }
-
-var infos = new Infos();
-{/literal}
-{foreach from=$tabs item=tab}
-infos.setPos("{$tab.id}", {$tab.nb});
-{/foreach}
-{literal}
-
-var uniqueType = new Array();{/literal}
-{foreach from=$tabs item=tab}
-{foreach from=$tab.blocks item=block}
-{if $block.unique == 1}
-uniqueType["{$block.id}"] = true;
-{else}
-uniqueType["{$block.id}"] = false;
-{/if}
-{/foreach}
-{/foreach}{literal}
 
     function addInfo(type) {
         var prev_id = infos.getPos(type);
@@ -206,8 +204,6 @@ uniqueType["{$block.id}"] = false;
         });
     }
 
-
-
     function deleteRow(type, id) {
         var row_name = type + '_' + id;
         var parent = document.getElementById(type);
@@ -231,14 +227,6 @@ uniqueType["{$block.id}"] = false;
             jQuery('add_' + tagName).show();
         }
 
-    }
-
-    function loadedConfiguration() {
-        jQuery('table.ListTable').each(function(el) {
-            if (el.id != undefined && el.id != '') {
-                checkTypeValidity("block_" + el.id);
-            }
-        });
     }
 
     function changeTab(tab) {

--- a/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+++ b/www/include/configuration/configCentreonBroker/formCentreonBroker.php
@@ -37,8 +37,18 @@ if (!isset($centreon)) {
     exit();
 }
 
-if (!$centreon->user->admin && isset($_GET['id'])
-    && count($allowedBrokerConf) && !isset($allowedBrokerConf[$_GET['id']])) {
+$id = filter_var(
+    $_REQUEST['id'],
+    FILTER_VALIDATE_INT,
+    ['options' => ['default' => 0]]
+);
+
+if (
+    !$centreon->user->admin
+    && $id !== 0
+    && count($allowedBrokerConf)
+    && !isset($allowedBrokerConf[$id])
+) {
     $msg = new CentreonMsg();
     $msg->setImage("./img/icons/warning.png");
     $msg->setTextStyle("bold");
@@ -187,8 +197,7 @@ if (isset($_GET["o"]) && $_GET["o"] == 'a') {
     );
     $form->setDefaults($result);
     $tpl->assign('config_id', 0);
-} elseif (isset($_GET['id']) && $_GET['id'] != 0) {
-    $id = $_GET['id'];
+} elseif ($id !== 0) {
     $tpl->assign('config_id', $id);
     $defaultBrokerInformation = getCentreonBrokerInformation($id);
     if (!isset($defaultBrokerInformation['log_core'])) {


### PR DESCRIPTION
## Description
This PR intends to fix an issue where the broker output was empty when all the mandatories field of the form weren't filled


**Fixes** # MON-6883

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
