### PR TITLE
fix(conf/poller) Changing a remote server to a distant poller when changing the remote server IP

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -746,30 +746,35 @@ function addUserRessource(int $serverId): bool
 }
 
 /**
- * Update Remote Server informations
+ * Update Remote Server information
  *
  * @param array $data
- *
+ * @param string|null $oldIpAddress Old IP address of the server before the upgrade
  */
-function updateRemoteServerInformation(array $data)
+function updateRemoteServerInformation(array $data, string $oldIpAddress = null)
 {
-    global $pearDB, $centreon;
+    global $pearDB;
 
-    $res = $pearDB->query("SELECT * FROM `remote_servers` WHERE ip = '" . $data["ns_ip_address"] . "'");
-    $rows = $res->fetch(\PDO::FETCH_ASSOC);
+    $statement = $pearDB->prepare("SELECT COUNT(*) AS total FROM remote_servers WHERE ip = :ip");
+    $statement->bindValue(':ip', $oldIpAddress ?? $data["ns_ip_address"]);
+    $statement->execute();
+    $total = (int) $statement->fetch(\PDO::FETCH_ASSOC)['total'];
 
-    if ($rows > 1) {
-        $rq = "UPDATE `remote_servers` SET ";
-        $rq .= "http_method = '" . $data["http_method"] . "', ";
-        isset($data["http_port"]) && !empty($data["http_port"])
-            ? $rq .= "http_port = '" . $data["http_port"] . "', "
-            : $rq .= "http_port = NULL, ";
-        $rq .= "no_check_certificate = '" . $data["no_check_certificate"]["no_check_certificate"] . "', ";
-        $rq .= "no_proxy = '" . $data["no_proxy"]["no_proxy"] . "' ";
-        $rq .= "WHERE ip = '" . $data["ns_ip_address"] . "'";
-        $pearDB->query($rq);
+    if ($total === 1) {
+        $statement = $pearDB->prepare("
+            UPDATE remote_servers 
+            SET http_method = :http_method, http_port = :http_port,
+                no_check_certificate = :no_check_certificate, no_proxy = :no_proxy, ip = :new_ip
+            WHERE ip = :ip
+        ");
+        $statement->bindValue(':http_method', $data["http_method"]);
+        $statement->bindValue(':http_port', $data["http_port"] ?? null, \PDO::PARAM_INT);
+        $statement->bindValue(':no_proxy', $data["no_proxy"]["no_proxy"]);
+        $statement->bindValue(':no_check_certificate', $data["no_check_certificate"]["no_check_certificate"]);
+        $statement->bindValue(':new_ip', $data["ns_ip_address"]);
+        $statement->bindValue(':ip', $oldIpAddress ?? $data["ns_ip_address"]);
+        $statement->execute();
     }
-    $res->closeCursor();
 }
 
 /**
@@ -791,6 +796,14 @@ function updateServer(int $id, array $data): void
         $pearDB->query("UPDATE `nagios_server` SET `is_default` = '0'");
     }
     $retValue = [];
+
+    // We retrieve IP address that was defined before the update request
+    $statement = $pearDB->prepare('SELECT ns_ip_address FROM nagios_server WHERE id = :id');
+    $statement->bindValue(':id', $id, \PDO::PARAM_INT);
+    $statement->execute();
+    $ipAddressBeforeChanges = ($result = $statement->fetch(\PDO::FETCH_ASSOC))
+        ? $result['ns_ip_address']
+        : null;
 
     $rq = "UPDATE `nagios_server` SET ";
     $rq .= "`name` = ";
@@ -985,7 +998,7 @@ function updateServer(int $id, array $data): void
         // catch exception but don't return anything to avoid blank pages on form
     }
 
-    updateRemoteServerInformation($data);
+    updateRemoteServerInformation($data, $ipAddressBeforeChanges);
     additionnalRemoteServersByPollerId($id, $data["remote_additional_id"]);
 
     if (isset($_REQUEST['pollercmd'])) {


### PR DESCRIPTION
## Description

When changing the IP address of a remote server, it becomes a distant poller.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
