### PR TITLE
fix(web): update footer's copyright

### DIFF
--- a/www/front_src/src/components/footer/index.js
+++ b/www/front_src/src/components/footer/index.js
@@ -77,7 +77,7 @@ class Footer extends Component {
             </ul>
           </div>
           <div className={styles['footer-wrap-right']}>
-            <span>Copyright &copy; 2005 - 2020</span>
+            <span>Copyright &copy; 2005 - 2021</span>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
Replace #9950

## Description
Update copyright date from 2020 to 2021. 
Happy august new year!!!

* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (MON-10719)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>
Connect to centreon and check the date on the right side footer

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
