### PR TITLE
fix(downtime): host downtime cancellation fix for APIv2 on engineservice

### DIFF
--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -343,7 +343,7 @@ class EngineService extends AbstractCentreonService implements
             throw new EngineException(_('Downtime internal id can not be null'));
         }
 
-        $suffix = ($downtime->getServiceId() === null) ? 'HOST' : 'SVC';
+        $suffix = (empty($downtime->getServiceId())) ? 'HOST' : 'SVC';
         $preCommand = sprintf('DEL_%s_DOWNTIME;%d', $suffix, $downtime->getInternalId());
         $commandToSend = str_replace(['"', "\n"], ['', '<br/>'], $preCommand);
         $commandFull = $this->createCommandHeader($host->getPollerId()) . $commandToSend;


### PR DESCRIPTION
## Description

Wrong command sent to engine pipe, same patch as https://github.com/centreon/centreon/pull/9838 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira associated ticket

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
