### PR TITLE
fix(ldap): correct time reference used for LDAP sync

### DIFF
--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -917,14 +917,13 @@ class CentreonLDAP
      * unless it's required
      * If it's enabled, we need to wait until the next synchronization
      *
-     * @param integer $arId : Id of the current LDAP
-     * @param integer $contactId : Id the contact
-     * @return boolean
-     * @throws Exception
+     * @param int $arId : Id of the current LDAP
+     * @param int $contactId : Id the contact
+     * @return bool
      * @internal Needed on user's login and when manually requesting an update of user's LDAP data
      *
      */
-    public function isSyncNeededAtLogin(int $arId = null, int $contactId): bool
+    public function isSyncNeededAtLogin(int $arId, int $contactId): bool
     {
         try {
             // checking if an override was manually set on this contact
@@ -934,11 +933,12 @@ class CentreonLDAP
             );
             $stmtManualRequest->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
             $stmtManualRequest->execute();
-            $manualOverride = $stmtManualRequest->fetch();
-            if ($manualOverride['contact_ldap_required_sync']) {
+            $contactData = $stmtManualRequest->fetch();
+            // check if a manual override was set for this user
+            if ($contactData['contact_ldap_required_sync']) {
                 $this->centreonLog->insertLog(
                     3,
-                    'LDAP AUTH : LDAP synchronization was requested manually for ' . $manualOverride['contact_name']
+                    'LDAP AUTH : LDAP synchronization was requested manually for ' . $contactData['contact_name']
                 );
                 return true;
             }
@@ -956,7 +956,7 @@ class CentreonLDAP
                 $syncState[$row['ari_name']] = $row['ari_value'];
             }
 
-            if ($syncState['ldap_auto_sync'] || !$manualOverride['contact_ldap_last_sync']) {
+            if ($syncState['ldap_auto_sync'] || !$contactData['contact_ldap_last_sync']) {
                 // getting the base date reference set in the LDAP parameters
                 $stmtLdapBaseSync = $this->db->prepare(
                     'SELECT ar_sync_base_date AS `referenceDate` FROM auth_ressource
@@ -966,23 +966,36 @@ class CentreonLDAP
                 $stmtLdapBaseSync->execute();
                 $ldapBaseSync = $stmtLdapBaseSync->fetch();
 
+                // setting a default value, if the user account was imported and the user has never login
+                if (!$contactData['contact_ldap_last_sync']) {
+                    $contactData['contact_ldap_last_sync'] = 0;
+                }
+
                 // checking if the interval between two synchronizations is reached
                 $currentTime = time();
+
                 if (
-                    ($syncState['ldap_sync_interval'] * 3600 + $ldapBaseSync['referenceDate']) <= $currentTime
-                    && $manualOverride['contact_ldap_last_sync'] < $ldapBaseSync['referenceDate']
+                    ($syncState['ldap_sync_interval'] * 3600 + $contactData['contact_ldap_last_sync']) <= $currentTime
+                    && $contactData['contact_ldap_last_sync'] < $ldapBaseSync['referenceDate']
                 ) {
                     // synchronization is expected
                     $this->centreonLog->insertLog(
                         3,
-                        'LDAP AUTH : Updating user DN of ' . $manualOverride['contact_name']
+                        'LDAP AUTH : Updating user DN of ' . $contactData['contact_name']
                     );
                     return true;
                 }
             }
         } catch (\PDOException $e) {
-            throw new \Exception('Error while getting automatic synchronization value for LDAP Id : ' . $arId);
+            $this->centreonLog->insertLog(
+                3,
+                'Error while getting automatic synchronization value for LDAP Id : ' . $arId
+            );
             // assuming it needs to be synchronized
+            $this->centreonLog->insertLog(
+                3,
+                'LDAP AUTH : Updating user DN of ' . $contactData['contact_name']
+            );
             return true;
         }
         $this->centreonLog->insertLog(

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -925,7 +925,6 @@ class CentreonLDAP
      */
     public function isSyncNeededAtLogin(int $arId, int $contactId): bool
     {
-        $contactData = [];
         try {
             // checking if an override was manually set on this contact
             $stmtManualRequest = $this->db->prepare(

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -935,7 +935,7 @@ class CentreonLDAP
             $stmtManualRequest->execute();
             $contactData = $stmtManualRequest->fetch();
             // check if a manual override was set for this user
-            if ($contactData['contact_ldap_required_sync']) {
+            if ($contactData !== false && $contactData['contact_ldap_required_sync'] === '1') {
                 $this->centreonLog->insertLog(
                     3,
                     'LDAP AUTH : LDAP synchronization was requested manually for ' . $contactData['contact_name']

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -989,7 +989,8 @@ class CentreonLDAP
             // assuming it needs to be synchronized
             $this->centreonLog->insertLog(
                 3,
-                'LDAP AUTH : Updating user DN of ' . $contactData['contact_name']
+                'LDAP AUTH : Updating user DN of ' .
+                (!empty($contactData['contact_name']) ? $contactData['contact_name'] : "contact id $contactId")
             );
             return true;
         }

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -925,6 +925,7 @@ class CentreonLDAP
      */
     public function isSyncNeededAtLogin(int $arId, int $contactId): bool
     {
+        $contactData = [];
         try {
             // checking if an override was manually set on this contact
             $stmtManualRequest = $this->db->prepare(
@@ -956,7 +957,7 @@ class CentreonLDAP
                 $syncState[$row['ari_name']] = $row['ari_value'];
             }
 
-            if ($syncState['ldap_auto_sync'] || !$contactData['contact_ldap_last_sync']) {
+            if ($syncState['ldap_auto_sync'] || $contactData['contact_ldap_last_sync'] === 0) {
                 // getting the base date reference set in the LDAP parameters
                 $stmtLdapBaseSync = $this->db->prepare(
                     'SELECT ar_sync_base_date AS `referenceDate` FROM auth_ressource
@@ -965,11 +966,6 @@ class CentreonLDAP
                 $stmtLdapBaseSync->bindValue(':arId', $arId, \PDO::PARAM_INT);
                 $stmtLdapBaseSync->execute();
                 $ldapBaseSync = $stmtLdapBaseSync->fetch();
-
-                // setting a default value, if the user account was imported and the user has never login
-                if (!$contactData['contact_ldap_last_sync']) {
-                    $contactData['contact_ldap_last_sync'] = 0;
-                }
 
                 // checking if the interval between two synchronizations is reached
                 $currentTime = time();


### PR DESCRIPTION
## Description

- The sync delay used to update the LDAP's user data was based on the last form update time, while it should have been based on the last user login time
- Rename used variable
- Do not throw an error and assume a sync is required on LDAP data retrieval error
- Set default value for user's first login time
- Update docblock

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
