### PR TITLE
fix(ui): Missing french translations into messages.po for Acknowledgement

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14655,5 +14655,8 @@ msgstr "Permitir certificado autofirmado"
 #  msgid "Monitoring server"
 #  msgstr ""
 
-msgid "Check duration"
-msgstr ""
+# msgid "Check duration"
+# msgstr ""
+
+# msgid "Acknowledgement"
+# msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15331,7 +15331,7 @@ msgid "Host group"
 msgstr "Groupe d'hôtes"
 
 msgid "Downtime"
-msgstr "Planifier une plage de maintenance"
+msgstr "Plage de maintenance"
 
 msgid "In downtime"
 msgstr "En plage de maintenance"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15276,6 +15276,9 @@ msgstr "Erreur lors de la suppression des tokens pour un contact"
 msgid "Acknowledged by"
 msgstr "Acquitté par"
 
+msgid "Acknowledgement"
+msgstr "Acquittement"
+
 msgid "Acknowledge services attached to host"
 msgstr "Acquitter les services attachés à l'hôte"
 
@@ -15328,7 +15331,7 @@ msgid "Host group"
 msgstr "Groupe d'hôtes"
 
 msgid "Downtime"
-msgstr "Plannifier une plage de maintenance"
+msgstr "Planifier une plage de maintenance"
 
 msgid "In downtime"
 msgstr "En plage de maintenance"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15100,3 +15100,6 @@ msgstr "Erro ao remover tokens de um contato"
 
 #  msgid "Check duration"
 #  msgstr ""
+
+# msgid "Acknowledgement"
+# msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15101,3 +15101,6 @@ msgstr "Erro ao remover tokens de um contato"
 
 msgid "Check duration"
 msgstr ""
+
+# msgid "Acknowledgement"
+# msgstr ""


### PR DESCRIPTION
## Description

Missing french translations into messages.po for Acknowledgement

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)


## Target serie

- [x] 20.10.x


<h2> How this pull request can be tested ? </h2>

Set the UI in french , then  add an acknowledgement , and check in detail panel the translation.


