### PR TITLE
Fix(UI): Wrong legend name in graph

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -117,7 +117,9 @@ const LegendContent = ({
     display,
   }: Line): JSX.Element => {
     const legendName = legend || name;
-    const metricName = includes('#', legendName) ? split('#')[1] : legendName;
+    const metricName = includes('#', legendName)
+      ? split('#')(legendName)[1]
+      : legendName;
     return (
       <div
         onMouseEnter={(): void => onHighlight(metric)}
@@ -204,7 +206,7 @@ const LegendContent = ({
                   component="p"
                   variant="caption"
                 >
-                  {`(${line.unit})`}
+                  {line.unit && `(${line.unit})`}
                 </Typography>
               </div>
               {formattedValue ? (


### PR DESCRIPTION
## Description

This fixes a wrong metric name in the legend when there is an instance in the metric name

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Monitor a AWS instance with "Cloud-Aws-Ec2-instance-custom" as host template
- Click on a service named "Ec2-Cpu-Credit"
- Select the "Graph" tab
- The real metric name (without the instance) is displayed for each legend name

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
