### PR TITLE
fix(resource): only display comments that are not deleted

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
@@ -530,7 +530,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
             LEFT JOIN `:db`.contact AS `ct` ON ct.contact_alias = c.author
             WHERE c.host_id = :host_id
             AND (c.service_id = " . ($serviceId !== null ? ':service_id)' : '0 OR c.service_id IS NULL)') . "
-            AND source = 1
+            AND source = 1 AND c.deletion_time IS NULL
         ");
 
         $collector->addValue(':host_id', $hostId, \PDO::PARAM_INT);


### PR DESCRIPTION
## Description
This PR intends to remove from the Timeline of a Resource the comments that were deleted by the user

https://www.loom.com/share/ee8ab75752a6434fbdbef80196f70a62

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- See the video provided to test

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
