### PR TITLE
fix(resource): do not display commandLine in detail until ACL are OK

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -291,15 +291,22 @@ class MonitoringResourceController extends AbstractController
 
         $this->resource->enrichHostWithDetails($resource);
 
-        try {
-            $host = (new Host())->setId($resource->getId())
-                ->setCheckCommand($resource->getCommandLine());
-            $this->monitoring->hidePasswordInHostCommandLine($host);
-            $resource->setCommandLine($host->getCheckCommand());
-        } catch (\Throwable $ex) {
-            $resource->setCommandLine(
-                sprintf(_('Unable to hide passwords in command (Reason: %s)'), $ex->getMessage())
-            );
+        if (
+            $contact->hasRole(Contact::ROLE_DISPLAY_COMMAND) ||
+            $contact->isAdmin()
+        ) {
+            try {
+                $host = (new Host())->setId($resource->getId())
+                    ->setCheckCommand($resource->getCommandLine());
+                $this->monitoring->hidePasswordInHostCommandLine($host);
+                $resource->setCommandLine($host->getCheckCommand());
+            } catch (\Throwable $ex) {
+                $resource->setCommandLine(
+                    sprintf(_('Unable to hide passwords in command (Reason: %s)'), $ex->getMessage())
+                );
+            }
+        } else {
+            $resource->setCommandLine(null);
         }
 
         $context = (new Context())
@@ -352,17 +359,24 @@ class MonitoringResourceController extends AbstractController
 
         $this->resource->enrichServiceWithDetails($resource);
 
-        try {
-            $service = (new Service())
-                ->setId($resource->getId())
-                ->setHost((new Host())->setId($resource->getParent()->getId()))
-                ->setCommandLine($resource->getCommandLine());
-            $this->monitoring->hidePasswordInServiceCommandLine($service);
-            $resource->setCommandLine($service->getCommandLine());
-        } catch (\Throwable $ex) {
-            $resource->setCommandLine(
-                sprintf(_('Unable to hide passwords in command (Reason: %s)'), $ex->getMessage())
-            );
+        if (
+            $contact->hasRole(Contact::ROLE_DISPLAY_COMMAND) ||
+            $contact->isAdmin()
+        ) {
+            try {
+                $service = (new Service())
+                    ->setId($resource->getId())
+                    ->setHost((new Host())->setId($resource->getParent()->getId()))
+                    ->setCommandLine($resource->getCommandLine());
+                $this->monitoring->hidePasswordInServiceCommandLine($service);
+                $resource->setCommandLine($service->getCommandLine());
+            } catch (\Throwable $ex) {
+                $resource->setCommandLine(
+                    sprintf(_('Unable to hide passwords in command (Reason: %s)'), $ex->getMessage())
+                );
+            }
+        } else {
+            $resource->setCommandLine(null);
         }
 
         $context = (new Context())

--- a/src/Centreon/Domain/Contact/Contact.php
+++ b/src/Centreon/Domain/Contact/Contact.php
@@ -47,6 +47,7 @@ class Contact implements UserInterface, ContactInterface
     public const ROLE_HOST_SUBMIT_RESULT = 'ROLE_HOST_SUBMIT_RESULT';
     public const ROLE_HOST_ADD_COMMENT = 'ROLE_HOST_ADD_COMMENT';
     public const ROLE_SERVICE_ADD_COMMENT = 'ROLE_SERVICE_ADD_COMMENT';
+    public const ROLE_DISPLAY_COMMAND = 'ROLE_DISPLAY_COMMAND';
 
     // user pages access
     public const ROLE_CONFIGURATION_HOSTS_WRITE = 'ROLE_CONFIGURATION_HOSTS_HOSTS_RW';

--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -380,6 +380,9 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             case 'service_comment':
                 $contact->addRole(Contact::ROLE_SERVICE_ADD_COMMENT);
                 break;
+            case 'service_display_command':
+                $contact->addRole(Contact::ROLE_DISPLAY_COMMAND);
+                break;
         }
     }
 


### PR DESCRIPTION
## Description

This PR intends to hide the commandLine executed when you don't have access to it in Resource Status
https://www.loom.com/share/f5793352296943c9845523a97e76af23

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Video for testing matters or Jira issue

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
