### PR TITLE
fix(security): sanitize value before unserialize in centreonutils

### DIFF
--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -242,7 +242,13 @@ class CentreonUtils
         $init = array();
         try {
             $initForm = $form->getElement('initialValues');
-            $initialValues = unserialize($initForm->getValue());
+            $initForm = filter_var($initForm->getValue(), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+
+            if ($initForm === false) {
+                throw new \InvalidArgumentException('Invalid Parameters');
+            }
+            $initialValues = unserialize($initForm);
+
             if (!empty($initialValues) && isset($initialValues[$key])) {
                 $init = $initialValues[$key];
             }


### PR DESCRIPTION
## Description

sanitize value before unserialize in centreonutils

**Fixes** # MON-6767

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
