### PR TITLE
fix(ui): Remove background color on submenu user edit

### DIFF
--- a/www/front_src/src/components/header/header.scss
+++ b/www/front_src/src/components/header/header.scss
@@ -282,7 +282,6 @@
       .submenu-user-edit {
         font-family: $primary-font-light;
         margin-left: 4px;
-        background-color: #000915;
         color: $white-color;
         float: right;
         text-decoration-line: underline;


### PR DESCRIPTION
## Description

Remove background color on submenu user edit, in the Header after clicking on icon User.


## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Logon on UI, and click on icon look's like User. 


