### PR TITLE
enh(ui): Add diverses  formats option to export the graphs

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14708,12 +14708,12 @@ msgstr "Permitir certificado autofirmado"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "Current"
+#  msgid "Original size"
 #  msgstr ""
 
-#  msgid "Medium"
+#  msgid "Medium size"
 #  msgstr ""
 
 
-#  msgid "Small"
+#  msgid "Small size"
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14708,7 +14708,7 @@ msgstr "Permitir certificado autofirmado"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "As Current size"
+#  msgid "As Displayed"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14707,3 +14707,13 @@ msgstr "Permitir certificado autofirmado"
 
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
+
+#  msgid "Current"
+#  msgstr ""
+
+#  msgid "Medium"
+#  msgstr ""
+
+
+#  msgid "Small"
+#  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14708,7 +14708,7 @@ msgstr "Permitir certificado autofirmado"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "As Displayed"
+#  msgid "As displayed"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14708,7 +14708,7 @@ msgstr "Permitir certificado autofirmado"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "Original size"
+#  msgid "As Current size"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16140,3 +16140,12 @@ msgstr "Au moins une colonne doit être sélectionnée"
 
 msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
+
+#  msgid "Current"
+#  msgstr "Taille courante"
+
+#  msgid "Medium"
+#  msgstr "Taille moyenne"
+
+#  msgid "Small"
+#  msgstr "Taille petite"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16142,7 +16142,7 @@ msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
 #  msgid "As Displayed"
-#  msgstr "Comme Affiché"
+#  msgstr "Comme affiché"
 
 #  msgid "Medium size"
 #  msgstr "Taille Moyenne"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16141,7 +16141,7 @@ msgstr "Au moins une colonne doit être sélectionnée"
 msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
-#  msgid "As Displayed"
+#  msgid "As displayed"
 #  msgstr "Comme affiché"
 
 #  msgid "Medium size"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16141,8 +16141,8 @@ msgstr "Au moins une colonne doit être sélectionnée"
 msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
-#  msgid "As Current size"
-#  msgstr "Taille Actuelle"
+#  msgid "As Displayed"
+#  msgstr "Comme Affiché"
 
 #  msgid "Medium size"
 #  msgstr "Taille Moyenne"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16142,10 +16142,10 @@ msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
 #  msgid "Current"
-#  msgstr "Taille courante"
+#  msgstr "Courante"
 
 #  msgid "Medium"
-#  msgstr "Taille moyenne"
+#  msgstr "Moyenne"
 
 #  msgid "Small"
-#  msgstr "Taille petite"
+#  msgstr "Petite"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16145,7 +16145,7 @@ msgstr "La durée doit être inférieure à une année"
 #  msgstr "Comme affiché"
 
 #  msgid "Medium size"
-#  msgstr "Taille Moyenne"
+#  msgstr "Taille moyenne"
 
 #  msgid "Small size"
 #  msgstr "Petite Taille"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16141,8 +16141,8 @@ msgstr "Au moins une colonne doit être sélectionnée"
 msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
-#  msgid "Current"
-#  msgstr "Courante"
+#  msgid "Original"
+#  msgstr "Originale"
 
 #  msgid "Medium"
 #  msgstr "Moyenne"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16141,8 +16141,8 @@ msgstr "Au moins une colonne doit être sélectionnée"
 msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
-#  msgid "Original size"
-#  msgstr "Taille Originale"
+#  msgid "As Current size"
+#  msgstr "Taille Actuelle"
 
 #  msgid "Medium size"
 #  msgstr "Taille Moyenne"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16141,11 +16141,11 @@ msgstr "Au moins une colonne doit être sélectionnée"
 msgid "The duration must be lesser than a year"
 msgstr "La durée doit être inférieure à une année"
 
-#  msgid "Original"
-#  msgstr "Originale"
+#  msgid "Original size"
+#  msgstr "Taille Originale"
 
-#  msgid "Medium"
-#  msgstr "Moyenne"
+#  msgid "Medium size"
+#  msgstr "Taille Moyenne"
 
-#  msgid "Small"
-#  msgstr "Petite"
+#  msgid "Small size"
+#  msgstr "Petite Taille"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15159,7 +15159,7 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "Original size"
+#  msgid "As Current size"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15159,12 +15159,12 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "Current"
+#  msgid "Original size"
 #  msgstr ""
 
-#  msgid "Medium"
+#  msgid "Medium size"
 #  msgstr ""
 
 
-#  msgid "Small"
+#  msgid "Small size"
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15159,7 +15159,7 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "As Current size"
+#  msgid "As Displayed"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15158,3 +15158,13 @@ msgstr "Erro ao remover tokens de um contato"
 
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
+
+#  msgid "Current"
+#  msgstr ""
+
+#  msgid "Medium"
+#  msgstr ""
+
+
+#  msgid "Small"
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15147,7 +15147,7 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "As Current size"
+#  msgid "As Displayed"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15146,3 +15146,13 @@ msgstr "Erro ao remover tokens de um contato"
 
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
+
+#  msgid "Current"
+#  msgstr ""
+
+#  msgid "Medium"
+#  msgstr ""
+
+
+#  msgid "Small"
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15147,12 +15147,12 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "Current"
+#  msgid "Original size"
 #  msgstr ""
 
-#  msgid "Medium"
+#  msgid "Medium size"
 #  msgstr ""
 
 
-#  msgid "Small"
+#  msgid "Small size"
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15147,7 +15147,7 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "Original size"
+#  msgid "As Current size"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15147,7 +15147,7 @@ msgstr "Erro ao remover tokens de um contato"
 #  msgid "The duration must be lesser than a year"
 #  msgstr ""
 
-#  msgid "As Displayed"
+#  msgid "As displayed"
 #  msgstr ""
 
 #  msgid "Medium size"

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
@@ -3,15 +3,28 @@ import dom2image from 'dom-to-image';
 
 interface Props {
   element: HTMLElement;
+  ratio: number;
   title: string;
 }
 
-const exportToPng = async ({ element, title }: Props): Promise<void> => {
+const exportToPng = async ({ element, title, ratio }: Props): Promise<void> => {
   const dateTime = new Date().toISOString().substring(0, 19);
+
+  const getTranslation = (size: number) => {
+    return ((1 - ratio) * size) / 2;
+  };
+
+  const translateY = getTranslation(element.offsetHeight);
+  const translateX = getTranslation(element.offsetWidth);
 
   return dom2image
     .toBlob(element, {
       bgcolor: '#FFFFFF',
+      height: element.offsetHeight * ratio,
+      style: {
+        transform: `translate(-${translateX}px, -${translateY}px) scale(${ratio})`,
+      },
+      width: element.offsetWidth * ratio,
     })
     .then((blob) => {
       return saveAs(blob, `${title}-${dateTime}.png`);

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -46,7 +46,7 @@ import { Resource } from '../../models';
 import { ResourceDetails } from '../../Details/models';
 import { CommentParameters } from '../../Actions/api';
 import {
-  labelAsCurrentSize,
+  labelAsDisplayed,
   labelExportToPng,
   labelSmallSize,
   labelMediumSize,
@@ -413,7 +413,7 @@ const PerformanceGraph = ({
                     onClose={closeSizeExportMenu}
                   >
                     <MenuItem onClick={() => convertToPng(1)}>
-                      {t(labelAsCurrentSize)}
+                      {t(labelAsDisplayed)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.75)}>
                       {t(labelMediumSize)}

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -46,10 +46,10 @@ import { Resource } from '../../models';
 import { ResourceDetails } from '../../Details/models';
 import { CommentParameters } from '../../Actions/api';
 import {
-  labelOriginal,
+  labelOriginalSize,
   labelExportToPng,
-  labelSmall,
-  labelMedium,
+  labelSmallSize,
+  labelMediumSize,
   labelNoDataForThisPeriod,
 } from '../../translatedLabels';
 import {
@@ -377,8 +377,6 @@ const PerformanceGraph = ({
 
   const containsMetrics = not(isNil(metrics)) && not(isEmpty(metrics));
 
-  const keySize = ' size';
-
   return (
     <MetricsValueContext.Provider value={metricsValueProps}>
       <div
@@ -415,16 +413,13 @@ const PerformanceGraph = ({
                     onClose={closeSizeExportMenu}
                   >
                     <MenuItem onClick={() => convertToPng(1)}>
-                      {t(labelOriginal)}
-                      {keySize}
+                      {t(labelOriginalSize)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.75)}>
-                      {t(labelMedium)}
-                      {keySize}
+                      {t(labelMediumSize)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.5)}>
-                      {t(labelSmall)}
-                      {keySize}
+                      {t(labelSmallSize)}
                     </MenuItem>
                   </Menu>
                 </>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -377,6 +377,8 @@ const PerformanceGraph = ({
 
   const containsMetrics = not(isNil(metrics)) && not(isEmpty(metrics));
 
+  const keySize = ' size';
+
   return (
     <MetricsValueContext.Provider value={metricsValueProps}>
       <div
@@ -414,12 +416,15 @@ const PerformanceGraph = ({
                   >
                     <MenuItem onClick={() => convertToPng(1)}>
                       {t(labelOriginal)}
+                      {keySize}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.75)}>
                       {t(labelMedium)}
+                      {keySize}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.5)}>
                       {t(labelSmall)}
+                      {keySize}
                     </MenuItem>
                   </Menu>
                 </>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -353,12 +353,13 @@ const PerformanceGraph = ({
     });
   };
 
-  const convertToPng = (): void => {
+  const convertToPng = (ratio: number): void => {
+    setMenuAnchor(null);
     setExporting(true);
     exportToPng({
       element: performanceGraphRef.current as HTMLElement,
-      title: `${resource?.name}-performanceo`,
-      // add size props
+      ratio,
+      title: `${resource?.name}-performance`,
     }).finally(() => {
       setExporting(false);
     });
@@ -411,13 +412,13 @@ const PerformanceGraph = ({
                     open={Boolean(menuAnchor)}
                     onClose={closeSizeExportMenu}
                   >
-                    <MenuItem onClick={convertToPng}>
+                    <MenuItem onClick={() => convertToPng(1)}>
                       {t(labelCurrentSizeExport)}
                     </MenuItem>
-                    <MenuItem onClick={convertToPng}>
+                    <MenuItem onClick={() => convertToPng(0.75)}>
                       {t(labelMediumSizeExport)}
                     </MenuItem>
-                    <MenuItem onClick={convertToPng}>
+                    <MenuItem onClick={() => convertToPng(0.5)}>
                       {t(labelSmallSizeExport)}
                     </MenuItem>
                   </Menu>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -46,10 +46,10 @@ import { Resource } from '../../models';
 import { ResourceDetails } from '../../Details/models';
 import { CommentParameters } from '../../Actions/api';
 import {
-  labelOriginalSizeExport,
+  labelOriginal,
   labelExportToPng,
-  labelSmallSizeExport,
-  labelMediumSizeExport,
+  labelSmall,
+  labelMedium,
   labelNoDataForThisPeriod,
 } from '../../translatedLabels';
 import {
@@ -413,13 +413,13 @@ const PerformanceGraph = ({
                     onClose={closeSizeExportMenu}
                   >
                     <MenuItem onClick={() => convertToPng(1)}>
-                      {t(labelOriginalSizeExport)}
+                      {t(labelOriginal)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.75)}>
-                      {t(labelMediumSizeExport)}
+                      {t(labelMedium)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.5)}>
-                      {t(labelSmallSizeExport)}
+                      {t(labelSmall)}
                     </MenuItem>
                   </Menu>
                 </>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -46,7 +46,7 @@ import { Resource } from '../../models';
 import { ResourceDetails } from '../../Details/models';
 import { CommentParameters } from '../../Actions/api';
 import {
-  labelCurrentSizeExport,
+  labelOriginalSizeExport,
   labelExportToPng,
   labelSmallSizeExport,
   labelMediumSizeExport,
@@ -413,7 +413,7 @@ const PerformanceGraph = ({
                     onClose={closeSizeExportMenu}
                   >
                     <MenuItem onClick={() => convertToPng(1)}>
-                      {t(labelCurrentSizeExport)}
+                      {t(labelOriginalSizeExport)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.75)}>
                       {t(labelMediumSizeExport)}

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -22,7 +22,13 @@ import {
 } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
-import { makeStyles, Typography, Theme } from '@material-ui/core';
+import {
+  makeStyles,
+  Typography,
+  Theme,
+  MenuItem,
+  Menu,
+} from '@material-ui/core';
 import SaveAsImageIcon from '@material-ui/icons/SaveAlt';
 import { Skeleton } from '@material-ui/lab';
 
@@ -40,7 +46,10 @@ import { Resource } from '../../models';
 import { ResourceDetails } from '../../Details/models';
 import { CommentParameters } from '../../Actions/api';
 import {
+  labelCurrentSizeExport,
   labelExportToPng,
+  labelLargeSizeExport,
+  labelMediumSizeExport,
   labelNoDataForThisPeriod,
 } from '../../translatedLabels';
 import {
@@ -165,6 +174,14 @@ const PerformanceGraph = ({
   const [exporting, setExporting] = React.useState<boolean>(false);
   const performanceGraphRef = React.useRef<HTMLDivElement | null>(null);
   const performanceGraphHeightRef = React.useRef<number>(0);
+  const [menuAnchor, setMenuAnchor] = React.useState<Element | null>(null);
+
+  const openSizeExportMenu = (event: React.MouseEvent): void => {
+    setMenuAnchor(event.currentTarget);
+  };
+  const closeSizeExportMenu = (): void => {
+    setMenuAnchor(null);
+  };
 
   const { selectedResourceId } = useResourceContext();
 
@@ -340,7 +357,8 @@ const PerformanceGraph = ({
     setExporting(true);
     exportToPng({
       element: performanceGraphRef.current as HTMLElement,
-      title: `${resource?.name}-performance`,
+      title: `${resource?.name}-performanceo`,
+      // add size props
     }).finally(() => {
       setExporting(false);
     });
@@ -378,14 +396,32 @@ const PerformanceGraph = ({
                 loading={exporting}
                 loadingIndicatorSize={16}
               >
-                <IconButton
-                  disableTouchRipple
-                  disabled={isNil(timeline)}
-                  title={t(labelExportToPng)}
-                  onClick={convertToPng}
-                >
-                  <SaveAsImageIcon style={{ fontSize: 18 }} />
-                </IconButton>
+                <>
+                  <IconButton
+                    disableTouchRipple
+                    disabled={isNil(timeline)}
+                    title={t(labelExportToPng)}
+                    onClick={openSizeExportMenu}
+                  >
+                    <SaveAsImageIcon style={{ fontSize: 18 }} />
+                  </IconButton>
+                  <Menu
+                    keepMounted
+                    anchorEl={menuAnchor}
+                    open={Boolean(menuAnchor)}
+                    onClose={closeSizeExportMenu}
+                  >
+                    <MenuItem onClick={convertToPng}>
+                      {t(labelCurrentSizeExport)}
+                    </MenuItem>
+                    <MenuItem onClick={convertToPng}>
+                      {t(labelMediumSizeExport)}
+                    </MenuItem>
+                    <MenuItem onClick={convertToPng}>
+                      {t(labelLargeSizeExport)}
+                    </MenuItem>
+                  </Menu>
+                </>
               </ContentWithCircularLoading>
             </div>
           </div>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -48,7 +48,7 @@ import { CommentParameters } from '../../Actions/api';
 import {
   labelCurrentSizeExport,
   labelExportToPng,
-  labelLargeSizeExport,
+  labelSmallSizeExport,
   labelMediumSizeExport,
   labelNoDataForThisPeriod,
 } from '../../translatedLabels';
@@ -418,7 +418,7 @@ const PerformanceGraph = ({
                       {t(labelMediumSizeExport)}
                     </MenuItem>
                     <MenuItem onClick={convertToPng}>
-                      {t(labelLargeSizeExport)}
+                      {t(labelSmallSizeExport)}
                     </MenuItem>
                   </Menu>
                 </>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -46,7 +46,7 @@ import { Resource } from '../../models';
 import { ResourceDetails } from '../../Details/models';
 import { CommentParameters } from '../../Actions/api';
 import {
-  labelOriginalSize,
+  labelAsCurrentSize,
   labelExportToPng,
   labelSmallSize,
   labelMediumSize,
@@ -413,7 +413,7 @@ const PerformanceGraph = ({
                     onClose={closeSizeExportMenu}
                   >
                     <MenuItem onClick={() => convertToPng(1)}>
-                      {t(labelOriginalSize)}
+                      {t(labelAsCurrentSize)}
                     </MenuItem>
                     <MenuItem onClick={() => convertToPng(0.75)}>
                       {t(labelMediumSize)}

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,6 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelAsDisplayed = 'As Displayed';
+export const labelAsDisplayed = 'As displayed';
 export const labelMediumSize = 'Medium size';
 export const labelSmallSize = 'Small size';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,7 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelSelectedSizeExport = 'Selected Size Export';
 export const labelCurrentSizeExport = 'Current';
 export const labelMediumSizeExport = 'Medium';
 export const labelSmallSizeExport = 'Small';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,6 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelAsCurrentSize = 'As Current size';
+export const labelAsDisplayed = 'As Displayed';
 export const labelMediumSize = 'Medium size';
 export const labelSmallSize = 'Small size';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,6 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelCurrentSizeExport = 'Current';
+export const labelOriginalSizeExport = 'Original';
 export const labelMediumSizeExport = 'Medium';
 export const labelSmallSizeExport = 'Small';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,6 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelOriginalSizeExport = 'Original';
-export const labelMediumSizeExport = 'Medium';
-export const labelSmallSizeExport = 'Small';
+export const labelOriginal = 'Original';
+export const labelMedium = 'Medium';
+export const labelSmall = 'Small';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,6 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelOriginal = 'Original';
-export const labelMedium = 'Medium';
-export const labelSmall = 'Small';
+export const labelOriginalSize = 'Original size';
+export const labelMediumSize = 'Medium size';
+export const labelSmallSize = 'Small size';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -214,6 +214,6 @@ export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
 export const labelSelectedSizeExport = 'Selected Size Export';
-export const labelCurrentSizeExport = 'Current size export';
-export const labelMediumSizeExport = 'Medium size export';
-export const labelSmallSizeExport = 'Large size export';
+export const labelCurrentSizeExport = 'Current';
+export const labelMediumSizeExport = 'Medium';
+export const labelSmallSizeExport = 'Small';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -216,4 +216,4 @@ export const labelMaxDuration1Year = 'The duration must be lesser than a year';
 export const labelSelectedSizeExport = 'Selected Size Export';
 export const labelCurrentSizeExport = 'Current size export';
 export const labelMediumSizeExport = 'Medium size export';
-export const labelLargeSizeExport = 'Large size export';
+export const labelSmallSizeExport = 'Large size export';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,3 +213,7 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
+export const labelSelectedSizeExport = 'Selected Size Export';
+export const labelCurrentSizeExport = 'Current size export';
+export const labelMediumSizeExport = 'Medium size export';
+export const labelLargeSizeExport = 'Large size export';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,6 +213,6 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
-export const labelOriginalSize = 'Original size';
+export const labelAsCurrentSize = 'As Current size';
 export const labelMediumSize = 'Medium size';
 export const labelSmallSize = 'Small size';


### PR DESCRIPTION
## Description

Allow for users to use pre-determined export sizes:

- Original size
- Medium size
- Small size

Ideally, we'll decide on the standard sizes based on the most common resolutions (1080p, 1440p, 2160p) and feedback from Experts/Clients/Community on their preferred resolution (==> Medium)

## Type of change

- [x] New functionality (non-breaking change)

## Target serie

- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- On resource status, click on service with graph available, 
then on detail panel on tab GRAPH , 
- Click on icon to export the graph and select size you want export for graph.

Demo:
https://www.loom.com/share/921a623a600c4398a3b40444365358d7

