### PR TITLE
enh(conf/clapi) Export multiple services with the same name

### DIFF
--- a/lib/Centreon/Object/Object.php
+++ b/lib/Centreon/Object/Object.php
@@ -263,15 +263,21 @@ abstract class Centreon_Object
         if (count($filters)) {
             foreach ($filters as $key => $rawvalue) {
                 if (!count($filterTab)) {
-                    $sql .= " WHERE $key LIKE ? ";
+                    $sql .= " WHERE $key ";
                 } else {
-                    $sql .= " $filterType $key LIKE ? ";
+                    $sql .= " $filterType $key ";
                 }
-                $value = trim($rawvalue);
-                $value = str_replace("\\", "\\\\", $value);
-                $value = str_replace("_", "\_", $value);
-                $value = str_replace(" ", "\ ", $value);
-                $filterTab[] = $value;
+                if (is_array($rawvalue)) {
+                    $sql .= ' IN (' . str_repeat('?,', count($rawvalue) - 1) . '?) ';
+                    $filterTab = array_merge($filterTab, $rawvalue);
+                } else {
+                    $sql .= ' LIKE ? ';
+                    $value = trim($rawvalue);
+                    $value = str_replace("\\", "\\\\", $value);
+                    $value = str_replace("_", "\_", $value);
+                    $value = str_replace(" ", "\ ", $value);
+                    $filterTab[] = $value;
+                }
             }
         }
         if (isset($order) && isset($sort) && (strtoupper($sort) == "ASC" || strtoupper($sort) == "DESC")) {

--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -885,7 +885,7 @@ class CentreonAPI
                     if (isset($splits[2])) {
                         $name .= ';' . $splits[2];
                     }
-                    if ($this->objectTable[$splits[0]]->getObjectId($name) == 0) {
+                    if ($this->objectTable[$splits[0]]->getObjectId($name, CentreonObject::MULTIPLE_VALUE) == 0) {
                         echo "Unknown object : $splits[0];$splits[1]\n";
                         $this->setReturnCode(1);
                         

--- a/www/class/centreon-clapi/centreonObject.class.php
+++ b/www/class/centreon-clapi/centreonObject.class.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 CENTREON
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -42,16 +43,19 @@ require_once _CENTREON_PATH_ . "www/class/centreon-clapi/centreonExported.class.
 
 abstract class CentreonObject
 {
-    const MISSINGPARAMETER = "Missing parameters";
-    const MISSINGNAMEPARAMETER = "Missing name parameter";
-    const OBJECTALREADYEXISTS = "Object already exists";
-    const OBJECT_NOT_FOUND = "Object not found";
-    const UNKNOWN_METHOD = "Method not implemented into Centreon API";
-    const NAMEALREADYINUSE = "Name is already in use";
-    const NB_UPDATE_PARAMS = 3;
-    const UNKNOWNPARAMETER = "Unknown parameter";
-    const OBJECTALREADYLINKED = "Objects already linked";
-    const OBJECTNOTLINKED = "Objects are not linked";
+    public const MISSINGPARAMETER = "Missing parameters";
+    public const MISSINGNAMEPARAMETER = "Missing name parameter";
+    public const OBJECTALREADYEXISTS = "Object already exists";
+    public const OBJECT_NOT_FOUND = "Object not found";
+    public const UNKNOWN_METHOD = "Method not implemented into Centreon API";
+    public const NAMEALREADYINUSE = "Name is already in use";
+    public const NB_UPDATE_PARAMS = 3;
+    public const UNKNOWNPARAMETER = "Unknown parameter";
+    public const OBJECTALREADYLINKED = "Objects already linked";
+    public const OBJECTNOTLINKED = "Objects are not linked";
+    public const SINGLE_VALUE = 0;
+    public const MULTIPLE_VALUE = 1;
+
 
     private $centreon_api = null;
     protected static $instances;
@@ -206,14 +210,16 @@ abstract class CentreonObject
      * @param string $name
      * @return int
      */
-    public function getObjectId($name)
+    public function getObjectId($name, int $type = self::SINGLE_VALUE)
     {
         if (isset($this->objectIds[$name])) {
             return $this->objectIds[$name];
         }
         $ids = $this->object->getIdByParameter($this->object->getUniqueLabelField(), array($name));
         if (count($ids)) {
-            $this->objectIds[$name] = $ids[0];
+            $this->objectIds[$name] = ($type === self::SINGLE_VALUE)
+                ? $ids[0]
+                : $ids;
             return $this->objectIds[$name];
         }
         return 0;
@@ -244,8 +250,9 @@ abstract class CentreonObject
     {
         $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? "https" : "http";
         $port = '';
-        if (($protocol == 'http' && $_SERVER['SERVER_PORT'] != 80) ||
-            ($protocol == 'https' && $_SERVER['SERVER_PORT'] != 443)
+        if (
+            ($protocol == 'http' && $_SERVER['SERVER_PORT'] != 80)
+            || ($protocol == 'https' && $_SERVER['SERVER_PORT'] != 443)
         ) {
             $port = ':' . $_SERVER['SERVER_PORT'];
         }
@@ -356,7 +363,8 @@ abstract class CentreonObject
             $objectId = $params['objectId'];
             unset($params['objectId']);
 
-            if (isset($params[$uniqueLabel])
+            if (
+                isset($params[$uniqueLabel])
                 && $this->objectExists($params[$uniqueLabel], $objectId) == true
             ) {
                 throw new CentreonClapiException(self::NAMEALREADYINUSE);
@@ -457,10 +465,13 @@ abstract class CentreonObject
         }
 
         $filterId = $this->getObjectId($filterName);
-        $exported->ariane_push($this->action, $filterId, $filterName);
-        if ($exported->is_exported($this->action, $filterId, $filterName)) {
-            $exported->ariane_pop();
-            return false;
+        $filterIds = is_array($filterId) ? $filterId : [$filterId];
+        foreach ($filterIds as $filterId) {
+            $exported->ariane_push($this->action, $filterId, $filterName);
+            if ($exported->is_exported($this->action, $filterId, $filterName)) {
+                $exported->ariane_pop();
+                return false;
+            }
         }
 
         return true;

--- a/www/class/centreon-clapi/centreonService.class.php
+++ b/www/class/centreon-clapi/centreonService.class.php
@@ -145,7 +145,7 @@ class CentreonService extends CentreonObject
      * @param string $name
      * @return int
      */
-    public function getObjectId($name)
+    public function getObjectId($name, int $type = CentreonObject::SINGLE_VALUE)
     {
         if (isset($this->objectIds[$name])) {
             return $this->objectIds[$name];
@@ -158,7 +158,7 @@ class CentreonService extends CentreonObject
                 return $this->objectIds[$name];
             }
         } else {
-            return parent::getObjectId($name);
+            return parent::getObjectId($name, $type);
         }
 
         return 0;

--- a/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 CENTREON
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2021 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -49,11 +50,11 @@ require_once "Centreon/Object/Service/Template.php";
 class CentreonServiceTemplate extends CentreonObject
 {
 
-    const ORDER_SVCDESC = 0;
-    const ORDER_SVCALIAS = 1;
-    const ORDER_SVCTPL = 2;
-    const NB_UPDATE_PARAMS = 3;
-    const UNKNOWN_NOTIFICATION_OPTIONS = "Invalid notifications options";
+    public const ORDER_SVCDESC = 0;
+    public const ORDER_SVCALIAS = 1;
+    public const ORDER_SVCTPL = 2;
+    public const NB_UPDATE_PARAMS = 3;
+    public const UNKNOWN_NOTIFICATION_OPTIONS = "Invalid notifications options";
 
     public static $aDepends = array(
         'CMD',
@@ -203,8 +204,6 @@ class CentreonServiceTemplate extends CentreonObject
         if (count($params) < 2) {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
-
-        
         $authorizeParam = array(
             'activate',
             'description',
@@ -339,7 +338,6 @@ class CentreonServiceTemplate extends CentreonObject
                             $ret = $ret[$field];
                             break;
                     }
-                
                     if (!isset($exportedFields[$paramSearch])) {
                         $resultString .= $ret . $this->delim;
                         $exportedFields[$paramSearch] = 1;
@@ -356,7 +354,6 @@ class CentreonServiceTemplate extends CentreonObject
         echo implode(';', array_unique(explode(';', $paramString))) . "\n";
         echo substr($resultString, 0, -1) . "\n";
     }
-    
 
     /**
      * Get clapi action name from db column name


### PR DESCRIPTION
## Description

Currently it is not possible to export all services with the same name, only the first found is exported.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create multiple hosts where at least one service has the same name in all hosts.
Run the export command with the service name (common to all hosts)

ex: `centreon -u admin -p xxxxxxx -e --select='SERVICE;Cpu' --filter-type='^SERVICE$'`

The list should show the service for all the hosts it belongs to.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
