### PR TITLE
enh(UI): Remove tooltips and add time tick above the graph

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14667,9 +14667,6 @@ msgstr "Permitir certificado autofirmado"
 # msgid "Graph options"
 # msgstr ""
 
-# msgid "Display metric values tooltip"
-# msgstr ""
-
 # msgid "Check duration"
 # msgstr ""
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16108,9 +16108,6 @@ msgstr "La date de fin doit être supérieure à la date de début"
 msgid "Graph options"
 msgstr "Options de graphe"
 
-msgid "Display metric values tooltip"
-msgstr "Afficher l’info-bulle des valeurs de métriques"
-
 msgid "Check duration"
 msgstr "Temps d'exécution"
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15124,9 +15124,6 @@ msgstr "Erro ao remover tokens de um contato"
 # msgid "Graph options"
 # msgstr ""
 
-# msgid "Display metric values tooltip"
-# msgstr ""
-
 # msgid "Check duration"
 # msgstr ""
 
@@ -15137,9 +15134,6 @@ msgstr "Erro ao remover tokens de um contato"
 # msgstr ""
 
 #  msgid "Check duration"
-
-#  msgid "Display metric values tooltip"
-#  msgstr ""
 
 #  msgid "Check duration"
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15111,9 +15111,6 @@ msgstr "Erro ao remover tokens de um contato"
 # msgid "Graph options"
 # msgstr ""
 
-# msgid "Display metric values tooltip"
-# msgstr ""
-
 # msgid "Check duration"
 # msgstr ""
 

--- a/setupTest.js
+++ b/setupTest.js
@@ -17,12 +17,12 @@ dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);
 
 document.createRange = () => ({
-  setStart: () => {},
-  setEnd: () => {},
   commonAncestorContainer: {
     nodeName: 'BODY',
     ownerDocument: document,
   },
+  setEnd: () => {},
+  setStart: () => {},
 });
 
 class IntersectionObserver {
@@ -36,21 +36,21 @@ class IntersectionObserver {
 }
 
 Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
   configurable: true,
   value: IntersectionObserver,
+  writable: true,
 });
 
 Object.defineProperty(global, 'IntersectionObserver', {
-  writable: true,
   configurable: true,
   value: IntersectionObserver,
+  writable: true,
 });
 
 i18n.use(initReactI18next).init({
-  nsSeparator: false,
-  keySeparator: false,
   fallbackLng: 'en',
+  keySeparator: false,
   lng: 'en',
+  nsSeparator: false,
   resources: {},
 });

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -598,11 +598,6 @@ describe(Details, () => {
                 label: 'Display events',
                 value: true,
               },
-              displayTooltips: {
-                id: 'displayTooltips',
-                label: 'Display metric values tooltip',
-                value: false,
-              },
             },
             selectedTimePeriodId: periodId,
           });

--- a/www/front_src/src/Resources/Details/models.ts
+++ b/www/front_src/src/Resources/Details/models.ts
@@ -50,7 +50,6 @@ interface GraphOption {
 }
 
 export interface GraphOptions {
-  [GraphOptionId.displayTooltips]: GraphOption;
   [GraphOptionId.displayEvents]: GraphOption;
 }
 

--- a/www/front_src/src/Resources/Details/tabs/Graph/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Graph/index.tsx
@@ -14,6 +14,9 @@ import { GraphOptions } from '../../models';
 import useGraphOptions, {
   GraphOptionsContext,
 } from '../../../Graph/Performance/ExportableGraphWithTimeline/useGraphOptions';
+import useMousePosition, {
+  MousePositionContext,
+} from '../../../Graph/Performance/ExportableGraphWithTimeline/useMousePosition';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -71,6 +74,8 @@ const GraphTabContent = ({
     onTimePeriodChange: setGraphTabParameters,
   });
 
+  const mousePositionProps = useMousePosition();
+
   const changeTabGraphOptions = (graphOptions: GraphOptions) => {
     setGraphTabParameters({
       ...tabParameters.graph,
@@ -92,16 +97,18 @@ const GraphTabContent = ({
           selectedTimePeriodId={selectedTimePeriod?.id}
           onChange={changeSelectedTimePeriod}
         />
-        <ExportablePerformanceGraphWithTimeline
-          adjustTimePeriod={adjustTimePeriod}
-          customTimePeriod={customTimePeriod}
-          getIntervalDates={getIntervalDates}
-          graphHeight={280}
-          periodQueryParameters={periodQueryParameters}
-          resource={details}
-          resourceDetailsUpdated={resourceDetailsUpdated}
-          selectedTimePeriod={selectedTimePeriod}
-        />
+        <MousePositionContext.Provider value={mousePositionProps}>
+          <ExportablePerformanceGraphWithTimeline
+            adjustTimePeriod={adjustTimePeriod}
+            customTimePeriod={customTimePeriod}
+            getIntervalDates={getIntervalDates}
+            graphHeight={280}
+            periodQueryParameters={periodQueryParameters}
+            resource={details}
+            resourceDetailsUpdated={resourceDetailsUpdated}
+            selectedTimePeriod={selectedTimePeriod}
+          />
+        </MousePositionContext.Provider>
       </div>
     </GraphOptionsContext.Provider>
   );

--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -6,6 +6,9 @@ import { Resource } from '../../../models';
 import ExportablePerformanceGraphWithTimeline from '../../../Graph/Performance/ExportableGraphWithTimeline';
 import { CustomTimePeriod, TimePeriod } from '../Graph/models';
 import { AdjustTimePeriodProps } from '../../../Graph/Performance/models';
+import useMousePosition, {
+  MousePositionContext,
+} from '../../../Graph/Performance/ExportableGraphWithTimeline/useMousePosition';
 
 const MemoizedPerformanceGraph = React.memo(
   ExportablePerformanceGraphWithTimeline,
@@ -14,15 +17,12 @@ const MemoizedPerformanceGraph = React.memo(
     const nextResource = nextProps.resource;
     const prevPeriodQueryParameters = prevProps.periodQueryParameters;
     const nextPeriodQueryParameters = nextProps.periodQueryParameters;
-    const prevTooltipPosition = prevProps.tooltipPosition;
-    const nextTooltipPosition = nextProps.tooltipPosition;
     const prevSelectedTimePeriod = prevProps.selectedTimePeriod;
     const nextSelectedTimePeriod = nextProps.selectedTimePeriod;
 
     return (
       equals(prevResource?.id, nextResource?.id) &&
       equals(prevPeriodQueryParameters, nextPeriodQueryParameters) &&
-      equals(prevTooltipPosition, nextTooltipPosition) &&
       equals(prevSelectedTimePeriod, nextSelectedTimePeriod)
     );
   },
@@ -49,9 +49,7 @@ const ServiceGraphs = ({
   adjustTimePeriod,
   resourceDetailsUpdated,
 }: Props): JSX.Element => {
-  const [tooltipPosition, setTooltipPosition] = React.useState<
-    [number, number]
-  >();
+  const mousePositionProps = useMousePosition();
 
   const servicesWithGraph = services.filter(
     pipe(path(['links', 'endpoints', 'performance_graph']), isNil, not),
@@ -59,29 +57,29 @@ const ServiceGraphs = ({
 
   return (
     <>
-      {servicesWithGraph.map((service) => {
-        const { id } = service;
-        const isLastService = equals(last(servicesWithGraph), service);
+      <MousePositionContext.Provider value={mousePositionProps}>
+        {servicesWithGraph.map((service) => {
+          const { id } = service;
+          const isLastService = equals(last(servicesWithGraph), service);
 
-        return (
-          <div key={id}>
-            <MemoizedPerformanceGraph
-              limitLegendRows
-              adjustTimePeriod={adjustTimePeriod}
-              customTimePeriod={customTimePeriod}
-              getIntervalDates={getIntervalDates}
-              graphHeight={120}
-              periodQueryParameters={periodQueryParameters}
-              resource={service}
-              resourceDetailsUpdated={resourceDetailsUpdated}
-              selectedTimePeriod={selectedTimePeriod}
-              tooltipPosition={tooltipPosition}
-              onTooltipDisplay={setTooltipPosition}
-            />
-            {isLastService && <div ref={infiniteScrollTriggerRef} />}
-          </div>
-        );
-      })}
+          return (
+            <div key={id}>
+              <MemoizedPerformanceGraph
+                limitLegendRows
+                adjustTimePeriod={adjustTimePeriod}
+                customTimePeriod={customTimePeriod}
+                getIntervalDates={getIntervalDates}
+                graphHeight={120}
+                periodQueryParameters={periodQueryParameters}
+                resource={service}
+                resourceDetailsUpdated={resourceDetailsUpdated}
+                selectedTimePeriod={selectedTimePeriod}
+              />
+              {isLastService && <div ref={infiniteScrollTriggerRef} />}
+            </div>
+          );
+        })}
+      </MousePositionContext.Provider>
     </>
   );
 };

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -18,6 +18,7 @@ import {
 import { Resource } from '../../../models';
 import { ResourceDetails } from '../../../Details/models';
 import { AdjustTimePeriodProps, GraphOptionId } from '../models';
+import { useIntersection } from '../useGraphIntersection';
 
 import { defaultGraphOptions, useGraphOptionsContext } from './useGraphOptions';
 
@@ -71,6 +72,9 @@ const ExportablePerformanceGraphWithTimeline = ({
   const [timeline, setTimeline] = React.useState<Array<TimelineEvent>>();
   const graphOptions =
     useGraphOptionsContext()?.graphOptions || defaultGraphOptions;
+  const graphContainerRef = React.useRef<HTMLElement | null>(null);
+
+  const { setElement, isDisplaying } = useIntersection();
 
   const displayEventAnnotations = path<boolean>(
     [GraphOptionId.displayEvents, 'value'],
@@ -122,6 +126,10 @@ const ExportablePerformanceGraphWithTimeline = ({
     retrieveTimeline();
   }, [endpoint, selectedTimePeriod, customTimePeriod, displayEventAnnotations]);
 
+  React.useEffect(() => {
+    setElement(graphContainerRef.current);
+  }, []);
+
   const getEndpoint = (): string | undefined => {
     if (isNil(endpoint)) {
       return undefined;
@@ -145,7 +153,10 @@ const ExportablePerformanceGraphWithTimeline = ({
 
   return (
     <Paper className={classes.graphContainer}>
-      <div className={classes.graph}>
+      <div
+        className={classes.graph}
+        ref={graphContainerRef as React.MutableRefObject<HTMLDivElement>}
+      >
         <PerformanceGraph
           toggableLegend
           adjustTimePeriod={adjustTimePeriod}
@@ -153,6 +164,7 @@ const ExportablePerformanceGraphWithTimeline = ({
           displayEventAnnotations={displayEventAnnotations}
           endpoint={getEndpoint()}
           graphHeight={graphHeight}
+          isDisplaying={isDisplaying}
           limitLegendRows={limitLegendRows}
           resource={resource as Resource}
           resourceDetailsUpdated={resourceDetailsUpdated}

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -40,12 +40,10 @@ interface Props {
   getIntervalDates: () => [string, string];
   graphHeight: number;
   limitLegendRows?: boolean;
-  onTooltipDisplay?: (position?: [number, number]) => void;
   periodQueryParameters: string;
   resource?: Resource | ResourceDetails;
   resourceDetailsUpdated: boolean;
   selectedTimePeriod: TimePeriod | null;
-  tooltipPosition?: [number, number];
 }
 
 const ExportablePerformanceGraphWithTimeline = ({
@@ -54,8 +52,6 @@ const ExportablePerformanceGraphWithTimeline = ({
   getIntervalDates,
   periodQueryParameters,
   graphHeight,
-  onTooltipDisplay,
-  tooltipPosition,
   customTimePeriod,
   adjustTimePeriod,
   resourceDetailsUpdated,
@@ -76,10 +72,6 @@ const ExportablePerformanceGraphWithTimeline = ({
   const graphOptions =
     useGraphOptionsContext()?.graphOptions || defaultGraphOptions;
 
-  const displayTooltipValues = path<boolean>(
-    [GraphOptionId.displayTooltips, 'value'],
-    graphOptions,
-  );
   const displayEventAnnotations = path<boolean>(
     [GraphOptionId.displayEvents, 'value'],
     graphOptions,
@@ -159,20 +151,17 @@ const ExportablePerformanceGraphWithTimeline = ({
           adjustTimePeriod={adjustTimePeriod}
           customTimePeriod={customTimePeriod}
           displayEventAnnotations={displayEventAnnotations}
-          displayTooltipValues={displayTooltipValues}
           endpoint={getEndpoint()}
           graphHeight={graphHeight}
           limitLegendRows={limitLegendRows}
           resource={resource as Resource}
           resourceDetailsUpdated={resourceDetailsUpdated}
           timeline={timeline}
-          tooltipPosition={tooltipPosition}
           xAxisTickFormat={
             selectedTimePeriod?.dateTimeFormat ||
             customTimePeriod.xAxisTickFormat
           }
           onAddComment={addCommentToTimeline}
-          onTooltipDisplay={onTooltipDisplay}
         />
       </div>
     </Paper>

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -74,7 +74,7 @@ const ExportablePerformanceGraphWithTimeline = ({
     useGraphOptionsContext()?.graphOptions || defaultGraphOptions;
   const graphContainerRef = React.useRef<HTMLElement | null>(null);
 
-  const { setElement, isDisplaying } = useIntersection();
+  const { setElement, isInViewport } = useIntersection();
 
   const displayEventAnnotations = path<boolean>(
     [GraphOptionId.displayEvents, 'value'],
@@ -164,7 +164,7 @@ const ExportablePerformanceGraphWithTimeline = ({
           displayEventAnnotations={displayEventAnnotations}
           endpoint={getEndpoint()}
           graphHeight={graphHeight}
-          isDisplaying={isDisplaying}
+          isInViewport={isInViewport}
           limitLegendRows={limitLegendRows}
           resource={resource as Resource}
           resourceDetailsUpdated={resourceDetailsUpdated}

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useGraphOptions.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useGraphOptions.tsx
@@ -4,17 +4,17 @@ import { GraphOptions, GraphTabParameters } from '../../../Details/models';
 import { labelDisplayEvents } from '../../../translatedLabels';
 import { GraphOptionId } from '../models';
 
-interface GraphOptionsProps {
+interface GraphOptionsState {
   changeGraphOptions: (graphOptionId: GraphOptionId) => () => void;
   graphOptions: GraphOptions;
 }
 
 export const GraphOptionsContext = React.createContext<
-  GraphOptionsProps | undefined
+  GraphOptionsState | undefined
 >(undefined);
 
-export const useGraphOptionsContext = (): GraphOptionsProps =>
-  React.useContext(GraphOptionsContext) as GraphOptionsProps;
+export const useGraphOptionsContext = (): GraphOptionsState =>
+  React.useContext(GraphOptionsContext) as GraphOptionsState;
 
 export const defaultGraphOptions = {
   [GraphOptionId.displayEvents]: {
@@ -24,7 +24,7 @@ export const defaultGraphOptions = {
   },
 };
 
-interface UseGraphOptionsProps {
+interface UseGraphOptionsState {
   changeTabGraphOptions: (graphOptions: GraphOptions) => void;
   graphTabParameters?: GraphTabParameters;
 }
@@ -32,7 +32,7 @@ interface UseGraphOptionsProps {
 const useGraphOptions = ({
   graphTabParameters,
   changeTabGraphOptions,
-}: UseGraphOptionsProps): GraphOptionsProps => {
+}: UseGraphOptionsState): GraphOptionsState => {
   const [graphOptions, setGraphOptions] = React.useState<GraphOptions>({
     ...defaultGraphOptions,
     ...graphTabParameters?.graphOptions,

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useGraphOptions.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useGraphOptions.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 
 import { GraphOptions, GraphTabParameters } from '../../../Details/models';
-import {
-  labelDisplayEvents,
-  labelDisplayTooltips,
-} from '../../../translatedLabels';
+import { labelDisplayEvents } from '../../../translatedLabels';
 import { GraphOptionId } from '../models';
 
 interface GraphOptionsProps {
@@ -20,11 +17,6 @@ export const useGraphOptionsContext = (): GraphOptionsProps =>
   React.useContext(GraphOptionsContext) as GraphOptionsProps;
 
 export const defaultGraphOptions = {
-  [GraphOptionId.displayTooltips]: {
-    id: GraphOptionId.displayTooltips,
-    label: labelDisplayTooltips,
-    value: false,
-  },
   [GraphOptionId.displayEvents]: {
     id: GraphOptionId.displayEvents,
     label: labelDisplayEvents,

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useMousePosition.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useMousePosition.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+type MousePosition = [number, number] | null;
+
+interface UseMousePosition {
+  mousePosition: MousePosition;
+  setMousePosition: React.Dispatch<React.SetStateAction<MousePosition>>;
+}
+
+const useMousePosition = (): UseMousePosition => {
+  const [mousePosition, setMousePosition] = React.useState<MousePosition>(null);
+
+  return {
+    mousePosition,
+    setMousePosition,
+  };
+};
+
+export default useMousePosition;
+
+export const MousePositionContext = React.createContext<
+  UseMousePosition | undefined
+>(undefined);
+
+export const useMousePositionContext = (): UseMousePosition =>
+  React.useContext(MousePositionContext) as UseMousePosition;

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useMousePosition.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/useMousePosition.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 
 type MousePosition = [number, number] | null;
 
-interface UseMousePosition {
+interface MousePositionState {
   mousePosition: MousePosition;
   setMousePosition: React.Dispatch<React.SetStateAction<MousePosition>>;
 }
 
-const useMousePosition = (): UseMousePosition => {
+const useMousePosition = (): MousePositionState => {
   const [mousePosition, setMousePosition] = React.useState<MousePosition>(null);
 
   return {
@@ -19,8 +19,8 @@ const useMousePosition = (): UseMousePosition => {
 export default useMousePosition;
 
 export const MousePositionContext = React.createContext<
-  UseMousePosition | undefined
+  MousePositionState | undefined
 >(undefined);
 
-export const useMousePositionContext = (): UseMousePosition =>
-  React.useContext(MousePositionContext) as UseMousePosition;
+export const useMousePositionContext = (): MousePositionState =>
+  React.useContext(MousePositionContext) as MousePositionState;

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -608,7 +608,7 @@ const memoProps = [
   'displayTooltipValues',
   'displayEventAnnotations',
   'containsMetrics',
-  'isDisplaying',
+  'isInViewport',
 ];
 
 const MemoizedGraphContent = memoizeComponent<GraphContentProps>({
@@ -626,7 +626,7 @@ const Graph = (
     | 'hideAddCommentTooltip'
     | 'format'
     | 'changeMetricsValue'
-    | 'isDisplaying'
+    | 'isInViewport'
   >,
 ): JSX.Element => {
   const { format } = useLocaleDateTimeFormat();

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -608,6 +608,7 @@ const memoProps = [
   'displayTooltipValues',
   'displayEventAnnotations',
   'containsMetrics',
+  'isDisplaying',
 ];
 
 const MemoizedGraphContent = memoizeComponent<GraphContentProps>({
@@ -625,6 +626,7 @@ const Graph = (
     | 'hideAddCommentTooltip'
     | 'format'
     | 'changeMetricsValue'
+    | 'isDisplaying'
   >,
 ): JSX.Element => {
   const { format } = useLocaleDateTimeFormat();

--- a/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/index.tsx
@@ -1,16 +1,6 @@
 import * as React from 'react';
 
-import {
-  equals,
-  isNil,
-  isEmpty,
-  identity,
-  min,
-  max,
-  not,
-  lt,
-  gte,
-} from 'ramda';
+import { equals, isNil, identity, min, max, not, lt, gte } from 'ramda';
 import {
   Line,
   Bar,

--- a/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { isNil } from 'ramda';
+import { isNil, not } from 'ramda';
 
 import { dateTimeFormat, useLocaleDateTimeFormat } from '@centreon/ui';
 
@@ -29,7 +29,7 @@ interface UseMetricsValue {
   metricsValue: MetricsValue | null;
 }
 
-const useMetricsValue = (): UseMetricsValue => {
+const useMetricsValue = (isInViewPort?: boolean): UseMetricsValue => {
   const [metricsValue, setMetricsValue] = React.useState<MetricsValue | null>(
     null,
   );
@@ -42,6 +42,9 @@ const useMetricsValue = (): UseMetricsValue => {
     });
 
   const changeMetricsValue = ({ newMetricsValue }) => {
+    if (not(isInViewPort)) {
+      return;
+    }
     setMetricsValue(newMetricsValue);
   };
 

--- a/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
@@ -13,8 +13,6 @@ interface MetricsValue {
   lines: Array<Line>;
   metrics: Array<string>;
   timeValue: TimeValue;
-  x: number;
-  y: number;
 }
 
 interface FormattedMetricData {
@@ -25,7 +23,7 @@ interface FormattedMetricData {
 }
 
 interface UseMetricsValue {
-  changeMetricsValue: ({ newMetricsValue, displayTooltipValues }) => void;
+  changeMetricsValue: ({ newMetricsValue }) => void;
   formatDate: () => string;
   getFormattedMetricData: (metric: string) => FormattedMetricData | null;
   metricsValue: MetricsValue | null;

--- a/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
@@ -22,14 +22,14 @@ interface FormattedMetricData {
   unit: string;
 }
 
-interface UseMetricsValue {
+interface MetricsValueState {
   changeMetricsValue: ({ newMetricsValue }) => void;
   formatDate: () => string;
   getFormattedMetricData: (metric: string) => FormattedMetricData | null;
   metricsValue: MetricsValue | null;
 }
 
-const useMetricsValue = (isInViewPort?: boolean): UseMetricsValue => {
+const useMetricsValue = (isInViewPort?: boolean): MetricsValueState => {
   const [metricsValue, setMetricsValue] = React.useState<MetricsValue | null>(
     null,
   );
@@ -82,10 +82,10 @@ const useMetricsValue = (isInViewPort?: boolean): UseMetricsValue => {
 };
 
 export const MetricsValueContext = React.createContext<
-  UseMetricsValue | undefined
+  MetricsValueState | undefined
 >(undefined);
 
-export const useMetricsValueContext = (): UseMetricsValue =>
-  React.useContext(MetricsValueContext) as UseMetricsValue;
+export const useMetricsValueContext = (): MetricsValueState =>
+  React.useContext(MetricsValueContext) as MetricsValueState;
 
 export default useMetricsValue;

--- a/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Graph/useMetricsValue.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 
-import { isEmpty, isNil, not, or } from 'ramda';
-import { useTooltip } from '@visx/visx';
+import { isNil } from 'ramda';
 
 import { dateTimeFormat, useLocaleDateTimeFormat } from '@centreon/ui';
 
 import formatMetricValue from '../formatMetricValue';
 import { Line, TimeValue } from '../models';
 import { getLineForMetric } from '../timeSeries';
-
-import MetricsTooltip from './MetricsTooltip';
 
 interface MetricsValue {
   base: number;
@@ -31,12 +28,7 @@ interface UseMetricsValue {
   changeMetricsValue: ({ newMetricsValue, displayTooltipValues }) => void;
   formatDate: () => string;
   getFormattedMetricData: (metric: string) => FormattedMetricData | null;
-  hideTooltip;
   metricsValue: MetricsValue | null;
-  tooltipData;
-  tooltipLeft;
-  tooltipOpen;
-  tooltipTop;
 }
 
 const useMetricsValue = (): UseMetricsValue => {
@@ -44,14 +36,6 @@ const useMetricsValue = (): UseMetricsValue => {
     null,
   );
   const { format } = useLocaleDateTimeFormat();
-  const {
-    tooltipData,
-    tooltipLeft,
-    tooltipTop,
-    tooltipOpen,
-    showTooltip,
-    hideTooltip,
-  } = useTooltip();
 
   const formatDate = () =>
     format({
@@ -59,19 +43,8 @@ const useMetricsValue = (): UseMetricsValue => {
       formatString: dateTimeFormat,
     });
 
-  const changeMetricsValue = ({ newMetricsValue, displayTooltipValues }) => {
+  const changeMetricsValue = ({ newMetricsValue }) => {
     setMetricsValue(newMetricsValue);
-    if (or(not(displayTooltipValues), isNil(newMetricsValue))) {
-      hideTooltip();
-      return;
-    }
-    showTooltip({
-      tooltipData: isEmpty(newMetricsValue?.metrics) ? undefined : (
-        <MetricsTooltip />
-      ),
-      tooltipLeft: newMetricsValue?.x || 0,
-      tooltipTop: newMetricsValue?.y || 0,
-    });
   };
 
   const getFormattedMetricData = (metric: string) => {
@@ -103,12 +76,7 @@ const useMetricsValue = (): UseMetricsValue => {
     changeMetricsValue,
     formatDate,
     getFormattedMetricData,
-    hideTooltip,
     metricsValue,
-    tooltipData,
-    tooltipLeft,
-    tooltipOpen,
-    tooltipTop,
   };
 };
 

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -70,6 +70,7 @@ interface Props {
   displayTitle?: boolean;
   endpoint?: string;
   graphHeight: number;
+  isDisplaying?: boolean;
   limitLegendRows?: boolean;
   onAddComment?: (commentParameters: CommentParameters) => void;
   resource: Resource | ResourceDetails;
@@ -147,6 +148,7 @@ const PerformanceGraph = ({
   displayEventAnnotations = false,
   displayTitle = true,
   limitLegendRows,
+  isDisplaying = true,
 }: Props): JSX.Element | null => {
   const classes = useStyles({
     canAdjustTimePeriod: not(isNil(adjustTimePeriod)),
@@ -160,7 +162,7 @@ const PerformanceGraph = ({
   const [title, setTitle] = React.useState<string>();
   const [base, setBase] = React.useState<number>();
   const [exporting, setExporting] = React.useState<boolean>(false);
-  const performanceGraphRef = React.useRef<HTMLDivElement>();
+  const performanceGraphRef = React.useRef<HTMLDivElement | null>(null);
 
   const { selectedResourceId } = useResourceContext();
 
@@ -203,7 +205,12 @@ const PerformanceGraph = ({
     setLineData(undefined);
   }, [selectedResourceId]);
 
-  if (isNil(lineData) || isNil(timeline) || isNil(endpoint)) {
+  if (
+    isNil(lineData) ||
+    isNil(timeline) ||
+    isNil(endpoint) ||
+    not(isDisplaying)
+  ) {
     return (
       <LoadingSkeleton
         displayTitleSkeleton={displayTitle}
@@ -341,7 +348,9 @@ const PerformanceGraph = ({
     <MetricsValueContext.Provider value={metricsValueProps}>
       <div
         className={classes.container}
-        ref={performanceGraphRef as React.RefObject<HTMLDivElement>}
+        ref={
+          performanceGraphRef as React.MutableRefObject<HTMLDivElement | null>
+        }
       >
         {displayTitle && (
           <div className={classes.graphHeader}>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -17,6 +17,7 @@ import {
   add,
   negate,
   or,
+  pathOr,
 } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
@@ -29,6 +30,7 @@ import {
   timeFormat,
   ContentWithCircularLoading,
   IconButton,
+  useLocaleDateTimeFormat,
 } from '@centreon/ui';
 
 import { TimelineEvent } from '../../Details/tabs/Timeline/models';
@@ -86,9 +88,11 @@ const useStyles = makeStyles<Theme, MakeStylesProps>((theme) => ({
   container: {
     display: 'grid',
     flexDirection: 'column',
-    gridGap: theme.spacing(1),
+    gridGap: theme.spacing(0.5),
     gridTemplateRows: ({ graphHeight, displayTitle }): string =>
-      `${displayTitle ? 'auto' : ''} ${graphHeight}px auto`,
+      `${displayTitle ? 'auto' : ''} ${theme.spacing(
+        2,
+      )}px ${graphHeight}px auto`,
     height: '100%',
     justifyItems: 'center',
     width: 'auto',
@@ -171,6 +175,7 @@ const PerformanceGraph = ({
     request: getData,
   });
   const metricsValueProps = useMetricsValue();
+  const { toDateTime } = useLocaleDateTimeFormat();
 
   React.useEffect(() => {
     if (isNil(endpoint)) {
@@ -324,6 +329,14 @@ const PerformanceGraph = ({
     });
   };
 
+  const timeTick = pathOr(
+    '',
+    ['metricsValue', 'timeValue', 'timeTick'],
+    metricsValueProps,
+  );
+
+  const metrics = pathOr([], ['metricsValue', 'metrics'], metricsValueProps);
+
   return (
     <MetricsValueContext.Provider value={metricsValueProps}>
       <div
@@ -354,6 +367,12 @@ const PerformanceGraph = ({
             </div>
           </div>
         )}
+
+        <div>
+          {timeTick && not(isEmpty(metrics)) && (
+            <Typography variant="caption">{toDateTime(timeTick)}</Typography>
+          )}
+        </div>
 
         <ParentSize>
           {({ width, height }): JSX.Element => (

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 
 import { makeStyles, Typography, Theme } from '@material-ui/core';
 import SaveAsImageIcon from '@material-ui/icons/SaveAlt';
+import { Skeleton } from '@material-ui/lab';
 
 import {
   useRequest,
@@ -163,6 +164,7 @@ const PerformanceGraph = ({
   const [base, setBase] = React.useState<number>();
   const [exporting, setExporting] = React.useState<boolean>(false);
   const performanceGraphRef = React.useRef<HTMLDivElement | null>(null);
+  const performanceGraphHeightRef = React.useRef<number>(0);
 
   const { selectedResourceId } = useResourceContext();
 
@@ -172,7 +174,7 @@ const PerformanceGraph = ({
   } = useRequest<GraphData>({
     request: getData,
   });
-  const metricsValueProps = useMetricsValue();
+  const metricsValueProps = useMetricsValue(isDisplaying);
   const { toDateTime } = useLocaleDateTimeFormat();
 
   React.useEffect(() => {
@@ -205,16 +207,28 @@ const PerformanceGraph = ({
     setLineData(undefined);
   }, [selectedResourceId]);
 
-  if (
-    isNil(lineData) ||
-    isNil(timeline) ||
-    isNil(endpoint) ||
-    not(isDisplaying)
-  ) {
+  React.useEffect(() => {
+    if (isDisplaying && performanceGraphRef.current && lineData) {
+      performanceGraphHeightRef.current =
+        performanceGraphRef.current.clientHeight;
+    }
+  }, [isDisplaying, lineData]);
+
+  if (isNil(lineData) || isNil(timeline) || isNil(endpoint)) {
     return (
       <LoadingSkeleton
         displayTitleSkeleton={displayTitle}
         graphHeight={graphHeight}
+      />
+    );
+  }
+
+  if (lineData && not(isDisplaying)) {
+    return (
+      <Skeleton
+        height={performanceGraphHeightRef.current}
+        variant="rect"
+        width="100%"
       />
     );
   }

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -71,7 +71,7 @@ interface Props {
   displayTitle?: boolean;
   endpoint?: string;
   graphHeight: number;
-  isDisplaying?: boolean;
+  isInViewport?: boolean;
   limitLegendRows?: boolean;
   onAddComment?: (commentParameters: CommentParameters) => void;
   resource: Resource | ResourceDetails;
@@ -149,7 +149,7 @@ const PerformanceGraph = ({
   displayEventAnnotations = false,
   displayTitle = true,
   limitLegendRows,
-  isDisplaying = true,
+  isInViewport = true,
 }: Props): JSX.Element | null => {
   const classes = useStyles({
     canAdjustTimePeriod: not(isNil(adjustTimePeriod)),
@@ -174,7 +174,7 @@ const PerformanceGraph = ({
   } = useRequest<GraphData>({
     request: getData,
   });
-  const metricsValueProps = useMetricsValue(isDisplaying);
+  const metricsValueProps = useMetricsValue(isInViewport);
   const { toDateTime } = useLocaleDateTimeFormat();
 
   React.useEffect(() => {
@@ -208,11 +208,11 @@ const PerformanceGraph = ({
   }, [selectedResourceId]);
 
   React.useEffect(() => {
-    if (isDisplaying && performanceGraphRef.current && lineData) {
+    if (isInViewport && performanceGraphRef.current && lineData) {
       performanceGraphHeightRef.current =
         performanceGraphRef.current.clientHeight;
     }
-  }, [isDisplaying, lineData]);
+  }, [isInViewport, lineData]);
 
   if (isNil(lineData) || isNil(timeline) || isNil(endpoint)) {
     return (
@@ -223,7 +223,7 @@ const PerformanceGraph = ({
     );
   }
 
-  if (lineData && not(isDisplaying)) {
+  if (lineData && not(isInViewport)) {
     return (
       <Skeleton
         height={performanceGraphHeightRef.current}

--- a/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
+++ b/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
@@ -21,7 +21,7 @@ export const useIntersection = (): UseIntersection => {
     observer.current = new window.IntersectionObserver(
       ([newEntry]) => setEntry(newEntry),
       {
-        rootMargin: '150px 0px 150px 0px',
+        threshold: 0,
       },
     );
 
@@ -35,7 +35,7 @@ export const useIntersection = (): UseIntersection => {
   }, [element]);
 
   return {
-    isDisplaying: Boolean(entry?.isIntersecting),
+    isDisplaying: entry?.isIntersecting ?? true,
     setElement,
   };
 };

--- a/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
+++ b/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-interface UseIntersection {
+interface GraphIntersectionState {
   isInViewport: boolean;
   setElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
 }
 
-export const useIntersection = (): UseIntersection => {
+export const useIntersection = (): GraphIntersectionState => {
   const [entry, setEntry] = React.useState<IntersectionObserverEntry | null>(
     null,
   );

--- a/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
+++ b/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+interface UseIntersection {
+  isDisplaying: boolean;
+  setElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
+}
+
+export const useIntersection = (): UseIntersection => {
+  const [entry, setEntry] = React.useState<IntersectionObserverEntry | null>(
+    null,
+  );
+  const [element, setElement] = React.useState<HTMLElement | null>(null);
+
+  const observer = React.useRef<IntersectionObserver | null>(null);
+
+  React.useEffect(() => {
+    if (observer.current) {
+      observer.current.disconnect();
+    }
+
+    observer.current = new window.IntersectionObserver(
+      ([newEntry]) => setEntry(newEntry),
+      {
+        rootMargin: '150px 0px 150px 0px',
+      },
+    );
+
+    if (element) {
+      observer.current.observe(element);
+    }
+
+    return () => {
+      observer.current?.disconnect();
+    };
+  }, [element]);
+
+  return {
+    isDisplaying: Boolean(entry?.isIntersecting),
+    setElement,
+  };
+};

--- a/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
+++ b/www/front_src/src/Resources/Graph/Performance/useGraphIntersection.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 interface UseIntersection {
-  isDisplaying: boolean;
+  isInViewport: boolean;
   setElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
 }
 
@@ -35,7 +35,7 @@ export const useIntersection = (): UseIntersection => {
   }, [element]);
 
   return {
-    isDisplaying: entry?.isIntersecting ?? true,
+    isInViewport: entry?.isIntersecting ?? true,
     setElement,
   };
 };

--- a/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -9,6 +9,11 @@ import { IconButton, ComponentColumnProps } from '@centreon/ui';
 
 import { labelGraph } from '../../translatedLabels';
 import PerformanceGraph from '../../Graph/Performance';
+import useMousePosition, {
+  MousePositionContext,
+} from '../../Graph/Performance/ExportableGraphWithTimeline/useMousePosition';
+import { ResourceDetails } from '../../Details/models';
+import { Resource } from '../../models';
 
 import HoverChip from './HoverChip';
 import IconColumn from './IconColumn';
@@ -22,6 +27,28 @@ const useStyles = makeStyles((theme) => ({
     width: 575,
   },
 }));
+
+interface GraphProps {
+  endpoint?: string;
+  row: Resource | ResourceDetails;
+}
+
+const Graph = ({ row, endpoint }: GraphProps): JSX.Element => {
+  const mousePositionProps = useMousePosition();
+
+  return (
+    <MousePositionContext.Provider value={mousePositionProps}>
+      <PerformanceGraph
+        limitLegendRows
+        displayTitle={false}
+        endpoint={endpoint}
+        graphHeight={150}
+        resource={row}
+        timeline={[]}
+      />
+    </MousePositionContext.Provider>
+  );
+};
 
 const GraphColumn = ({
   onClick,
@@ -57,14 +84,7 @@ const GraphColumn = ({
           label={labelGraph}
         >
           <Paper className={classes.graph}>
-            <PerformanceGraph
-              limitLegendRows
-              displayTitle={false}
-              endpoint={endpoint}
-              graphHeight={150}
-              resource={row}
-              timeline={[]}
-            />
+            <Graph endpoint={endpoint} row={row} />
           </Paper>
         </HoverChip>
       </IconColumn>

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -202,7 +202,6 @@ export const labelMin = 'Min';
 export const labelMax = 'Max';
 export const labelAvg = 'Avg';
 export const labelCompactTimePeriod = 'Compact time period';
-export const labelDisplayTooltips = 'Display metric values tooltip';
 export const labelAction = 'Action';
 export const labelNotes = 'Notes';
 export const labelChecksDisabled = 'All checks are disabled';


### PR DESCRIPTION
## Description

This removes the metrics values tooltip and displays the date time tick over the graph
https://www.loom.com/share/cf98e4f42f964080a0b29634a57130c3

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Select a Resource with data
- Select the Graph tab on the panel
- Click on the "Graph Options" icon
- -> The "Display metrics values tooltips" does appear
- Hover the graph part with data
- -> A date time text appears above the graph (which the mouse position on the X axis) 

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
