### PR TITLE
fix(security): hide OpenId tokens in CentreonUI form

### DIFF
--- a/www/include/Administration/parameters/DB-Func.php
+++ b/www/include/Administration/parameters/DB-Func.php
@@ -791,18 +791,28 @@ function updateGeneralConfigData($gopt_id = null)
             ? $pearDB->escape($ret["openid_connect_redirect_url"]) : ""
     );
 
-    updateOption(
-        $pearDB,
-        "openid_connect_client_id",
-        isset($ret["openid_connect_client_id"]) && $ret["openid_connect_client_id"] != null
-            ? $pearDB->escape($ret["openid_connect_client_id"]) : ""
-    );
-    updateOption(
-        $pearDB,
-        "openid_connect_client_secret",
-        isset($ret["openid_connect_client_secret"]) && $ret["openid_connect_client_secret"] != null
-            ? $pearDB->escape($ret["openid_connect_client_secret"]) : ""
-    );
+    if (
+        isset($ret["openid_connect_client_id"])
+        && $ret["openid_connect_client_id"] !== CentreonAuth::PWS_OCCULTATION
+    ) {
+        updateOption(
+            $pearDB,
+            "openid_connect_client_id",
+            $pearDB->escape($ret["openid_connect_client_id"])
+        );
+    }
+
+    if (
+        isset($ret["openid_connect_client_secret"])
+        && $ret["openid_connect_client_secret"] !== CentreonAuth::PWS_OCCULTATION
+    ) {
+        updateOption(
+            $pearDB,
+            "openid_connect_client_secret",
+            $pearDB->escape($ret["openid_connect_client_secret"])
+        );
+    }
+
     updateOption(
         $pearDB,
         "openid_connect_verify_peer",

--- a/www/include/Administration/parameters/general/form.php
+++ b/www/include/Administration/parameters/general/form.php
@@ -297,9 +297,9 @@ $form->addElement('text', 'openid_connect_end_session_endpoint', _('End Session 
 $form->addElement('text', 'openid_connect_scope', _('Scope'), array('size' => 50));
 $form->addElement('text', 'openid_connect_login_claim', _('Login claim value'), array('size' => 50));
 $form->addElement('text', 'openid_connect_redirect_url', _('Redirect Url'), array('size' => 50));
-$form->addElement('text', 'openid_connect_client_id', _('Client ID'), array('size' => 50, 'autocomplete' => 'off'));
+$form->addElement('password', 'openid_connect_client_id', _('Client ID'), array('size' => 50, 'autocomplete' => 'off'));
 $form->addElement(
-    'text',
+    'password',
     'openid_connect_client_secret',
     _('Client Secret'),
     array('size' => 50, 'autocomplete' => 'off')

--- a/www/include/Administration/parameters/general/form.php
+++ b/www/include/Administration/parameters/general/form.php
@@ -297,8 +297,12 @@ $form->addElement('text', 'openid_connect_end_session_endpoint', _('End Session 
 $form->addElement('text', 'openid_connect_scope', _('Scope'), array('size' => 50));
 $form->addElement('text', 'openid_connect_login_claim', _('Login claim value'), array('size' => 50));
 $form->addElement('text', 'openid_connect_redirect_url', _('Redirect Url'), array('size' => 50));
-$form->addElement('text', 'openid_connect_client_id', _('Client ID'), array('size' => 50));
-$form->addElement('text', 'openid_connect_client_secret', _('Client Secret'), array('size' => 50));
+$form->addElement('text', 'openid_connect_client_id', _('Client ID'), array('size' => 50, 'autocomplete' => 'off'));
+$form->addElement(
+    'text',
+    'openid_connect_client_secret',
+    _('Client Secret'), array('size' => 50, 'autocomplete' => 'off')
+);
 
 $openIdConnectVerifyPeer[] = $form->createElement(
     'checkbox',
@@ -360,6 +364,12 @@ $form->addRule(
 $tpl = new Smarty();
 $tpl = initSmartyTpl($path . 'general/', $tpl);
 
+if (!empty($gopt['openid_connect_client_id'])) {
+    $gopt['openid_connect_client_id'] = CentreonAuth::PWS_OCCULTATION;
+}
+if (!empty($gopt['openid_connect_client_secret'])) {
+    $gopt['openid_connect_client_secret'] = CentreonAuth::PWS_OCCULTATION;
+}
 $form->setDefaults($gopt);
 
 $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));

--- a/www/include/Administration/parameters/general/form.php
+++ b/www/include/Administration/parameters/general/form.php
@@ -301,7 +301,8 @@ $form->addElement('text', 'openid_connect_client_id', _('Client ID'), array('siz
 $form->addElement(
     'text',
     'openid_connect_client_secret',
-    _('Client Secret'), array('size' => 50, 'autocomplete' => 'off')
+    _('Client Secret'),
+    array('size' => 50, 'autocomplete' => 'off')
 );
 
 $openIdConnectVerifyPeer[] = $form->createElement(


### PR DESCRIPTION
## Description

this PR hide OpenId tokens in CentreonUI form

**Fixes** # MON-10849

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
