### PR TITLE
enh(CentreonUtils): Use option allowed_classes in unserialize

### DIFF
--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -247,7 +247,7 @@ class CentreonUtils
             if ($initForm === false) {
                 throw new \InvalidArgumentException('Invalid Parameters');
             }
-            $initialValues = unserialize($initForm);
+            $initialValues = unserialize($initForm, ['allowed_classes' => false]);
 
             if (!empty($initialValues) && isset($initialValues[$key])) {
                 $init = $initialValues[$key];

--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -247,6 +247,7 @@ class CentreonUtils
             if ($initForm === false) {
                 throw new \InvalidArgumentException('Invalid Parameters');
             }
+
             $initialValues = unserialize($initForm, ['allowed_classes' => false]);
 
             if (!empty($initialValues) && isset($initialValues[$key])) {


### PR DESCRIPTION
## Description

this PR intends to use option allowed_classes in unserialize

**Fixes** # MON-10802

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
