### PR TITLE
fix(forms) check key macroInput presence before foreach in form service

### DIFF
--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1152,18 +1152,20 @@ if ($form->validate() && $from_list_menu == false) {
          * Before saving, we check if a password macro has changed its name to be able to give it the right password
          * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
          */
-        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
-            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
-                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
-                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
-                    /*
-                     * The password has not been changed along with the name, so its value is equal to the wildcard.
-                     * We will therefore recover the password stored for its original name.
-                     */
-                    foreach ($aMacros as $indexMacro => $macroDetails) {
-                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
-                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
-                            break;
+        if (array_key_exists('macroInput', $_REQUEST)) {
+            foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+                if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                    $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                    if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                        /*
+                         * The password has not been changed along with the name, so its value is equal to the wildcard.
+                         * We will therefore recover the password stored for its original name.
+                         */
+                        foreach ($aMacros as $indexMacro => $macroDetails) {
+                            if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                                $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description

when updating an existing service with no macro, a warning appeared in PHP logs

`PHP Warning:  Invalid argument supplied for foreach() in /usr/share/centreon/www/include/configuration/configObject/service/formService.php on line 1155`

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Edit a saved service or a duplicated service
Remove/leave custom macros field empty
Save
Check php log, no warning should be found

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
