### PR TITLE
Fix(UI): Services graph are positioned in a mess

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { path, isNil, equals, last, pipe, not } from 'ramda';
 
+import { makeStyles } from '@material-ui/styles';
+
 import { Resource } from '../../../models';
 import ExportablePerformanceGraphWithTimeline from '../../../Graph/Performance/ExportableGraphWithTimeline';
 import { CustomTimePeriod, TimePeriod } from '../Graph/models';
@@ -39,6 +41,12 @@ interface Props {
   services: Array<Resource>;
 }
 
+const useStyles = makeStyles({
+  serviceGraph: {
+    display: 'grid',
+  },
+});
+
 const ServiceGraphs = ({
   services,
   infiniteScrollTriggerRef,
@@ -49,6 +57,7 @@ const ServiceGraphs = ({
   adjustTimePeriod,
   resourceDetailsUpdated,
 }: Props): JSX.Element => {
+  const classes = useStyles();
   const mousePositionProps = useMousePosition();
 
   const servicesWithGraph = services.filter(
@@ -63,7 +72,7 @@ const ServiceGraphs = ({
           const isLastService = equals(last(servicesWithGraph), service);
 
           return (
-            <React.Fragment key={id}>
+            <div className={classes.serviceGraph} key={id}>
               <MemoizedPerformanceGraph
                 limitLegendRows
                 adjustTimePeriod={adjustTimePeriod}
@@ -76,7 +85,7 @@ const ServiceGraphs = ({
                 selectedTimePeriod={selectedTimePeriod}
               />
               {isLastService && <div ref={infiniteScrollTriggerRef} />}
-            </React.Fragment>
+            </div>
           );
         })}
       </MousePositionContext.Provider>

--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -63,7 +63,7 @@ const ServiceGraphs = ({
           const isLastService = equals(last(servicesWithGraph), service);
 
           return (
-            <div key={id}>
+            <React.Fragment key={id}>
               <MemoizedPerformanceGraph
                 limitLegendRows
                 adjustTimePeriod={adjustTimePeriod}
@@ -76,7 +76,7 @@ const ServiceGraphs = ({
                 selectedTimePeriod={selectedTimePeriod}
               />
               {isLastService && <div ref={infiniteScrollTriggerRef} />}
-            </div>
+            </React.Fragment>
           );
         })}
       </MousePositionContext.Provider>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -91,7 +91,7 @@ const useStyles = makeStyles<Theme, MakeStylesProps>((theme) => ({
     flexDirection: 'column',
     gridGap: theme.spacing(0.5),
     gridTemplateRows: ({ graphHeight, displayTitle }): string =>
-      `${displayTitle ? 'auto' : ''} ${theme.spacing(
+      `${displayTitle ? 'min-content' : ''} ${theme.spacing(
         2,
       )}px ${graphHeight}px auto`,
     height: '100%',

--- a/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -21,9 +21,8 @@ import IconColumn from './IconColumn';
 const useStyles = makeStyles((theme) => ({
   graph: {
     display: 'block',
-    maxHeight: 288,
     overflow: 'auto',
-    padding: theme.spacing(2),
+    padding: theme.spacing(1),
     width: 575,
   },
 }));


### PR DESCRIPTION
## Description

This fixes services graph position to align the graph tile on their height 
![Screenshot 2021-04-26 at 12 10 41](https://user-images.githubusercontent.com/12515407/116087894-9e41f400-a6a1-11eb-87a5-ba91daf2cd67.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create some services with metrics data
- Click on a service
- Select the Graph tab
- Expand the panel to the maximum
- -> The graph tiles should be aligned on their height as the image above 

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
