### PR TITLE
Fix(UI): Improve legend layout

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -66,6 +66,7 @@ const ServiceGraphs = ({
         return (
           <div key={id}>
             <MemoizedPerformanceGraph
+              limitLegendRows
               adjustTimePeriod={adjustTimePeriod}
               customTimePeriod={customTimePeriod}
               getIntervalDates={getIntervalDates}

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -39,6 +39,7 @@ interface Props {
   customTimePeriod: CustomTimePeriod;
   getIntervalDates: () => [string, string];
   graphHeight: number;
+  limitLegendRows?: boolean;
   onTooltipDisplay?: (position?: [number, number]) => void;
   periodQueryParameters: string;
   resource?: Resource | ResourceDetails;
@@ -58,6 +59,7 @@ const ExportablePerformanceGraphWithTimeline = ({
   customTimePeriod,
   adjustTimePeriod,
   resourceDetailsUpdated,
+  limitLegendRows,
 }: Props): JSX.Element => {
   const classes = useStyles();
 
@@ -160,6 +162,7 @@ const ExportablePerformanceGraphWithTimeline = ({
           displayTooltipValues={displayTooltipValues}
           endpoint={getEndpoint()}
           graphHeight={graphHeight}
+          limitLegendRows={limitLegendRows}
           resource={resource as Resource}
           resourceDetailsUpdated={resourceDetailsUpdated}
           timeline={timeline}

--- a/www/front_src/src/Resources/Graph/Performance/Legend/Marker.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/Marker.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles<
       equals(LegendMarkerVariant.dot, variant) ? '50%' : 0,
     height: ({ variant }) =>
       equals(LegendMarkerVariant.dot, variant) ? 9 : '100%',
-    marginRight: theme.spacing(1),
+    marginRight: theme.spacing(0.5),
     width: 9,
   },
 }));

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import clsx from 'clsx';
-import { concat, equals, find, includes, propOr, split } from 'ramda';
+import { equals, find, includes, propOr, split } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -167,7 +167,7 @@ const LegendContent = ({
 
   return (
     <div className={classes.items}>
-      {concat(concat(concat(lines, lines), lines), lines).map((line) => {
+      {lines.map((line) => {
         const { color, name, display } = line;
 
         const markerColor = display

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import clsx from 'clsx';
-import { equals, find, includes, propOr, split } from 'ramda';
+import { concat, equals, find, includes, propOr, split } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -167,7 +167,7 @@ const LegendContent = ({
 
   return (
     <div className={classes.items}>
-      {lines.map((line) => {
+      {concat(lines, lines).map((line) => {
         const { color, name, display } = line;
 
         const markerColor = display

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import clsx from 'clsx';
-import { equals, find, includes, propOr, split } from 'ramda';
+import { concat, equals, find, includes, propOr, split } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -22,7 +22,12 @@ import { labelAvg, labelMax, labelMin } from '../../../translatedLabels';
 
 import LegendMarker from './Marker';
 
-const useStyles = makeStyles<Theme, { panelWidth: number }>((theme) => ({
+interface MakeStylesProps {
+  limitLegendRows: boolean;
+  panelWidth: number;
+}
+
+const useStyles = makeStyles<Theme, MakeStylesProps, string>((theme) => ({
   caption: ({ panelWidth }) => ({
     color: fade(theme.palette.common.black, 0.6),
     lineHeight: 1.2,
@@ -35,25 +40,20 @@ const useStyles = makeStyles<Theme, { panelWidth: number }>((theme) => ({
   hidden: {
     color: theme.palette.text.disabled,
   },
-  icon: {
-    borderRadius: '50%',
-    height: 9,
-    marginRight: theme.spacing(1),
-    width: 9,
-  },
   item: {
     display: 'grid',
     gridTemplateColumns: 'min-content minmax(50px, 1fr)',
-    margin: theme.spacing(0, 1, 1, 1),
+    marginBottom: theme.spacing(1),
   },
-  items: {
+  items: ({ limitLegendRows }) => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
     justifyContent: 'center',
-    maxHeight: theme.spacing(16),
+    marginLeft: theme.spacing(0.5),
+    maxHeight: limitLegendRows ? theme.spacing(16) : '25vh',
     overflowY: 'auto',
     width: '100%',
-  },
+  }),
   legendData: {
     display: 'flex',
     flexDirection: 'column',
@@ -63,7 +63,7 @@ const useStyles = makeStyles<Theme, { panelWidth: number }>((theme) => ({
     fontWeight: theme.typography.body1.fontWeight,
   },
   minMaxAvgContainer: {
-    columnGap: '8px',
+    columnGap: theme.spacing(0.5),
     display: 'grid',
     gridAutoRows: `${theme.spacing(2)}px`,
     gridTemplateColumns: 'repeat(2, min-content)',
@@ -80,6 +80,7 @@ const useStyles = makeStyles<Theme, { panelWidth: number }>((theme) => ({
 
 interface Props {
   base: number;
+  limitLegendRows?: boolean;
   lines: Array<Line>;
   onClearHighlight: () => void;
   onHighlight: (metric: string) => void;
@@ -104,8 +105,9 @@ const LegendContent = ({
   onClearHighlight,
   panelWidth,
   base,
+  limitLegendRows = false,
 }: LegendContentProps): JSX.Element => {
-  const classes = useStyles({ panelWidth });
+  const classes = useStyles({ limitLegendRows, panelWidth });
   const theme = useTheme();
   const { metricsValue, getFormattedMetricData } = useMetricsValueContext();
   const { t } = useTranslation();
@@ -165,7 +167,7 @@ const LegendContent = ({
 
   return (
     <div className={classes.items}>
-      {lines.map((line) => {
+      {concat(concat(concat(lines, lines), lines), lines).map((line) => {
         const { color, name, display } = line;
 
         const markerColor = display

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import clsx from 'clsx';
-import { concat, equals, find, includes, propOr, split } from 'ramda';
+import { equals, find, includes, propOr, split } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -50,7 +50,7 @@ const useStyles = makeStyles<Theme, MakeStylesProps, string>((theme) => ({
     gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
     justifyContent: 'center',
     marginLeft: theme.spacing(0.5),
-    maxHeight: limitLegendRows ? theme.spacing(16) : '25vh',
+    maxHeight: limitLegendRows ? theme.spacing(16) : 'unset',
     overflowY: 'auto',
     width: '100%',
   }),
@@ -167,7 +167,7 @@ const LegendContent = ({
 
   return (
     <div className={classes.items}>
-      {concat(lines, lines).map((line) => {
+      {lines.map((line) => {
         const { color, name, display } = line;
 
         const markerColor = display

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -67,6 +67,7 @@ interface Props {
   displayTooltipValues?: boolean;
   endpoint?: string;
   graphHeight: number;
+  limitLegendRows?: boolean;
   onAddComment?: (commentParameters: CommentParameters) => void;
   onTooltipDisplay?: (position?: [number, number]) => void;
   resource: Resource | ResourceDetails;
@@ -148,6 +149,7 @@ const PerformanceGraph = ({
   displayEventAnnotations = false,
   displayTooltipValues = false,
   displayTitle = true,
+  limitLegendRows,
 }: Props): JSX.Element | null => {
   const classes = useStyles({
     canAdjustTimePeriod: not(isNil(adjustTimePeriod)),
@@ -384,6 +386,7 @@ const PerformanceGraph = ({
         <div className={classes.legend}>
           <Legend
             base={base as number}
+            limitLegendRows={limitLegendRows}
             lines={sortedLines}
             toggable={toggableLegend}
             onClearHighlight={clearHighlight}

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -113,10 +113,7 @@ const useStyles = makeStyles<Theme, MakeStylesProps>((theme) => ({
     width: '90%',
   },
   legend: {
-    alignItems: 'center',
-    display: 'flex',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
+    height: '100%',
     width: '100%',
   },
   loadingContainer: {

--- a/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -58,6 +58,7 @@ const GraphColumn = ({
         >
           <Paper className={classes.graph}>
             <PerformanceGraph
+              limitLegendRows
               displayTitle={false}
               endpoint={endpoint}
               graphHeight={150}


### PR DESCRIPTION
## Description

This improves the legend layout. Now, we display the complete legend when display a service graph but we keep the limit legend item's rows when displaying the listing graph / Services graphs.
It also fix a horizontal scroll clipping in the legend when resizing the panel
https://www.loom.com/share/5a714a88541b49258fa5a673faa8c9bb

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Open the details for a Resource with data and with a lot of metrics
- Select the Graph tab
- Resize the panel
- -> No Horizontal scrollbar appear

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
