### PR TITLE
Fix(UI): Switching resources with the graph tab open displays the previous one for a short while

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -16,6 +16,7 @@ import {
   not,
   add,
   negate,
+  or,
 } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
@@ -42,6 +43,7 @@ import {
   CustomTimePeriod,
   CustomTimePeriodProperty,
 } from '../../Details/tabs/Graph/models';
+import { useResourceContext } from '../../Context';
 
 import Graph from './Graph';
 import Legend from './Legend';
@@ -161,6 +163,8 @@ const PerformanceGraph = ({
   const [exporting, setExporting] = React.useState<boolean>(false);
   const performanceGraphRef = React.useRef<HTMLDivElement>();
 
+  const { selectedResourceId } = useResourceContext();
+
   const {
     sendRequest: sendGetGraphDataRequest,
     sending: sendingGetGraphDataRequest,
@@ -191,6 +195,13 @@ const PerformanceGraph = ({
       setLineData(newLineData);
     });
   }, [endpoint]);
+
+  React.useEffect(() => {
+    if (or(isNil(selectedResourceId), isNil(lineData))) {
+      return;
+    }
+    setLineData(undefined);
+  }, [selectedResourceId]);
 
   if (isNil(lineData) || isNil(timeline) || isNil(endpoint)) {
     return (


### PR DESCRIPTION
## Description

This fixes the graph still display the previous Resource's graph data while switching to another Resource
https://www.loom.com/share/a31535e4068f4257a37ff3042c617244 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create at least 3 Resources with data
- Click on a Resource row
- Select the Graph tab
- -> the graph is displayed
- Select another Resource (without closing the panel)
- -> A loading skeleton is displayed while loading performance data about this Resource

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
