### PR TITLE
enh(api): add metrics information in performance endpoint

### DIFF
--- a/doc/API/centreon-api-v2.1.yaml
+++ b/doc/API/centreon-api-v2.1.yaml
@@ -2335,14 +2335,26 @@ paths:
                               type: string
                               description: label to display in legend
                               example: 'Last:1.00'
+                        last_value:
+                          type: number
+                          nullable: true
+                          description: last value
+                          example: 5.0
                         minimum_value:
                           type: number
+                          nullable: true
                           description: minimum value
-                          example: 1.0
+                          example: 0.0
                         maximum_value:
                           type: number
+                          nullable: true
                           description: maximum value
-                          example: 1.0
+                          example: 10.0
+                        average_value:
+                          type: number
+                          nullable: true
+                          description: average value
+                          example: 5.64
                   times:
                     type: array
                     items:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -1966,14 +1966,26 @@ paths:
                               type: string
                               description: label to display in legend
                               example: 'Last:1.00'
+                        last_value:
+                          type: number
+                          nullable: true
+                          description: last value
+                          example: 5.0
                         minimum_value:
                           type: number
+                          nullable: true
                           description: minimum value
-                          example: 1.0
+                          example: 0.0
                         maximum_value:
                           type: number
+                          nullable: true
                           description: maximum value
-                          example: 1.0
+                          example: 10.0
+                        average_value:
+                          type: number
+                          nullable: true
+                          description: average value
+                          example: 5.64
                   times:
                     type: array
                     items:

--- a/www/class/centreonGraphNg.class.php
+++ b/www/class/centreonGraphNg.class.php
@@ -1076,6 +1076,11 @@ class CentreonGraphNg
             } else {
                 $metricFullname = 'vv' . $metric['vmetric_id'];
             }
+
+            $metric['last_value'] = null;
+            $metric['minimum_value'] = null;
+            $metric['maximum_value'] = null;
+            $metric['average_value'] = null;
             for (; $gprintsPos < $gprintsSize; $gprintsPos++) {
                 if (isset($rrdData['meta']['gprints'][$gprintsPos]['line'])) {
                     if ($rrdData['meta']['gprints'][$gprintsPos]['line'] == $metricFullname) {
@@ -1085,25 +1090,31 @@ class CentreonGraphNg
                     }
                 } elseif ($insert == 1) {
                     $metric['prints'][] = array_values($rrdData['meta']['gprints'][$gprintsPos]);
+                    foreach (array_values($rrdData['meta']['gprints'][$gprintsPos]) as $gprintValue) {
+                        if (preg_match('/^(.+):((?:\d|\.)+)$/', $gprintValue, $matches)) {
+                            switch ($matches[1]) {
+                                case 'Last':
+                                    $metric['last_value'] = (float) $matches[2];
+                                    break;
+                                case 'Min':
+                                    $metric['minimum_value'] = (float) $matches[2];
+                                    break;
+                                case 'Max':
+                                    $metric['maximum_value'] = (float) $matches[2];
+                                    break;
+                                case 'Average':
+                                    $metric['average_value'] = (float) $matches[2];
+                                    break;
+                            }
+                        }
+                    }
                 }
             }
 
-            $minimumValue = null;
-            $maximumValue = null;
             for ($dataIndex = 0; $dataIndex < $size; $dataIndex++) {
                 $metric['data'][] = $rrdData['data'][$dataIndex][$metricIndex];
-                if (!is_null($rrdData['data'][$dataIndex][$metricIndex]) &&
-                    (is_null($minimumValue) || $rrdData['data'][$dataIndex][$metricIndex] < $minimumValue)) {
-                    $minimumValue = $rrdData['data'][$dataIndex][$metricIndex];
-                }
-                if (!is_null($rrdData['data'][$dataIndex][$metricIndex]) &&
-                    (is_null($maximumValue) || $rrdData['data'][$dataIndex][$metricIndex] > $maximumValue)) {
-                    $maximumValue = $rrdData['data'][$dataIndex][$metricIndex];
-                }
             }
 
-            $metric['minimum_value'] = $minimumValue;
-            $metric['maximum_value'] = $maximumValue;
             $metricIndex++;
         }
     }


### PR DESCRIPTION
## Description

Add `last_value` & `average_value` metrics information to performance endpoint

**Fixes** MON-6989

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)