### PR TITLE
fix(filters): migrate properly personal filters (sort)

### DIFF
--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '21.04.0');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '21.04.1');
 
 --
 -- Contenu de la table `contact`

--- a/www/install/php/Update-21.04.1.php
+++ b/www/install/php/Update-21.04.1.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+include_once __DIR__ . "/../../class/centreonLog.class.php";
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 21.04.1: ';
+
+$pearDB = new CentreonDB('centreon', 3, false);
+
+/**
+ * Query with transaction
+ */
+try {
+    $pearDB->beginTransaction();
+    /**
+     * Retrieve user filters
+     */
+    $statement = $pearDB->query(
+        "SELECT `id`, `criterias` FROM `user_filter`"
+    );
+
+    $fixedCriteriaFilters = [];
+
+    /**
+     * Sort filter criteria was not correctly added during the 21.04.0
+     * upgrade. It should be an array and not an object
+     */
+    while ($filter = $statement->fetch()) {
+        $id = $filter['id'];
+        $decodedCriterias = json_decode($filter['criterias'], true);
+        foreach ($decodedCriterias as $criteriaKey => $criteria) {
+            if ($criteria['name'] === 'sort') {
+                $decodedCriterias[$criteriaKey]['value'] = ['status_severity_code', $criteria['value']['status_severity_code']];
+            }
+        }
+
+        $fixedCriteriaFilters[$id] = json_encode($decodedCriterias);
+    }
+
+    /**
+     * UPDATE SQL request on filters
+     */
+    foreach ($fixedCriteriaFilters as $id => $criterias) {
+        $errorMessage = "Unable to update filter values in user_filter table.";
+        $statement = $pearDB->prepare(
+            "UPDATE `user_filter` SET `criterias` = :criterias WHERE `id` = :id"
+        );
+        $statement->bindValue(':id', (int) $id, \PDO::PARAM_INT);
+        $statement->bindValue(':criterias', $criterias, \PDO::PARAM_STR);
+        $statement->execute();
+    }
+    $pearDB->commit();
+} catch (\Exception $e) {
+    $pearDB->rollBack();
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage .
+        " - Code : " . (int)$e->getCode() .
+        " - Error : " . $e->getMessage() .
+        " - Trace : " . $e->getTraceAsString()
+    );
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int)$e->getCode(), $e);
+}

--- a/www/install/php/Update-21.04.1.php
+++ b/www/install/php/Update-21.04.1.php
@@ -50,7 +50,10 @@ try {
         $decodedCriterias = json_decode($filter['criterias'], true);
         foreach ($decodedCriterias as $criteriaKey => $criteria) {
             if ($criteria['name'] === 'sort') {
-                $decodedCriterias[$criteriaKey]['value'] = ['status_severity_code', $criteria['value']['status_severity_code']];
+                $decodedCriterias[$criteriaKey]['value'] = [
+                    'status_severity_code',
+                    $criteria['value']['status_severity_code']
+                ];
             }
         }
 


### PR DESCRIPTION
## Description

This PR aims to fix an issue that occured during the 21.04.0 upgrade.
Sort parameters were added to custom filters but not in the correct format. (saved as object and not array)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Update from 21.04.x (where filters are no longer listed)
- Filters should be listed again

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
