### PR TITLE
fix(generateImage): statement reliable only if chartId is well formatted

### DIFF
--- a/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/www/include/views/graphs/generateGraphs/generateImage.php
@@ -144,20 +144,19 @@ if (!empty($chartId)) {
     } else {
         throw new \InvalidArgumentException('chartId must be a combination of integers');
     }
-}
+    $statement = $pearDBO->prepare(
+        'SELECT id FROM index_data WHERE host_id = :hostId AND service_id = :serviceId'
+    );
+    $statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
+    $statement->bindValue(':serviceId', $serviceId, \PDO::PARAM_INT);
 
-$statement = $pearDBO->prepare(
-    'SELECT id FROM index_data WHERE host_id = :hostId AND service_id = :serviceId'
-);
-$statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
-$statement->bindValue(':serviceId', $serviceId, \PDO::PARAM_INT);
+    $statement->execute();
 
-$statement->execute();
-
-if ($row = $statement->fetch()) {
-    $index = $row['id'];
-} else {
-    die('Resource not found');
+    if ($row = $statement->fetch()) {
+        $index = $row['id'];
+    } else {
+        die('Resource not found');
+    }
 }
 
 $res = $pearDB->prepare(


### PR DESCRIPTION
## Description
This PR intends to patch an issue with the SQL request made on index_data table. This request is reliable only if chartId is correctly formatted so that we can extract serviceId and hostId to make the request.

Indirect impact: MBI report calls the generateImage.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to Monitoring -> Performances and generate (export PNG) an image for a metric - should work

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
