### PR TITLE
enh(ui): Tooltip and Detail panel display the last 24h (from now to previous 24h) on graph

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -14,6 +14,7 @@ import useMousePosition, {
 } from '../../Graph/Performance/ExportableGraphWithTimeline/useMousePosition';
 import { ResourceDetails } from '../../Details/models';
 import { Resource } from '../../models';
+import useTimePeriod from '../../Graph/Performance/TimePeriods/useTimePeriod';
 
 import HoverChip from './HoverChip';
 import IconColumn from './IconColumn';
@@ -34,6 +35,7 @@ interface GraphProps {
 }
 
 const Graph = ({ row, endpoint }: GraphProps): JSX.Element => {
+  const { periodQueryParameters } = useTimePeriod({});
   const mousePositionProps = useMousePosition();
 
   return (
@@ -41,7 +43,7 @@ const Graph = ({ row, endpoint }: GraphProps): JSX.Element => {
       <PerformanceGraph
         limitLegendRows
         displayTitle={false}
-        endpoint={endpoint}
+        endpoint={`${endpoint}${periodQueryParameters}`}
         graphHeight={150}
         resource={row}
         timeline={[]}


### PR DESCRIPTION
## Description

When monitoring is interrupted for a while (in this case, one night ) the graphs in Resources Status in Detail Panel and Tooltip are not in sync anymore when monitoring is restored.

The url called are not the same, but should return the same timeframe

**Fixes** # (issue)

Both Tooltip and Detail panel display the last 24h (from now to previous 24h)

## Type of change

- [x] New functionality (non-breaking change)

## Target serie

- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

-Have a central installed
-Deploy a host with some services (and have at least some metrics available before interrupting monitoring)
-Interrupt monitoring for the host
-Wait for X hours to pass
-Restore monitoring

