### PR TITLE
fix(kb): $templates array must be returned in reverse order

### DIFF
--- a/www/class/centreon-knowledge/ProceduresProxy.class.php
+++ b/www/class/centreon-knowledge/ProceduresProxy.class.php
@@ -223,7 +223,7 @@ class ProceduresProxy
          */
         $serviceId = $this->getServiceId($hostName, $serviceDescription);
         $templates = $this->serviceObj->getTemplatesChain($serviceId);
-        foreach ($templates as $templateId) {
+        foreach (array_reverse($templates) as $templateId) {
             $templateDescription = $this->serviceObj->getServiceDesc($templateId);
             $notesUrl = $this->getServiceNotesUrl((int) $templateId);
             if ($notesUrl !== null) {


### PR DESCRIPTION
## Description

The function getTemplatesChain store the templates id in reverse order, so when reading these values they must be readed in reverse order as well, in order to show the more priority template.

Let's take the following example:

Service1 -> Template_service1 [890] -> Template_services [300] -> Generic_template[1]

The function getTemplatesChain, store those templates ID as follow:

array[0] = 1
array[1] = 300
array[2] = 890

So when the function getServiceUrl has to return the template URL, it'll return always the link to the Generic_template[1]

If we read the array in reverse order the function will return the template URL of Template_service1[890], and I think this is the proper way to do it, since the idea is to show the procedures of the more specific template.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create a service with a service template, that template must have at least one more template associated to it, as the example above, all the service templates must have a serviceNotesUrl. 

Following the example above, if you click the link to get the procedure of the service1, you shall get the procedure of the Generic_template.


## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
