### PR TITLE
fix(upgrade): correct default value on alter table

### DIFF
--- a/www/install/php/Update-20.10.6.php
+++ b/www/install/php/Update-20.10.6.php
@@ -38,7 +38,7 @@ try {
         //Create the new column
         $errorMessage = "Unable to add pending column to platform_topology table";
         $pearDB->query(
-            "ALTER TABLE `platform_topology` ADD COLUMN `pending` enum('0','1') DEFAULT ('1') AFTER `parent_id`"
+            "ALTER TABLE `platform_topology` ADD COLUMN `pending` enum('0','1') DEFAULT '1' AFTER `parent_id`"
         );
     }
     $errorMessage = '';


### PR DESCRIPTION
## Description

mariaDB 10.1 does not accept default using parenthesis. Which block the upgrade from the 19.10.x

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
