### PR TITLE
fix(registration): fix wrong parse of network interfaces

### DIFF
--- a/bin/registerServerTopology.sh
+++ b/bin/registerServerTopology.sh
@@ -295,9 +295,9 @@ EOF
 
 #========= begin of get_current_node_ip()
 function get_current_node_ip() {
-  PARSED_CURRENT_NODE_URL[HOST]=$(hostname -I | xargs)
+  IP_LIST=$(hostname -I | xargs)
 
-  ips=($PARSED_CURRENT_NODE_URL[HOST])
+  ips=($IP_LIST)
   count_available_ips=${#ips[@]}
 
   if [[ $count_available_ips -gt 1 ]];


### PR DESCRIPTION
## Description

this PR intends to fix wrong parse of network interfaces

**Fixes** # MON-7131

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)


## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
