### PR TITLE
fix(ldap): correct url for search submission

### DIFF
--- a/www/include/Administration/parameters/ldap/list.php
+++ b/www/include/Administration/parameters/ldap/list.php
@@ -49,7 +49,7 @@ $searchLdap = filter_var(
     $_POST['searchLdap'] ?? $_GET['searchLdap'] ?? null,
     FILTER_SANITIZE_STRING
 );
-var_dump($searchLdap);
+
 $ldapConf = new CentreonLdapAdmin($pearDB);
 if (isset($_POST['searchLdap']) || isset($_GET['searchLdap'])) {
     $centreon->historySearch = array();

--- a/www/include/Administration/parameters/ldap/list.php
+++ b/www/include/Administration/parameters/ldap/list.php
@@ -49,7 +49,7 @@ $searchLdap = filter_var(
     $_POST['searchLdap'] ?? $_GET['searchLdap'] ?? null,
     FILTER_SANITIZE_STRING
 );
-
+var_dump($searchLdap);
 $ldapConf = new CentreonLdapAdmin($pearDB);
 if (isset($_POST['searchLdap']) || isset($_GET['searchLdap'])) {
     $centreon->historySearch = array();
@@ -77,7 +77,7 @@ $form = new HTML_QuickFormCustom('select_form', 'POST', "?o=ldap&p=" . $p);
 
 $attrBtnSuccess = array(
     "class" => "btc bt_success",
-    "onClick" => "window.history.replaceState('', '', '?p=" . $p . "');"
+    "onClick" => "window.history.replaceState('', '', '?p=" . $p . "&o=ldap');"
 );
 $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 


### PR DESCRIPTION
## Description

this PR fix an issue on Administration > Parameters > LDAP > Search button.

The Button now redirect to the LDAP listing as expected and no more to CentreonUI form.

**Fixes** # MON-6625

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add a LDAP Configuration, then try to search your ldap configuration. You should stay on Administration > Parameters > LDAP page with list filtered by your research.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
