### PR TITLE
Fix(UI): Adapt UI clock to match with the user language

### DIFF
--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
+import { not } from 'ramda';
 
 import {
   Checkbox,
@@ -66,7 +67,6 @@ const pickerCommonProps = {
     disableUnderline: true,
   },
   TextFieldComponent: TextField,
-  disableToolbar: true,
   inputVariant: 'filled',
   margin: 'none',
   variant: 'inline',
@@ -74,12 +74,12 @@ const pickerCommonProps = {
 
 const datePickerProps = {
   ...pickerCommonProps,
+  disableToolbar: true,
   format: 'L',
 } as Omit<DatePickerProps, 'onChange' | 'value'>;
 
 const timePickerProps = {
   ...pickerCommonProps,
-  ampm: false,
   format: 'LT',
 } as Omit<TimePickerProps, 'onChange' | 'value'>;
 
@@ -97,7 +97,7 @@ const DialogDowntime = ({
   const { t } = useTranslation();
   const { locale } = useUserContext();
   const { getDowntimeDeniedTypeAlert, canDowntimeServices } = useAclQuery();
-  const Adapter = useDateTimePickerAdapter();
+  const { Adapter, isMeridianFormat } = useDateTimePickerAdapter();
 
   const open = resources.length > 0;
 
@@ -149,6 +149,7 @@ const DialogDowntime = ({
                   KeyboardButtonProps={{
                     'aria-label': t(labelChangeStartTime),
                   }}
+                  ampm={isMeridianFormat(values.timeStart)}
                   aria-label={t(labelStartTime)}
                   error={errors?.timeStart !== undefined}
                   helperText={errors?.timeStart}
@@ -180,7 +181,9 @@ const DialogDowntime = ({
                   KeyboardButtonProps={{
                     'aria-label': t(labelChangeEndTime),
                   }}
+                  ampm={isMeridianFormat(values.timeEnd)}
                   aria-label={t(labelEndTime)}
+                  disableToolbar={not(isMeridianFormat(values.timeEnd))}
                   error={errors?.timeEnd !== undefined}
                   helperText={errors?.timeEnd}
                   value={values.timeEnd}

--- a/www/front_src/src/Resources/Graph/Performance/TimePeriods/CustomTimePeriodPickers.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/TimePeriods/CustomTimePeriodPickers.tsx
@@ -115,7 +115,7 @@ const CustomTimePeriodPickers = ({
   const { t } = useTranslation();
   const { locale } = useUserContext();
   const { format } = useLocaleDateTimeFormat();
-  const Adapter = useDateTimePickerAdapter();
+  const { Adapter, isMeridianFormat } = useDateTimePickerAdapter();
 
   const isInvalidDate = ({ startDate, endDate }) =>
     dayjs(startDate).isSameOrAfter(dayjs(endDate), 'minute');
@@ -227,7 +227,10 @@ const CustomTimePeriodPickers = ({
               <div aria-label={t(labelStartDate)}>
                 <DateTimePickerInput
                   changeDate={changeDate}
-                  commonPickersProps={commonPickersProps}
+                  commonPickersProps={{
+                    ...commonPickersProps,
+                    ampm: isMeridianFormat(start),
+                  }}
                   date={start}
                   maxDate={customTimePeriod.end}
                   property={CustomTimePeriodProperty.start}
@@ -240,7 +243,10 @@ const CustomTimePeriodPickers = ({
               <div aria-label={t(labelEndDate)}>
                 <DateTimePickerInput
                   changeDate={changeDate}
-                  commonPickersProps={commonPickersProps}
+                  commonPickersProps={{
+                    ...commonPickersProps,
+                    ampm: isMeridianFormat(end),
+                  }}
                   date={end}
                   minDate={customTimePeriod.start}
                   property={CustomTimePeriodProperty.end}

--- a/www/front_src/src/Resources/useDateTimePickerAdapter.ts
+++ b/www/front_src/src/Resources/useDateTimePickerAdapter.ts
@@ -1,13 +1,21 @@
 /* eslint-disable class-methods-use-this */
 import DayjsAdapter from '@date-io/dayjs';
 import dayjs from 'dayjs';
+import { includes } from 'ramda';
 
 import { useUserContext } from '@centreon/ui-context';
 import { useLocaleDateTimeFormat } from '@centreon/ui';
 
-const useDateTimePickerAdapter = (): typeof DayjsAdapter => {
+interface UseDateTimePickerAdapterProps {
+  Adapter: typeof DayjsAdapter;
+  isMeridianFormat: (date: Date) => boolean;
+}
+
+const meridians = ['AM', 'PM'];
+
+const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
   const { locale, timezone } = useUserContext();
-  const { format } = useLocaleDateTimeFormat();
+  const { format, toTime } = useLocaleDateTimeFormat();
 
   class Adapter extends DayjsAdapter {
     public format(date, formatString): string {
@@ -39,7 +47,16 @@ const useDateTimePickerAdapter = (): typeof DayjsAdapter => {
     }
   }
 
-  return Adapter;
+  const isMeridianFormat = (date: Date) => {
+    const localizedTime = toTime(date);
+
+    return meridians.some((meridian) => includes(meridian, localizedTime));
+  };
+
+  return {
+    Adapter,
+    isMeridianFormat,
+  };
 };
 
 export default useDateTimePickerAdapter;


### PR DESCRIPTION
## Description

This adapts the time picker (clock) to take into account the user language and adapt his own display to show meridian clock or non meridian clock. This impacts the graph date time picker and the downtime time pickers.
![Clock](https://user-images.githubusercontent.com/12515407/123799864-f20eca80-d8e8-11eb-8162-eb6e230d819e.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Select english as user language
- Select a resource with a graph
- Open a date time picker to edit a custom time period
- -> The clock is displayed with meridian (am/pm) text and 12 hours are selectable
- Close the panel
- Open the downtime dialog for a resource
- Click on the time field to open the picker
- -> The clock is also displayed with meridian (am/pm) text and 12 hours are selectable
- Change your user language to french (or spanish)
- Log out and re-log in
- Select a resource with a graph
- Open a date time picker to edit a custom time period
- -> The clock is displayed without meridian (am/pm) text and 24 hours are selectable
- Close the panel
- Open the downtime dialog for a resource
- Click on the time field to open the picker
- -> The clock is also displayed without meridian (am/pm) text and 24hours are selectable

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
