### PR TITLE
fix(downtime): host downtime cancellation fix for APIv2

### DIFF
--- a/src/Centreon/Domain/Downtime/DowntimeService.php
+++ b/src/Centreon/Domain/Downtime/DowntimeService.php
@@ -257,7 +257,7 @@ class DowntimeService extends AbstractCentreonService implements DowntimeService
             throw new EntityNotFoundException(_('Downtime not found'));
         }
 
-        $downtimeType = ($downtime->getServiceId() === null) ? 'host' : 'service';
+        $downtimeType = (empty($downtime->getServiceId())) ? 'host' : 'service';
 
         if (!is_null($downtime->getDeletionTime())) {
             throw new DowntimeException(


### PR DESCRIPTION
## Description

This PR intends to patch an issue that occured on DOWNTIME CANCELLATION for hosts using the API v2 /monitoring/downtimes ENDPOINT

For a host, the service_id is stored as '0' and not 'NULL'

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Make sure to have a Host in a non-OK status
- Set a downtime on this Host.
- Get the downtime ID using the /monitoring/downtimes ENDPOINT
- Cancel the downtime using /monitoring/downtimes/downtimeID ENDPOINT (DELETE HTTP VERB)
- 
## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
