### PR TITLE
fix(UI): Add background color for  submenu profile in the Header

### DIFF
--- a/www/front_src/src/components/header/header.scss
+++ b/www/front_src/src/components/header/header.scss
@@ -281,6 +281,7 @@
       .submenu-user-edit {
         font-family: $primary-font-light;
         margin-left: 4px;
+        background-color: #000915;
         color: $white-color;
         float: right;
         text-decoration-line: underline;

--- a/www/front_src/src/components/header/header.scss
+++ b/www/front_src/src/components/header/header.scss
@@ -263,6 +263,7 @@
         padding: 10px;
         display: block;
         font-family: $primary-font-light;
+        background-color: #232f39;
         color: $white-color;
         text-decoration: none;
         font-size: 0.8rem;
@@ -337,12 +338,6 @@
       .submenu-user-name {
         display: block;
         margin-bottom: 10px;
-      }
-      .button-wrap {
-        .btn {
-          margin-top: 10px;
-          float: right;
-        }
       }
     }
     &-top-item {
@@ -490,4 +485,8 @@
 }
 .submenu-padding {
   height: 55px;
+}
+.logoutLink {
+  display: grid;
+  justify-content: flex-end;
 }

--- a/www/front_src/src/components/header/userMenu/index.js
+++ b/www/front_src/src/components/header/userMenu/index.js
@@ -156,7 +156,7 @@ class UserMenu extends Component {
                   </span>
                 </li>
                 {autologinkey && (
-                  <>
+                  <div className={styles['submenu-content']}>
                     <button
                       className={styles['submenu-user-button']}
                       onClick={this.onCopy}
@@ -175,11 +175,11 @@ class UserMenu extends Component {
                       ref={(node) => (this.autologinNode = node)}
                       value={autolink}
                     />
-                  </>
+                  </div>
                 )}
               </ul>
-              <div className={styles['button-wrap']}>
-                <a href="index.php?disconnect=1">
+              <div className={styles['submenu-content']}>
+                <a className={styles.logoutLink} href="index.php?disconnect=1">
                   <button
                     className={classnames(
                       styles.btn,


### PR DESCRIPTION
## Description

The submenu profile's background is transparent

**Fixes** # (issue)

This submenu should have a background like the other submenus
<img width="261" alt="Capture d’écran 2021-07-23 à 10 46 48" src="https://user-images.githubusercontent.com/16045498/126758898-01c5effc-0166-44bb-8018-8c9cda157f33.png">


## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Log on the UI , and click on user's icon in the Header , all submenus have a background color now

