### PR TITLE
enh(acl): avoid to always recalculate ACLs for BV

### DIFF
--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -341,7 +341,10 @@ try {
         WHERE acl_groups.acl_group_id = acl_res_group_relations.acl_group_id
             AND acl_res_group_relations.acl_res_id = acl_resources.acl_res_id
             AND acl_groups.acl_group_activate = '1'
-            AND (acl_groups.acl_group_changed = '1' OR acl_resources.changed = '1')"
+            AND (
+                acl_groups.acl_group_changed = '1' OR 
+                (acl_resources.changed = '1' AND acl_resources.acl_res_activate IS NOT NULL)
+            )"
     );
     while ($result = $dbResult1->fetch()) {
         $tabGroups[] = $result['acl_group_id'];


### PR DESCRIPTION
## Description

ACL are computed every time for BV. Issue still remains even if you uninstall centreon-bam or license expired.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Need centreon-bam module installed
- Assign a business view Y to an acl group X. 
- acl shouldn't be recreated for the acl group X.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
