### PR TITLE
fix(login): Use correct database name for api login

### DIFF
--- a/src/Centreon/Infrastructure/Security/AuthenticationRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Security/AuthenticationRepositoryRDB.php
@@ -58,7 +58,7 @@ class AuthenticationRepositoryRDB implements AuthenticationRepositoryInterface
     {
         global $dependencyInjector;
         $pearDB = new \CentreonDB(
-            \CentreonDB::DB_CONFIGURATION,
+            \CentreonDB::LABEL_DB_CONFIGURATION,
             3,
             true
         );

--- a/src/Centreon/Infrastructure/Security/AuthenticationRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Security/AuthenticationRepositoryRDB.php
@@ -58,7 +58,7 @@ class AuthenticationRepositoryRDB implements AuthenticationRepositoryInterface
     {
         global $dependencyInjector;
         $pearDB = new \CentreonDB(
-            $this->db->getCentreonDbName(),
+            \CentreonDB::DB_CONFIG,
             3,
             true
         );

--- a/src/Centreon/Infrastructure/Security/AuthenticationRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Security/AuthenticationRepositoryRDB.php
@@ -58,7 +58,7 @@ class AuthenticationRepositoryRDB implements AuthenticationRepositoryInterface
     {
         global $dependencyInjector;
         $pearDB = new \CentreonDB(
-            \CentreonDB::DB_CONFIG,
+            \CentreonDB::DB_CONFIGURATION,
             3,
             true
         );

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -48,7 +48,7 @@ require_once __DIR__ . '/centreonLog.class.php';
  */
 class CentreonDB extends \PDO
 {
-    public const DB_CONFIG = 'centreon';
+    public const DB_CONFIGURATION = 'centreon';
     public const DB_REALTIME = 'centstorage';
     private static $instance = [];
     protected $db_type = "mysql";
@@ -86,7 +86,7 @@ class CentreonDB extends \PDO
      *
      * @throws Exception
      */
-    public function __construct($db = self::DB_CONFIG, $retry = 3, $silent = false)
+    public function __construct($db = self::DB_CONFIGURATION, $retry = 3, $silent = false)
     {
         try {
             $conf_centreon['hostCentreon'] = hostCentreon;
@@ -318,9 +318,9 @@ class CentreonDB extends \PDO
      * @return CentreonDB
      * @throws Exception
      */
-    public static function factory($name = self::DB_CONFIG)
+    public static function factory($name = self::DB_CONFIGURATION)
     {
-        if (!in_array($name, [self::DB_CONFIG, self::DB_REALTIME])) {
+        if (!in_array($name, [self::DB_CONFIGURATION, self::DB_REALTIME])) {
             throw new Exception("The datasource isn't defined in configuration file.");
         }
         if (!isset(self::$instance[$name])) {

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -48,6 +48,8 @@ require_once __DIR__ . '/centreonLog.class.php';
  */
 class CentreonDB extends \PDO
 {
+    public const DB_CONFIG = 'centreon';
+    public const DB_REALTIME = 'centstorage';
     private static $instance = [];
     protected $db_type = "mysql";
     protected $db_port = "3306";
@@ -133,12 +135,11 @@ class CentreonDB extends \PDO
             ];
 
             switch (strtolower($db)) {
-                case "centstorage":
+                case self::DB_REALTIME:
                     $this->dsn['hostspec'] = $conf_centreon["hostCentstorage"];
                     $this->dsn['database'] = $conf_centreon["dbcstg"];
                     break;
-                case "centreon":
-                case "default":
+                default:
                     $this->dsn['hostspec'] = $conf_centreon["hostCentreon"];
                     $this->dsn['database'] = $conf_centreon["db"];
                     break;

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -79,14 +79,14 @@ class CentreonDB extends \PDO
     /**
      * Constructor
      *
-     * @param string $db | centreon, centstorage, or ndo
+     * @param string $db | centreon, centstorage
      * @param int $retry
      * @param bool $silent | when silent is set to false, it will display an HTML error msg,
      *                       otherwise it will throw an Exception
      *
      * @throws Exception
      */
-    public function __construct($db = "centreon", $retry = 3, $silent = false)
+    public function __construct($db = self::DB_CONFIG, $retry = 3, $silent = false)
     {
         try {
             $conf_centreon['hostCentreon'] = hostCentreon;
@@ -318,9 +318,9 @@ class CentreonDB extends \PDO
      * @return CentreonDB
      * @throws Exception
      */
-    public static function factory($name = "centreon")
+    public static function factory($name = self::DB_CONFIG)
     {
-        if (!in_array($name, ['centreon', 'centstorage', 'ndo'])) {
+        if (!in_array($name, [self::DB_CONFIG, self::DB_REALTIME])) {
             throw new Exception("The datasource isn't defined in configuration file.");
         }
         if (!isset(self::$instance[$name])) {

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -135,7 +135,7 @@ class CentreonDB extends \PDO
             ];
 
             switch (strtolower($db)) {
-                case self::DB_REALTIME:
+                case self::LABEL_DB_REALTIME:
                     $this->dsn['hostspec'] = $conf_centreon["hostCentstorage"];
                     $this->dsn['database'] = $conf_centreon["dbcstg"];
                     break;

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -48,8 +48,8 @@ require_once __DIR__ . '/centreonLog.class.php';
  */
 class CentreonDB extends \PDO
 {
-    public const DB_CONFIGURATION = 'centreon';
-    public const DB_REALTIME = 'centstorage';
+    public const LABEL_DB_CONFIGURATION = 'centreon';
+    public const LABEL_DB_REALTIME = 'centstorage';
     private static $instance = [];
     protected $db_type = "mysql";
     protected $db_port = "3306";
@@ -86,7 +86,7 @@ class CentreonDB extends \PDO
      *
      * @throws Exception
      */
-    public function __construct($db = self::DB_CONFIGURATION, $retry = 3, $silent = false)
+    public function __construct($db = self::LABEL_DB_CONFIGURATION, $retry = 3, $silent = false)
     {
         try {
             $conf_centreon['hostCentreon'] = hostCentreon;
@@ -318,9 +318,9 @@ class CentreonDB extends \PDO
      * @return CentreonDB
      * @throws Exception
      */
-    public static function factory($name = self::DB_CONFIGURATION)
+    public static function factory($name = self::LABEL_DB_CONFIGURATION)
     {
-        if (!in_array($name, [self::DB_CONFIGURATION, self::DB_REALTIME])) {
+        if (!in_array($name, [self::LABEL_DB_CONFIGURATION, self::LABEL_DB_REALTIME])) {
             throw new Exception("The datasource isn't defined in configuration file.");
         }
         if (!isset(self::$instance[$name])) {


### PR DESCRIPTION
## Description

This PR intends to fix an issue where we didn't bind correctly the database name and host if the name was different of "centreon"

**Fixes** # MON-7368

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Install a centreon with database name different than "centreon". 
- Complete web install
- Try to login to apiV2.
- It should be successfull.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
