### PR TITLE
fix(ui): Handle case when Note URL is empty but Note is defined

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/Url/Action.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/Action.tsx
@@ -15,11 +15,7 @@ const ActionUrlColumn = ({ row }: ComponentColumnProps): JSX.Element => {
   );
 
   return (
-    <UrlColumn
-      endpoint={endpoint}
-      icon={<IconAction fontSize="small" />}
-      title={endpoint}
-    />
+    <UrlColumn endpoint={endpoint} icon={<IconAction fontSize="small" />} />
   );
 };
 

--- a/www/front_src/src/Resources/Listing/columns/Url/Notes.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/Notes.tsx
@@ -21,9 +21,10 @@ const NotesUrlColumn = ({ row }: ComponentColumnProps): JSX.Element => {
 
   return (
     <UrlColumn
+      avatarTitle="N"
       endpoint={endpoint}
       icon={<IconLink fontSize="small" />}
-      title={title || endpoint}
+      title={title}
     />
   );
 };

--- a/www/front_src/src/Resources/Listing/columns/Url/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/index.tsx
@@ -61,7 +61,7 @@ const UrlColumn = ({
       >
         <IconButton
           ariaLabel={title}
-          title={t((title || endpoint) as string)}
+          title={title || endpoint}
           onClick={(): null => {
             return null;
           }}

--- a/www/front_src/src/Resources/Listing/columns/Url/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/index.tsx
@@ -7,7 +7,6 @@ import { Avatar, makeStyles, Tooltip } from '@material-ui/core';
 
 import { IconButton } from '@centreon/ui';
 
-import { labelUrl } from '../../../translatedLabels';
 import IconColumn from '../IconColumn';
 
 const useStyles = makeStyles((theme) => ({

--- a/www/front_src/src/Resources/Listing/columns/Url/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { isNil, isEmpty } from 'ramda';
-import { useTranslation } from 'react-i18next';
 
 import { Avatar, makeStyles, Tooltip } from '@material-ui/core';
 
@@ -31,7 +30,6 @@ const UrlColumn = ({
   icon,
   avatarTitle,
 }: Props): JSX.Element | null => {
-  const { t } = useTranslation();
   const classes = useStyles();
 
   const isEndpointEmpty = isNil(endpoint) || isEmpty(endpoint);

--- a/www/front_src/src/Resources/Listing/columns/Url/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/index.tsx
@@ -3,22 +3,53 @@ import * as React from 'react';
 import { isNil, isEmpty } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
+import { Avatar, makeStyles, Tooltip } from '@material-ui/core';
+
 import { IconButton } from '@centreon/ui';
 
 import { labelUrl } from '../../../translatedLabels';
 import IconColumn from '../IconColumn';
 
+const useStyles = makeStyles((theme) => ({
+  avatar: {
+    backgroundColor: theme.palette.primary.main,
+    fontSize: theme.typography.body2.fontSize,
+    height: theme.spacing(2),
+    width: theme.spacing(2),
+  },
+}));
+
 interface Props {
+  avatarTitle?: string;
   endpoint?: string;
   icon: JSX.Element;
   title?: string;
 }
 
-const UrlColumn = ({ endpoint, title, icon }: Props): JSX.Element | null => {
+const UrlColumn = ({
+  endpoint,
+  title,
+  icon,
+  avatarTitle,
+}: Props): JSX.Element | null => {
   const { t } = useTranslation();
+  const classes = useStyles();
 
-  if (isNil(endpoint) || isEmpty(endpoint)) {
+  const isEndpointEmpty = isNil(endpoint) || isEmpty(endpoint);
+  const isTitleEmpty = isNil(title) || isEmpty(title);
+
+  if (isEndpointEmpty && isTitleEmpty) {
     return null;
+  }
+
+  if (isEndpointEmpty) {
+    return (
+      <IconColumn>
+        <Tooltip className={classes.avatar} title={title as string}>
+          <Avatar>{avatarTitle}</Avatar>
+        </Tooltip>
+      </IconColumn>
+    );
   }
 
   return (
@@ -31,7 +62,7 @@ const UrlColumn = ({ endpoint, title, icon }: Props): JSX.Element | null => {
       >
         <IconButton
           ariaLabel={title}
-          title={t(title || labelUrl)}
+          title={t((title || endpoint) as string)}
           onClick={(): null => {
             return null;
           }}


### PR DESCRIPTION
## Description

At the moment, Note URLs are displayed within the Resource Status page with the associated Note in tooltip.
Handle Notes (not empty) but with no URL.

**Fixes** # (issue)

How to handle Notes (not empty) but with no URL ? (this case is not presently displayed in RS)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to configuration host or service
In tab "**Extended informations**" add  information like ' Follow this procedure available in action URL' in field **Notes**.
![Capture d’écran 2021-05-20 à 16 42 47](https://user-images.githubusercontent.com/16045498/119000613-8cdfc500-b98b-11eb-9751-6ca2ca89d001.png)

Save and export configuration, and  come back in resource status to show if Icon (avatar) is displayed like the screenshot behind:
![Capture d’écran 2021-05-20 à 16 44 13](https://user-images.githubusercontent.com/16045498/119000625-8fdab580-b98b-11eb-8cc6-2ea3e14760db.png)

