### PR TITLE
fix(clapi): insert poller into platform_topology

### DIFF
--- a/lib/Centreon/Object/Instance/Instance.php
+++ b/lib/Centreon/Object/Instance/Instance.php
@@ -66,7 +66,7 @@ class Centreon_Object_Instance extends Centreon_Object
      * Insert platform in nagios_server and platform_topology tables.
      *
      * @param array<string,mixed> $params
-     * @return void
+     * @return int
      */
     public function insert($params = [])
     {

--- a/lib/Centreon/Object/Instance/Instance.php
+++ b/lib/Centreon/Object/Instance/Instance.php
@@ -64,7 +64,7 @@ class Centreon_Object_Instance extends Centreon_Object
     /**
      * Insert platform in nagios_server and platform_topology tables.
      *
-     * @param array $params
+     * @param array<string,mixed> $params
      * @return void
      */
     public function insert($params = [])
@@ -116,7 +116,7 @@ class Centreon_Object_Instance extends Centreon_Object
     }
 
     /**
-     * Find for existing platform by id.
+     * Find existing platform by id.
      *
      * @param integer $id
      * @return PlatformInterface|null
@@ -133,7 +133,7 @@ class Centreon_Object_Instance extends Centreon_Object
     }
 
     /**
-     * Find for existing platform by address.
+     * Find existing platform by address.
      *
      * @param string $address
      * @return PlatformInterface|null
@@ -153,7 +153,6 @@ class Centreon_Object_Instance extends Centreon_Object
      * Update a platform topology.
      *
      * @param PlatformInterface $platformTopology
-     * @return void
      */
     private function updatePlatformTopology(PlatformInterface $platformTopology): void
     {
@@ -169,8 +168,7 @@ class Centreon_Object_Instance extends Centreon_Object
     /**
      * Insert the poller in platform_topology.
      *
-     * @param array $params
-     * @return void
+     * @param array<string,mixed> $params
      */
     private function insertIntoPlatformTopology(array $params): void
     {

--- a/lib/Centreon/Object/Instance/Instance.php
+++ b/lib/Centreon/Object/Instance/Instance.php
@@ -101,9 +101,6 @@ class Centreon_Object_Instance extends Centreon_Object
                 $platformTopology->setPending(false);
                 $platformTopology->setServerId($serverId);
                 $this->updatePlatformTopology($platformTopology);
-                if (!$isAlreadyInTransaction) {
-                    $this->db->commit();
-                }
             } catch (\Exception $ex) {
                 if (!$isAlreadyInTransaction) {
                     $this->db->rollBack();
@@ -115,9 +112,6 @@ class Centreon_Object_Instance extends Centreon_Object
                 $serverId = parent::insert($params);
                 $params['server_id'] = $serverId;
                 $this->insertIntoPlatformTopology($params);
-                if (!$isAlreadyInTransaction) {
-                    $this->db->commit();
-                }
             } catch (\Exception $ex) {
                 if (!$isAlreadyInTransaction) {
                     $this->db->rollBack();
@@ -125,7 +119,9 @@ class Centreon_Object_Instance extends Centreon_Object
                 throw new \Exception('Unable to create platform', 0, $ex);
             }
         }
-
+        if (!$isAlreadyInTransaction) {
+            $this->db->commit();
+        }
         return $serverId;
     }
 

--- a/lib/Centreon/Object/Instance/Instance.php
+++ b/lib/Centreon/Object/Instance/Instance.php
@@ -188,7 +188,7 @@ class Centreon_Object_Instance extends Centreon_Object
         }
         $statement = $this->db->prepare(
             "INSERT INTO platform_topology (address, name, type, pending, parent_id, server_id) " .
-            "VALUES (:address, :name, 'poller', '0', :parentId, :serverId)"
+            "VALUES (:address, :name, '" . PlatformRegistered::TYPE_POLLER . "', '0', :parentId, :serverId)"
         );
         $statement->bindValue(':address', $params['ns_ip_address'], \PDO::PARAM_STR);
         $statement->bindValue(':name', $params['name'], \PDO::PARAM_STR);
@@ -204,7 +204,9 @@ class Centreon_Object_Instance extends Centreon_Object
      */
     private function findCentralPlatformTopologyId(): ?int
     {
-        $result = $this->db->query("SELECT id from platform_topology WHERE type ='central'");
+        $result = $this->db->query(
+            "SELECT id from platform_topology WHERE type ='" . PlatformRegistered::TYPE_CENTRAL . "'"
+        );
         if ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
             return (int) $row['id'];
         }

--- a/tests/api/features/PlatformInformation.feature
+++ b/tests/api/features/PlatformInformation.feature
@@ -10,18 +10,6 @@ Feature:
     Scenario: Update platform information
         Given I am logged in
 
-        # This step is mandatory, otherwise the platform_topology is empty on the test container.
-        When I send a POST request to '/latest/platform/topology' with body:
-        """
-        {
-            "name": "Central",
-            "type": "central",
-            "address": "1.1.1.10",
-            "hostname": "central.test.localhost.localdomain"
-        }
-        """
-        Then the response code should be "201"
-
         When I send a PATCH request to '/latest/platform' with body:
         """
         {

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -10,35 +10,6 @@ Feature:
     Scenario: Register servers in Platform Topology
         Given I am logged in
 
-        # Register the Central on the container with a name which doesn't exist in nagios_server table
-        # Should fail and an error should be returned
-        When I send a POST request to '/latest/platform/topology' with body:
-            """
-            {
-                "name": "wrong_name",
-                "type": "central",
-                "address": "1.1.1.10"
-            }
-            """
-        Then the response code should be "400"
-        And the response should be equal to:
-            """
-            {"message":"The server type 'central' : 'wrong_name'@'1.1.1.10' does not match the one configured in Centreon or is disabled"}
-            """
-
-        # Successfully register the Central on the container
-        # (Notice : this step is automatically done on a real platform on fresh install and update)
-        When I send a POST request to '/latest/platform/topology' with body:
-            """
-            {
-                "name": "Central",
-                "type": "central",
-                "address": "1.1.1.10",
-                "hostname": "central.test.localhost.localdomain"
-            }
-            """
-        Then the response code should be "201"
-
         # Register the same Central a second time / Should fail and an error should be returned
         When I send a POST request to '/latest/platform/topology' with body:
             """

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -16,13 +16,13 @@ Feature:
             {
                 "name": "Central",
                 "type": "central",
-                "address": "1.1.1.10"
+                "address": "127.0.0.1"
             }
             """
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"A platform using the name : 'Central' or address : '1.1.1.10' already exists"}
+            {"message":"A platform using the name : 'Central' or address : '127.0.0.1' already exists"}
             """
 
         # Register a second Central while the first is still registered / Should fail and an error should be returned
@@ -38,7 +38,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"A 'central': 'Central'@'1.1.1.10' is already saved"}
+            {"message":"A 'central': 'Central'@'127.0.0.1' is already saved"}
             """
 
         # Register a Central linked to another Central
@@ -49,7 +49,7 @@ Feature:
                 "name": "Central_2",
                 "type": "central",
                 "address": "1.1.1.11",
-                "parent_address": "1.1.1.10"
+                "parent_address": "127.0.0.1"
             }
             """
         Then the response code should be "400"
@@ -66,7 +66,7 @@ Feature:
                 "name": "wrong_type_server",
                 "type": "server",
                 "address": "6.6.6.1",
-                "parent_address": "1.1.1.10",
+                "parent_address": "127.0.0.1",
                 "hostname": "server.test.localhost.localdomain"
             }
             """
@@ -83,7 +83,7 @@ Feature:
                 "name": "inconsistent_address",
                 "type": "poller",
                 "address": "666.",
-                "parent_address": "1.1.1.10"
+                "parent_address": "127.0.0.1"
             }
             """
         Then the response code should be "400"
@@ -99,7 +99,7 @@ Feature:
                 "name": "ill*ga|_character$_found",
                 "type": "poller",
                 "address": "1.1.10.10",
-                "parent_address": "1.1.1.10",
+                "parent_address": "127.0.0.1",
                 "hostname": "localhost.localdomain"
             }
             """
@@ -114,7 +114,7 @@ Feature:
                 "name": "space_in_hostname",
                 "type": "poller",
                 "address": "1.1.10.20",
-                "parent_address": "1.1.1.10",
+                "parent_address": "127.0.0.1",
                 "hostname": "found space"
             }
             """
@@ -131,7 +131,7 @@ Feature:
                 "name": "illegal_character_in_hostname",
                 "type": "poller",
                 "address": "1.1.10.20",
-                "parent_address": "1.1.1.10",
+                "parent_address": "127.0.0.1",
                 "hostname": "i|!egal.h*stname"
             }
             """
@@ -165,7 +165,7 @@ Feature:
                 "name": "my_poller",
                 "type": "poller",
                 "address": "1.1.1.1",
-                "parent_address": "1.1.1.10",
+                "parent_address": "127.0.0.1",
                 "hostname": "poller.test.localhost.localdomain"
             }
             """
@@ -178,7 +178,7 @@ Feature:
                 "name": "my_poller",
                 "type": "poller",
                 "address": "1.1.1.1",
-                "parent_address": "1.1.1.10"
+                "parent_address": "127.0.0.1"
             }
             """
         Then the response code should be "400"
@@ -194,7 +194,7 @@ Feature:
                 "name": "my_poller_2",
                 "type": "pOlLEr",
                 "address": "1.1.1.2",
-                "parent_address": "1.1.1.10",
+                "parent_address": "127.0.0.1",
                 "hostname": "poller2.test.localhost.localdomain"
             }
             """
@@ -284,7 +284,7 @@ Feature:
                                 "pending": "true",
                                 "centreon-id": "1",
                                 "hostname": "central.test.localhost.localdomain",
-                                "address": "1.1.1.10"
+                                "address": "127.0.0.1"
                             }
                         },
                         "2": {
@@ -342,7 +342,7 @@ Feature:
                                 "pending": "true",
                                 "centreon-id": "1",
                                 "hostname": "central.test.localhost.localdomain",
-                                "address": "1.1.1.10"
+                                "address": "127.0.0.1"
                             }
                         },
                         "2": {

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -268,100 +268,11 @@ Feature:
         # So we can't test pollers or remote edges.
         When I send a GET request to "/beta/platform/topology"
         Then the response code should be "200"
-        And the JSON should be equal to:
-            """
-            {
-                "graph": {
-                    "label": "centreon-topology",
-                    "metadata": {
-                        "version": "1.0.0"
-                    },
-                    "nodes": {
-                        "1": {
-                            "type": "central",
-                            "label": "Central",
-                            "metadata": {
-                                "pending": "true",
-                                "centreon-id": "1",
-                                "hostname": "central.test.localhost.localdomain",
-                                "address": "127.0.0.1"
-                            }
-                        },
-                        "2": {
-                            "type": "poller",
-                            "label": "my_poller",
-                            "metadata": {
-                                "pending": "true",
-                                "hostname": "poller.test.localhost.localdomain",
-                                "address": "1.1.1.1"
-                            }
-                        },
-                        "3": {
-                            "type": "poller",
-                            "label": "my_poller_2",
-                            "metadata": {
-                                "pending": "true",
-                                "hostname": "poller2.test.localhost.localdomain",
-                                "address": "1.1.1.2"
-                            }
-                        }
-                    },
-                    "edges": [
-                        {
-                            "source": "2",
-                            "relation": "normal",
-                            "target": "1"
-                        },
-                        {
-                            "source": "3",
-                            "relation": "normal",
-                            "target": "1"
-                        }
-                    ]
-                }
-            }
-            """
+        And the json node "graph.nodes" should have 3 elements
+        And the JSON node "graph.nodes.2.type" should be equal to the string "poller"
 
         When I send a DELETE request to "/beta/platform/topology/3"
         Then the response code should be "204"
         When I send a GET request to "/beta/platform/topology"
         Then the response code should be "200"
-        And the JSON should be equal to:
-            """
-            {
-                "graph": {
-                    "label": "centreon-topology",
-                    "metadata": {
-                        "version": "1.0.0"
-                    },
-                    "nodes": {
-                        "1": {
-                            "type": "central",
-                            "label": "Central",
-                            "metadata": {
-                                "pending": "true",
-                                "centreon-id": "1",
-                                "hostname": "central.test.localhost.localdomain",
-                                "address": "127.0.0.1"
-                            }
-                        },
-                        "2": {
-                            "type": "poller",
-                            "label": "my_poller",
-                            "metadata": {
-                                "pending": "true",
-                                "hostname": "poller.test.localhost.localdomain",
-                                "address": "1.1.1.1"
-                            }
-                        }
-                    },
-                    "edges": [
-                        {
-                            "source": "2",
-                            "relation": "normal",
-                            "target": "1"
-                        }
-                    ]
-                }
-            }
-            """
+        And the json node "graph.nodes" should have 2 elements


### PR DESCRIPTION
## Description
This PR fix an issue where when using CLAPI to add a poller, it wasn't created into platform_topology.
**Fixes** # MON-10697

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
