### PR TITLE
fix(bug): avoid blank screen while uploading invalid image format

### DIFF
--- a/www/include/options/media/images/DB-Func.php
+++ b/www/include/options/media/images/DB-Func.php
@@ -435,7 +435,9 @@ function isCorrectMIMEType(array $file): bool
         "jpg" => "image/jpeg",
         "jpeg" => "image/jpeg",
         "gif" => "image/gif",
-        "png" => "image/png"
+        "png" => "image/png",
+        "zip" => "application/zip",
+        "gzip" => "application/x-gzip"
     ];
     $fileExtension = end(explode(".", $file["name"]));
     if (!array_key_exists($fileExtension, $mimeTypeFileExtensionConcordance)) {
@@ -568,7 +570,9 @@ function isValidMIMETypeFromArchive(
         "jpg" => "image/jpeg",
         "jpeg" => "image/jpeg",
         "gif" => "image/gif",
-        "png" => "image/png"
+        "png" => "image/png",
+        "zip" => "application/zip",
+        "gzip" => "application/x-gzip"
     ];
 
     foreach ($files as $file) {

--- a/www/include/options/media/images/DB-Func.php
+++ b/www/include/options/media/images/DB-Func.php
@@ -439,7 +439,7 @@ function isCorrectMIMEType(array $file): bool
     ];
     $fileExtension = end(explode(".", $file["name"]));
     if (!array_key_exists($fileExtension, $mimeTypeFileExtensionConcordance)) {
-        throw new \Exception(sprintf('Invalid image extension: %s', $fileExtension));
+        return false;
     }
 
     $mimeType = mime_content_type($file['tmp_name']);
@@ -574,7 +574,7 @@ function isValidMIMETypeFromArchive(
     foreach ($files as $file) {
         $fileExtension = end(explode(".", $file));
         if (!array_key_exists($fileExtension, $mimeTypeFileExtensionConcordance)) {
-            throw new \Exception(sprintf('Invalid image extension: %s', $fileExtension));
+            return false;
         }
 
         $mimeType = mime_content_type($dir . '/' . $file);


### PR DESCRIPTION
## Description

This PR intends to fix an issue introduced with MON-6770 fix. If an error occured a blank page was displayed instead of coming back to the form


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
