### PR TITLE
enh(resource): return NULL for next_check when service is passive

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
@@ -144,7 +144,10 @@ final class HostProvider extends Provider
                 WHEN h.state_type = 0 THEN 'S'
             END, ')') AS `tries`,
             h.last_check AS `last_check`,
-            h.next_check AS `next_check`,
+            CASE
+                WHEN h.active_checks = 0 THEN NULL
+                WHEN h.active_checks = 1 THEN h.next_check
+            END AS `next_check`,
             h.output AS `information`,
             h.perfdata AS `performance_data`,
             h.execution_time AS `execution_time`,

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
@@ -158,7 +158,10 @@ final class ServiceProvider extends Provider
                 WHEN s.state_type = 0 THEN 'S'
             END, ')') AS `tries`,
             s.last_check AS `last_check`,
-            s.next_check AS `next_check`,
+            CASE
+                WHEN s.active_checks = 0 THEN NULL
+                WHEN s.active_checks = 1 THEN s.next_check
+            END AS `next_check`,
             s.output AS `information`,
             s.perfdata AS `performance_data`,
             s.execution_time AS `execution_time`,


### PR DESCRIPTION
## Description

MON-7313

This PR intends to handle the case when a service/host check is passive and/or active.

Use cases
- Active true and passive false -> next_check takes the value in the DB
- Active false and passive  true -> next_check returned as NULL
- Active true and passive true -> next_check takes the value in the DB


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

See jira issue

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
