### PR TITLE
fix(web): Undefined variables and LDAP's myAccount issue - @alfredosilvestre-natixis

### DIFF
--- a/www/class/centreon-clapi/centreonHost.class.php
+++ b/www/class/centreon-clapi/centreonHost.class.php
@@ -507,7 +507,7 @@ class CentreonHost extends CentreonObject
             $exportedFields = [];
             $resultString = "";
             foreach ($listParam as $paramSearch) {
-                if (!$paramString) {
+                if (!isset($paramString) || !$paramString) {
                     $paramString = $paramSearch;
                 } else {
                     $paramString = $paramString . $this->delim . $paramSearch;

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -346,7 +346,9 @@ $form->applyFilter('contact_name', 'myReplace');
 $form->addRule('contact_name', _("Compulsory name"), 'required');
 $form->addRule('contact_alias', _("Compulsory alias"), 'required');
 $form->addRule('contact_email', _("Valid Email"), 'required');
-$form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
+if ($cct["contact_auth_type"] != 'ldap') {
+    $form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
+}
 $form->registerRule('exist', 'callback', 'testExistence');
 $form->addRule('contact_name', _("Name already in use"), 'exist');
 $form->registerRule('existAlias', 'callback', 'testAliasExistence');

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -346,7 +346,7 @@ $form->applyFilter('contact_name', 'myReplace');
 $form->addRule('contact_name', _("Compulsory name"), 'required');
 $form->addRule('contact_alias', _("Compulsory alias"), 'required');
 $form->addRule('contact_email', _("Valid Email"), 'required');
-if ($cct["contact_auth_type"] != 'ldap') {
+if ($cct["contact_auth_type"] !== 'ldap') {
     $form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
 }
 $form->registerRule('exist', 'callback', 'testExistence');


### PR DESCRIPTION
## Description

**From**: @alfredosilvestre-natixis https://github.com/centreon/centreon/pull/9323
**Rebased on**: latest master
**Ticket**: MON-10714

The first issue is an undefined variable "paramString" when using the API to get a host parameter.

The second issue is when going to the "My Account" page on a user that has a "ldap" authentication type.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

First issue:
1. Send an API command via the web clapi interface to get a host parameter
2. Check the error on the php logs

Second issue:
1. Go to "Administration > Parameters > My Account" by clicking on the "Edit profile" link on the top right
2. Check the error on the php logs

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
