### PR TITLE
fix(conf/broker) Fixed saving broker configuration

### DIFF
--- a/www/include/configuration/configCentreonBroker/formCentreonBroker.ihtml
+++ b/www/include/configuration/configCentreonBroker/formCentreonBroker.ihtml
@@ -141,30 +141,32 @@
     {literal}
 
     jQuery('#Form').centreonValidate();
+    jQuery(document).ready(function() {
+        clonifyTableFields('parentGroup','displaynamegroup');
+    });
 
+    function mk_paginationFF(){};
+    function set_header_title(){};
 
-function mk_paginationFF(){};
-function set_header_title(){};
+    function Infos() {
+        this.tags = new Array();
 
-function Infos() {
-    this.tags = new Array();
+        this.getPos = function(type){
+            if (this.tags[type] == undefined) {
+                    this.tags[type] = 0;
+            }
+            return this.tags[type];
+        };
 
-    this.getPos = function(type){
-        if (this.tags[type] == undefined) {
-                this.tags[type] = 0;
-        }
-        return this.tags[type];
-    };
+        this.setPos = function(type, value){
+            this.tags[type] = value;
+        };
 
-    this.setPos = function(type, value){
-        this.tags[type] = value;
-    };
+        this.incrementPos = function(type){
+            this.tags[type]++;
+        };
 
-    this.incrementPos = function(type){
-        this.tags[type]++;
-    };
-
-}
+    }
 
     function addInfo(type) {
         var prev_id = infos.getPos(type);


### PR DESCRIPTION
## Description

Force data loading at the end of page loading.

**Fixes**

If we edit a broker configuration without opening the output tab, some information was not present when the form was submitted.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
