### PR TITLE
fix(Resource-status/Details): Fix wrong command line display when single argument with multiple characters is given

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/CommandLine/utils/index.ts
+++ b/www/front_src/src/Resources/Details/tabs/Details/CommandLine/utils/index.ts
@@ -11,11 +11,7 @@ import {
 import commandParser from 'string-argv';
 
 const isShortArgument = (argument: string): boolean => {
-  return (
-    startsWith('-', argument) &&
-    equals(argument.length, 2) &&
-    not(equals('--', argument))
-  );
+  return startsWith('-', argument) && not(equals('--', argument));
 };
 
 interface CommandWithArguments {


### PR DESCRIPTION
## Description

With the following command:
```
/usr/bin/time -r '127' -z 'super long option' -y "option with double quotes" -j 'value\ with\ anti\ slash' | new_command -z 'new option' -h \centreon\on\windows -drive \a -disk 1 -newdisk 2 -test 3
```

Before:
![image](https://user-images.githubusercontent.com/8367233/118807432-96dcc780-b8a8-11eb-9c23-eb9e98a91380.png)

After:
![Capture d’écran 2021-05-19 à 10 01 31](https://user-images.githubusercontent.com/8367233/118807462-a1975c80-b8a8-11eb-81dc-e8a89f2b6961.png)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 21.10.x (master)
