### PR TITLE
MON-11757 fix stickyness for ack

### DIFF
--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -106,7 +106,7 @@ class EngineService extends AbstractCentreonService implements
         $preCommand = sprintf(
             'ACKNOWLEDGE_HOST_PROBLEM;%s;%d;%d;%d;%s;%s',
             $host->getName(),
-            $sticky,
+            $acknowledgement->isSticky() ? 2 : 0,
             (int) $acknowledgement->isNotifyContacts(),
             (int) $acknowledgement->isPersistentComment(),
             $this->contact->getAlias(),

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -98,11 +98,6 @@ class EngineService extends AbstractCentreonService implements
             throw new EngineException('Host name can not be empty');
         }
 
-        $sticky = 0;
-        if ($acknowledgement->isSticky() === true) {
-            $sticky = 2;
-        }
-
         $preCommand = sprintf(
             'ACKNOWLEDGE_HOST_PROBLEM;%s;%d;%d;%d;%s;%s',
             $host->getName(),

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -97,11 +97,16 @@ class EngineService extends AbstractCentreonService implements
         if (empty($host->getName())) {
             throw new EngineException('Host name can not be empty');
         }
+        
+        $sticky = 0;
+        if ((int) $acknowledgement->isSticky() === 1) {
+            $sticky = 2;
+        }
 
         $preCommand = sprintf(
             'ACKNOWLEDGE_HOST_PROBLEM;%s;%d;%d;%d;%s;%s',
             $host->getName(),
-            (int) $acknowledgement->isSticky(),
+            $sticky,
             (int) $acknowledgement->isNotifyContacts(),
             (int) $acknowledgement->isPersistentComment(),
             $this->contact->getAlias(),
@@ -123,12 +128,17 @@ class EngineService extends AbstractCentreonService implements
         if (empty($service->getHost())) {
             throw new EngineException('The host of service is not defined');
         }
+        
+        $sticky = 0;
+        if ((int) $acknowledgement->isSticky() === 1) {
+            $sticky = 2;
+        }
 
         $preCommand = sprintf(
             'ACKNOWLEDGE_SVC_PROBLEM;%s;%s;%d;%d;%d;%s;%s',
             $service->getHost()->getName(),
             $service->getDescription(),
-            (int) $acknowledgement->isSticky(),
+            $sticky,
             (int) $acknowledgement->isNotifyContacts(),
             (int) $acknowledgement->isPersistentComment(),
             $this->contact->getAlias(),

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -129,11 +129,6 @@ class EngineService extends AbstractCentreonService implements
             throw new EngineException('The host of service is not defined');
         }
 
-        $sticky = 0;
-        if ($acknowledgement->isSticky() === true) {
-            $sticky = 2;
-        }
-
         $preCommand = sprintf(
             'ACKNOWLEDGE_SVC_PROBLEM;%s;%s;%d;%d;%d;%s;%s',
             $service->getHost()->getName(),

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -97,7 +97,7 @@ class EngineService extends AbstractCentreonService implements
         if (empty($host->getName())) {
             throw new EngineException('Host name can not be empty');
         }
-        
+
         $sticky = 0;
         if ((int) $acknowledgement->isSticky() === 1) {
             $sticky = 2;
@@ -128,7 +128,7 @@ class EngineService extends AbstractCentreonService implements
         if (empty($service->getHost())) {
             throw new EngineException('The host of service is not defined');
         }
-        
+
         $sticky = 0;
         if ((int) $acknowledgement->isSticky() === 1) {
             $sticky = 2;

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -138,7 +138,7 @@ class EngineService extends AbstractCentreonService implements
             'ACKNOWLEDGE_SVC_PROBLEM;%s;%s;%d;%d;%d;%s;%s',
             $service->getHost()->getName(),
             $service->getDescription(),
-            $sticky,
+            $acknowledgement->isSticky() ? 2 : 0,
             (int) $acknowledgement->isNotifyContacts(),
             (int) $acknowledgement->isPersistentComment(),
             $this->contact->getAlias(),

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -99,7 +99,7 @@ class EngineService extends AbstractCentreonService implements
         }
 
         $sticky = 0;
-        if ((int) $acknowledgement->isSticky() === 1) {
+        if ($acknowledgement->isSticky() === true) {
             $sticky = 2;
         }
 

--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -130,7 +130,7 @@ class EngineService extends AbstractCentreonService implements
         }
 
         $sticky = 0;
-        if ((int) $acknowledgement->isSticky() === 1) {
+        if ($acknowledgement->isSticky() === true) {
             $sticky = 2;
         }
 


### PR DESCRIPTION
## Description

resource status page uses the api/beta/monitoring/resources/acknowledge  endpoint
this endpoint set the sticky value to 1 or 0 instead of 2 or 0 according to this https://assets.nagios.com/downloads/nagioscore/docs/externalcmds/cmdinfo.php?command_id=40

Meaning that if you set the stickyness in your default configuration, it will not work at all and set the ack like it wasn't sticky

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

without this PR,
- go in administration -> parameters -> monitoring menu and tick the sticky checkbox  (meaning ack are going to be sticky)
-  go in the monitoring -> resources status page and put an ack on a service or a host, put the following comment "default sticky value: 1)
- wait for your ack to be displayed in the monitoring (yellow background on the service or host row)
- when ack is displayed, in your central database, run the following query : 
`select sticky,comment_data from centreon_storage.acknowledgements;` 
- you should have the following result: `|      0 | default sticky 1`

with this PR,
- repeat the above steps
- you should have the following result: `|      1 | default sticky 1`

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
