### PR TITLE
fix(sec): avoid sql injection in reload acl listing

### DIFF
--- a/www/class/centreonMsg.class.php
+++ b/www/class/centreonMsg.class.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -43,12 +44,12 @@ class CentreonMsg
     public $div;
 
     /* Constructor */
-    public function __construct($div_str = null)
+    public function __construct($divId = null)
     {
-        if (!isset($div_str) && !$div_str) {
+        if (empty($divId)) {
             $this->div = "centreonMsg";
         } else {
-            $this->div = $div_str;
+            $this->div = $divId;
         }
         $this->color = "#FFFFFF";
     }
@@ -106,9 +107,9 @@ class CentreonMsg
     /* If you want to display your message for a limited time period, just call this function */
     public function setTimeOut($sec)
     {
-        $sec *= 1000;
-        echo "<script type=\"text/javascript\">setTimeout(function(){new Effect.toggle(\"" .
-            $this->div . "\")}, " . $sec . ")</script>";
+        echo "<script type=\"text/javascript\">"
+            . "setTimeout(() => { jQuery(\"#" . $this->div . "\").toggle(); }, " . ($sec * 1000) . ");"
+            . "</script>";
     }
 
     /* Clear message box */
@@ -183,7 +184,7 @@ class CentreonMsg
     function _setTimeout(div_str, sec) {
         sec *= 1000;
         setTimeout(function () {
-            new Effect.toggle(div_str)
+            jQuery(`#${div_str}`).toggle()
         }, sec)
     }
 </script>

--- a/www/include/options/accessLists/reloadACL/reloadACL.php
+++ b/www/include/options/accessLists/reloadACL/reloadACL.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -37,12 +38,10 @@ if (!isset($centreon)) {
     exit();
 }
 
-$path = "./include/options/accessLists/reloadACL/";
-
 require_once "./include/common/common-Func.php";
 require_once "./class/centreonMsg.class.php";
 
-if (isset($_GET["o"]) && $_GET["o"] == "r") {
+if (isset($_GET["o"]) && $_GET["o"] === 'r') {
     $sid = session_id();
     $pearDB->query("UPDATE session SET update_acl = '1' WHERE session_id = '" . $pearDB->escape($sid) . "'");
     $pearDB->query("UPDATE acl_resources SET changed = '1'");
@@ -51,9 +50,11 @@ if (isset($_GET["o"]) && $_GET["o"] == "r") {
     $msg->setText(_("ACL reloaded"));
     $msg->setTimeOut("3");
     passthru(_CENTREON_PATH_ . "/cron/centAcl.php");
-} elseif (isset($_POST["o"]) && $_POST["o"] == "u") {
-    isset($_GET["select"]) ? $sel = $_GET["select"] : $sel = null;
-    isset($_POST["select"]) ? $sel = $_POST["select"] : $sel;
+} elseif (isset($_POST["o"]) && $_POST["o"] === 'u') {
+    $sel = filter_var_array(
+        $_GET["select"] ?? $_POST["select"] ?? [],
+        FILTER_VALIDATE_INT
+    );
 
     $pearDB->beginTransaction();
     try {
@@ -89,7 +90,7 @@ if (isset($_GET["o"]) && $_GET["o"] == "r") {
 
 # Smarty template Init
 $tpl = new Smarty();
-$tpl = initSmartyTpl($path, $tpl);
+$tpl = initSmartyTpl(__DIR__, $tpl);
 
 $res = $pearDB->query("SELECT DISTINCT * FROM session");
 $session_data = array();


### PR DESCRIPTION
## Description

avoid sql injection in reload acl listing

**Fixes** MON-7095

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)