### PR TITLE
fix(poller form): unable to replace localhost with real IP

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1446,18 +1446,18 @@ function ipCanBeUpdated(array $options): bool
             return true;
         }
         return false;
-    } else {
-        /**
-         * If nothing was found in nagios server check if it exists in platform topology
-         * e.g: a Central is 127.0.0.1 in NS but is displayed with its true IP in platform_topology
-         */
-        $statement = $pearDB->prepare("SELECT * FROM `platform_topology` WHERE `address` = :address");
-        $statement->bindValue(':address', $serverIp, \PDO::PARAM_STR);
-        $statement->execute();
-        $platformInTopology = $statement->fetch(\PDO::FETCH_ASSOC);
-        if ($platformInTopology) {
-            return false;
-        }
-        return true;
     }
+
+    /**
+     * If nothing was found in nagios server check if it exists in platform topology
+     * e.g: a Central is 127.0.0.1 in NS but is displayed with its true IP in platform_topology
+     */
+    $statement = $pearDB->prepare("SELECT * FROM `platform_topology` WHERE `address` = :address");
+    $statement->bindValue(':address', $serverIp, \PDO::PARAM_STR);
+    $statement->execute();
+    $platformInTopology = $statement->fetch(\PDO::FETCH_ASSOC);
+    if ($platformInTopology && (int)$platformInTopology['server_id'] !== $serverId) {
+        return false;
+    }
+    return true;
 }


### PR DESCRIPTION
## Description

Unable to replace localhost with real IP address, in the poller form, when real IP was already retrieved in platform_topology table

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
