### PR TITLE
feat(web): add security acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ on the market; it is absolutely free and Open Source.
 
 See also the list of our [**contributors**](https://github.com/centreon/centreon/graphs/contributors)
 
+<h4> Security Acknowledgement page </h4>
+
+We want to thank all [reporters and pentesters](SECURITY_ACK.md) who help us improve our product each day.
+
 <h2> Contributing </h2>
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, bug report, feature request and the process for submitting pull requests for us.

--- a/SECURITY_ACK.md
+++ b/SECURITY_ACK.md
@@ -1,0 +1,15 @@
+<h2> Security Acknowledgement </h2>
+
+Centreon is committed to the security of its product and services and is continuously improving policies, processes, and products to meet the highest standards.
+
+We acknowledge that Centreon users and security researchers following our Centreon Security Policy to report vulnerabilities are key to the success of this commitment. If you have reported first a confirmed vulnerability, we would like to recognize your contribution by listing your name or the name of your organization on this page. You may obviously choose to remain anonymous.
+
+To report a security vulnerability, follow this link: [Security Policy](SECURITY.md).
+
+Centreon reserves the right to make final decisions regarding publishing acknowledgments. Also, please be aware that only reports following our Security Policy may qualify for acknowledgement on this page.
+
+---
+
+<h3> 2021 </h3>
+
+* [Sick Codes](https://twitter.com/sickcodes), [wabaf3t](https://twitter.com/wabafet1) and [d0rkerdevil](https://twitter.com/d0rkerdevil) - 2021/02/16

--- a/SECURITY_ACK.md
+++ b/SECURITY_ACK.md
@@ -12,5 +12,10 @@ Centreon reserves the right to make final decisions regarding publishing acknowl
 
 <h3> 2021 </h3>
 
-* 2021/04/02 - [Alexandru Cucea](https://acucea.github.io/)
+* 2021/03/23 - [Benoit Poulet](https://twitter.com/poulet_benoit)
 * 2021/02/16 - [Sick Codes](https://twitter.com/sickcodes), [wabaf3t](https://twitter.com/wabafet1) and [d0rkerdevil](https://twitter.com/d0rkerdevil)
+* 2021/02/12 - [Alexandru Cucea](https://acucea.github.io/)
+
+<h3> 2020 </h3>
+
+* 2020/01/06 - Matthew Bach / [TheCyberGeek](https://thecybergeek.co.uk/)

--- a/SECURITY_ACK.md
+++ b/SECURITY_ACK.md
@@ -12,4 +12,5 @@ Centreon reserves the right to make final decisions regarding publishing acknowl
 
 <h3> 2021 </h3>
 
-* [Sick Codes](https://twitter.com/sickcodes), [wabaf3t](https://twitter.com/wabafet1) and [d0rkerdevil](https://twitter.com/d0rkerdevil) - 2021/02/16
+* 2021/04/02 - [Alexandru Cucea](https://acucea.github.io/)
+* 2021/02/16 - [Sick Codes](https://twitter.com/sickcodes), [wabaf3t](https://twitter.com/wabafet1) and [d0rkerdevil](https://twitter.com/d0rkerdevil)

--- a/SECURITY_ACK.md
+++ b/SECURITY_ACK.md
@@ -2,7 +2,9 @@
 
 Centreon is committed to the security of its product and services and is continuously improving policies, processes, and products to meet the highest standards.
 
-We acknowledge that Centreon users and security researchers following our Centreon Security Policy to report vulnerabilities are key to the success of this commitment. If you have reported first a confirmed vulnerability, we would like to recognize your contribution by listing your name or the name of your organization on this page. You may obviously choose to remain anonymous.
+We acknowledge that Centreon users and security researchers following our Centreon Security Policy to report vulnerabilities are key to the success of this commitment.
+If you are the first to report a confirmed vulnerability, we would like to recognize your contribution by listing your name or the name of your organization on this page.
+You may obviously choose to remain anonymous.
 
 To report a security vulnerability, follow this link: [Security Policy](SECURITY.md).
 

--- a/SECURITY_ACK.md
+++ b/SECURITY_ACK.md
@@ -14,6 +14,7 @@ Centreon reserves the right to make final decisions regarding publishing acknowl
 
 <h3> 2021 </h3>
 
+* 2021/04/07 - [Synacktiv](https://www.synacktiv.com/), Guillaume André and Théo Louis-Tisserand
 * 2021/03/23 - [Benoit Poulet](https://twitter.com/poulet_benoit)
 * 2021/02/16 - [Sick Codes](https://twitter.com/sickcodes), [wabaf3t](https://twitter.com/wabafet1) and [d0rkerdevil](https://twitter.com/d0rkerdevil)
 * 2021/02/12 - [Alexandru Cucea](https://acucea.github.io/)

--- a/www/front_src/src/components/footer/index.js
+++ b/www/front_src/src/components/footer/index.js
@@ -35,7 +35,7 @@ class Footer extends Component {
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Centreon Support
+                  Support
                 </a>
               </li>
               <li className={styles['footer-list-item']}>
@@ -63,6 +63,15 @@ class Footer extends Component {
                   target="_blank"
                 >
                   Slack
+                </a>
+              </li>
+              <li className={styles['footer-list-item']}>
+                <a
+                  href="https://github.com/centreon/centreon/security/policy"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Security Issue
                 </a>
               </li>
             </ul>

--- a/www/include/Administration/about/about.php
+++ b/www/include/Administration/about/about.php
@@ -54,9 +54,9 @@ $release = $dbResult->fetchRow();
                     </p><br>
                 </td>
                 <td>
-                    Developed by <a
-                        href="http://www.centreon.com">Centreon</a> and <a
-                        href="https://centreon.github.io/">community</a>
+                    Developed by
+                    <a href="http://www.centreon.com">Centreon</a> and
+                    <a href="https://centreon.github.io/">community</a>
                 </td>
                 <td style="text-align: center" rowspan="3">
                     <img src="./img/centreon.png" alt="logo centreon" />
@@ -174,7 +174,24 @@ $release = $dbResult->fetchRow();
                     </table>
                 </td>
             </tr>
+            <tr>
+                <td  style="vertical-align: top;padding-top :10px;">
+                    <h3 style='text-align:left;'><?php echo _("Security Acknowledgement"); ?></h3>
+                </td>
+                <td style="padding-top: 10px;" colspan="2">
+                    <table class="table" aria-label="Security Acknowledgement">
+                        <tr>
+                            <td>
+                                Many thanks to all the contributors to the security of Centreon
+                            </td>
+                        </tr>
+                        <tr><td>
+                            <a href="https://github.com/centreon/centreon/blob/master/SECURITY_ACK.md"
+                            title='Security Acknowledgement' target='_blank' rel="noopener">List of contributors</a>
+                        </td></tr>
+                    </table>
+                </td>
+            </tr>
         </table>
     </div>
-</div>
 </center>


### PR DESCRIPTION
## Description

Add github wall of fame and security acknowledgements
Add in centreon links refering to the security policy (footer) and hall of fame (about)

**Fixes** # (ref MON-10616)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
