### PR TITLE
fix(conf/service group) Fix blank page on service group dashboard

### DIFF
--- a/www/include/reporting/dashboard/template/viewServicesGroupLog.ihtml
+++ b/www/include/reporting/dashboard/template/viewServicesGroupLog.ihtml
@@ -144,7 +144,7 @@
 					<td {$style_warning}>{$tb.WARNING_TP}% ({$tb.WARNING_MP}%)</td>
 					<td {$style_warning_alert} style="width:30px;">{$tb.WARNING_A}</td>
 					<td {$style_critical}>{$tb.CRITICAL_TP}% ({$tb.CRITICAL_MP}%)</td>
-					<td {$style_critical_alert style="width:30px;"}>{$tb.CRITICAL_A}</td>
+					<td {$style_critical_alert} style="width:30px;">{$tb.CRITICAL_A}</td>
 					<td {$style_unknown}>{$tb.UNKNOWN_TP}% ({$tb.UNKNOWN_MP}%)</td>
 					<td {$style_unknown_alert} style="width:30px;">{$tb.UNKNOWN_A}</td>
 					<td {$style_maintenance}>{$tb.MAINTENANCE_TP}%</td>


### PR DESCRIPTION
## Description

When accessing the service group dashboard, a blank page is displayed.
The problem seems to be related to the Smarty update.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to the page .../centreon/main.php?p=30704

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
