### PR TITLE
Fix(UI): Exporting graph to png displays unwanted data

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Graph/TimeShiftZones/Icon.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/TimeShiftZones/Icon.tsx
@@ -37,10 +37,8 @@ const TimeShiftIcon = ({
 
   const { graphHeight, marginTop, shiftTime, loading } = useTimeShiftContext();
 
-  const getIconColor = () =>
-    loading || not(equals(directionHovered, direction))
-      ? 'disabled'
-      : 'primary';
+  const displayTimeShiftIcon =
+    not(loading) && equals(directionHovered, direction);
 
   const svgProps = {
     'aria-label': t(ariaLabel),
@@ -61,7 +59,7 @@ const TimeShiftIcon = ({
             height={timeShiftIconSize}
             width={timeShiftIconSize}
           />
-          <Icon color={getIconColor()} />
+          {displayTimeShiftIcon && <Icon color="primary" />}
         </svg>
       </g>
     ),

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -333,6 +333,7 @@ const PerformanceGraph = ({
                 loadingIndicatorSize={16}
               >
                 <IconButton
+                  disableTouchRipple
                   disabled={isNil(timeline)}
                   title={t(labelExportToPng)}
                   onClick={convertToPng}


### PR DESCRIPTION
## Description

This clears data to export to PNG
![Ping-performance-2021-04-14T16_35_54](https://user-images.githubusercontent.com/12515407/114746656-4bd31000-9d50-11eb-9690-3354453244df.png)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a Resource with data
- Click on the Resource
- Select the Graph tab
- Export the graph to PNG
- -> The image should no longer contains the "time shift" icons and a ugly purple filled circle in top-right side

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
