### PR TITLE
fix(form) remove php warning on host_register when sanitizing host fo…

### DIFF
--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -2570,8 +2570,8 @@ function sanitizeFormHostParameters(array $ret): array
                 break;
             case 'host_register':
                 $bindParams[':' . $inputName] = [
-                    \PDO::PARAM_STR => in_array($inputValue[$inputName], ['0', '1', '2', '3'])
-                        ? $inputValue[$inputName]
+                    \PDO::PARAM_STR => in_array($inputValue, ['0', '1', '2', '3'])
+                        ? $inputValue
                         : null
                 ];
                 break;


### PR DESCRIPTION
## Description

Refs: MON-7179

When adding a new host, a warning appears in PHP  logs :

`==> /var/opt/rh/rh-php73/log/php-fpm/centreon-error.log <==
[21-Apr-2021 14:09:26 Europe/Paris] PHP Warning:  Illegal string offset 'host_register' in /usr/share/centreon/www/include/configuration/configObject/host/DB-Func.php on line 2573
[21-Apr-2021 14:09:26 Europe/Paris] PHP Warning:  Illegal string offset 'host_register' in /usr/share/centreon/www/include/configuration/configObject/host/DB-Func.php on line 2574
`

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to configuration > hosts > hosts > add a new host
Fill : 

name, alias,
address, template,
check period, max/normal/retry intervals
active YES, passive NO

Save the form

Result: no warning should be found in centreon-error.log

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
