### PR TITLE
fix(upgrade): some sql errors

### DIFF
--- a/www/install/sql/centreon/Update-DB-2.8.18.sql
+++ b/www/install/sql/centreon/Update-DB-2.8.18.sql
@@ -36,8 +36,8 @@ VALUES (
 (SELECT `cb_field_id` FROM `cb_field` WHERE `description` = 'Value of the metric.'),
 0, 3, NULL, NULL);
 
-INSERT INTO `cb_list` (`cb_field_id`, `default_value`)
-VALUES((SELECT `cb_field_id` FROM `cb_field` WHERE `description` = 'Type of the metric.'), 'string');
+INSERT INTO `cb_list` (`cb_list_id`, `cb_field_id`, `default_value`)
+VALUES((SELECT IFNULL(MAX(l.cb_list_id), 0) + 1 from cb_list l), (SELECT `cb_field_id` FROM `cb_field` WHERE `description` = 'Type of the metric.'), 'string');
 
 INSERT INTO `cb_list_values` (`cb_list_id`, `value_name`, `value_value`)
 VALUES

--- a/www/install/sql/centreon/Update-DB-2.8.5.sql
+++ b/www/install/sql/centreon/Update-DB-2.8.5.sql
@@ -29,9 +29,9 @@ ALTER TABLE downtime_period MODIFY COLUMN `dtp_month_cycle` varchar(100);
 
 -- Add topology for split
 INSERT INTO `topology` (`topology_name`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_url`, `topology_show`, `readonly`)
-VALUES ('Chart split', 20401, 2040101, 1, 1, './include/views/graphs/graph-split.php', 0, 1);
+VALUES ('Chart split', 20401, 2040101, 1, 1, './include/views/graphs/graph-split.php', '0', '1');
 INSERT INTO `topology` (`topology_name`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_url`, `topology_show`, `readonly`)
-VALUES ('Chart periods', 20401, 2040102, 1, 1, './include/views/graphs/graph-periods.php', 0, 1);
+VALUES ('Chart periods', 20401, 2040102, 1, 1, './include/views/graphs/graph-periods.php', '0', '1');
 
 -- Fix problem regarding the recurrent downtimes
 UPDATE topology set topology_url_opt = NULL WHERE topology_page = 21003;


### PR DESCRIPTION
## Description

Install a centreon 2.8.x and upgrade it to 21.04.x (with MariaDB 10.5.x). You'll get errors during the update (wizard)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install a centreon 2.8.x and upgrade it to 21.04.x (with MariaDB 10.5.x). You'll get errors during the update (wizard)

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
