### PR TITLE
enh(menu): remove deprecated notif from menu

### DIFF
--- a/src/Centreon/Domain/Entity/Topology.php
+++ b/src/Centreon/Domain/Entity/Topology.php
@@ -154,13 +154,7 @@ class Topology
     public function getTopologyName(): ?string
     {
         // get translated menu entry
-        $topologyName = _($this->topology_name);
-
-        if ($this->getIsDeprecated() === true) {
-            $topologyName .= ' (' . _('deprecated') . ')';
-        }
-
-        return $topologyName;
+        return _($this->topology_name);
     }
 
     /**


### PR DESCRIPTION
## Description

remove entry from menu of deprecation


https://user-images.githubusercontent.com/31647811/115269570-bfec2a00-a13b-11eb-9dfa-5f4a9dfcbb25.mov



**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Enable deprecated pages
Check the menu

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
