### PR TITLE
fix(clapi): downtime duration is not mandatory for fixed downtimes

### DIFF
--- a/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/www/class/centreon-clapi/centreonDowntime.class.php
@@ -272,8 +272,8 @@ class CentreonDowntime extends CentreonObject
         if (!is_numeric($tmp[3])) {
             throw new CentreonClapiException('Incorrect fixed parameters');
         }
-        if (!is_numeric($tmp[4])) {
-            throw new CentreonClapiException('Incorrect duration parameters');
+        if ($tmp[3] == 0 && !is_numeric($tmp[4])) {
+            throw new CentreonClapiException('Incorrect duration parameters: a duration in seconds must be given for flexible downtimes');
         }
 
         $p = array();
@@ -281,7 +281,7 @@ class CentreonDowntime extends CentreonObject
         $p[':start_time'] = $tmp[1];
         $p[':end_time'] = $tmp[2];
         $p[':fixed'] = $tmp[3];
-        $p[':duration'] = $tmp[4];
+        $p[':duration'] = $tmp[3] == 0?$tmp[4]:'';
         $daysOfWeek = explode(',', strtolower($tmp[5]));
         $days = array();
         foreach ($daysOfWeek as $dayOfWeek) {

--- a/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/www/class/centreon-clapi/centreonDowntime.class.php
@@ -281,7 +281,7 @@ class CentreonDowntime extends CentreonObject
         $p[':start_time'] = $tmp[1];
         $p[':end_time'] = $tmp[2];
         $p[':fixed'] = $tmp[3];
-        $p[':duration'] = $tmp[3] == 0 ? $tmp[4] : '';
+        $p[':duration'] = $tmp[3] == 0 ? $tmp[4] : null;
         $daysOfWeek = explode(',', strtolower($tmp[5]));
         $days = array();
         foreach ($daysOfWeek as $dayOfWeek) {

--- a/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/www/class/centreon-clapi/centreonDowntime.class.php
@@ -273,7 +273,7 @@ class CentreonDowntime extends CentreonObject
             throw new CentreonClapiException('Incorrect fixed parameters');
         }
         if ($tmp[3] == 0 && !is_numeric($tmp[4])) {
-            throw new CentreonClapiException('Incorrect duration parameters: a duration in seconds must be given for flexible downtimes');
+            throw new CentreonClapiException('Incorrect duration parameters: mandatory for flexible downtimes');
         }
 
         $p = array();
@@ -281,7 +281,7 @@ class CentreonDowntime extends CentreonObject
         $p[':start_time'] = $tmp[1];
         $p[':end_time'] = $tmp[2];
         $p[':fixed'] = $tmp[3];
-        $p[':duration'] = $tmp[3] == 0?$tmp[4]:'';
+        $p[':duration'] = $tmp[3] == 0? $tmp[4]: '';
         $daysOfWeek = explode(',', strtolower($tmp[5]));
         $days = array();
         foreach ($daysOfWeek as $dayOfWeek) {

--- a/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/www/class/centreon-clapi/centreonDowntime.class.php
@@ -281,7 +281,7 @@ class CentreonDowntime extends CentreonObject
         $p[':start_time'] = $tmp[1];
         $p[':end_time'] = $tmp[2];
         $p[':fixed'] = $tmp[3];
-        $p[':duration'] = $tmp[3] == 0? $tmp[4]: '';
+        $p[':duration'] = $tmp[3] == 0 ? $tmp[4] : '';
         $daysOfWeek = explode(',', strtolower($tmp[5]));
         $days = array();
         foreach ($daysOfWeek as $dayOfWeek) {


### PR DESCRIPTION
## Description

Recurrent downtimes exported with CLAPI cannot be imported with... CLAPI.
This is because 
* the export does not export the duration for fixed downtimes (it's normal since they have fixed start time and end time).
* the import expects a duration whether the downtime is fixed or not

**Fixes** MON-10855

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

If possible, a step-by-step procedure to reproduce the issue:

Create a file with the following lines (lines created when we export a recurrent downtime):

```
DOWNTIME;ADD;DT-test1;DT-test1
DOWNTIME;setparam;DT-test1;dt_activate;1
DOWNTIME;ADDHOST;DT-test1;Central
DOWNTIME;ADDWEEKLYPERIOD;DT-test1;10:35;10:50;1;;4,5
```

then import file by clapi command:

```
centreon -u admin -p 'password' -i /tmp/downtime
```

**Additional information**

Downtime is not imported because the import cannot manage the missing seconds value about the flexible DOWNTIME type_

NOT WORKING: DOWNTIME;ADDWEEKLYPERIOD;DT-test1;10:35;10:50;1;;4,5
THIS WILL WORK: DOWNTIME;ADDWEEKLYPERIOD;DT-test1;10:35;10:50;1;7200;4,5

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
