### PR TITLE
enh(ci): play AT and IT only for reference, release and qa branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ def checkoutCentreonBuild(buildBranch) {
     $class: 'GitSCM',
     branches: [[name: "refs/heads/${branchName}"]],
     doGenerateSubmoduleConfigurations: false,
-    extensions: [[$class: 'CloneOption', timeout: 20, noTags: false]]
+    extensions: [[$class: 'CloneOption', timeout: 20, noTags: false]],
     userRemoteConfigs: [[
       $class: 'UserRemoteConfig',
       url: "ssh://git@github.com/centreon/centreon-build.git"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -350,88 +350,88 @@ try {
     }
   }
 
-  stage('API integration tests') {
-    if (hasBackendChanges) {
-      def parallelSteps = [:]
-      for (x in apiFeatureFiles) {
-        def feature = x
-        parallelSteps[feature] = {
-          node {
-            checkoutCentreonBuild(buildBranch)
-            unstash 'tar-sources'
-            unstash 'vendor'
-            def acceptanceStatus = sh(
-              script: "./centreon-build/jobs/web/${serie}/mon-web-api-integration-test.sh centos7 tests/api/features/${feature}",
-              returnStatus: true
-            )
-            junit 'xunit-reports/**/*.xml'
-            if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
-              currentBuild.result = 'FAILURE'
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'api-integration-test-logs/*.txt'
-          }
-        }
-      }
-      parallel parallelSteps
-      if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-        error('API integration tests stage failure.');
-      }
-    }
-  }
-
-  stage('E2E tests') {
-    def parallelSteps = [:]
-    for (x in e2eFeatureFiles) {
-      def feature = x
-      parallelSteps[feature] = {
-        node {
-          checkoutCentreonBuild(buildBranch)
-          unstash 'tar-sources'
-          unstash 'cypress-node-modules'
-          timeout(time: 10, unit: 'MINUTES') {
-          def acceptanceStatus = sh(script: "./centreon-build/jobs/web/${serie}/mon-web-e2e-test.sh centos7 tests/e2e/cypress/integration/${feature}", returnStatus: true)
-          junit 'centreon-web*/tests/e2e/cypress/results/reports/junit-report.xml'
-          if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
-            currentBuild.result = 'FAILURE'
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'centreon-web*/tests/e2e/cypress/results/**/*.mp4, centreon-web*/tests/e2e/cypress/results/**/*.png'
-          }
-        }
-      }
-    }
-    parallel parallelSteps
-    if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-      error('E2E tests stage failure.');
-    }
-  }
-
-  stage('Acceptance tests') {
-    if (hasBackendChanges || hasFrontendChanges) {
-      def parallelSteps = [:]
-      for (x in featureFiles) {
-        def feature = x
-        parallelSteps[feature] = {
-          node {
-            checkoutCentreonBuild(buildBranch)
-            unstash 'tar-sources'
-            unstash 'vendor'
-            def acceptanceStatus = sh(
-              script: "./centreon-build/jobs/web/${serie}/mon-web-acceptance.sh centos7 features/${feature} ${acceptanceTag}",
-              returnStatus: true
-            )
-            junit 'xunit-reports/**/*.xml'
-            if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
-              currentBuild.result = 'FAILURE'
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'acceptance-logs/*.txt, acceptance-logs/*.png, acceptance-logs/*.flv'
-          }
-        }
-      }
-      parallel parallelSteps
-      if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-        error('Critical tests stage failure.');
-      }
-    }
-  }
-
   if (isStableBuild()) {
+    stage('API integration tests') {
+      if (hasBackendChanges) {
+        def parallelSteps = [:]
+        for (x in apiFeatureFiles) {
+          def feature = x
+          parallelSteps[feature] = {
+            node {
+              checkoutCentreonBuild(buildBranch)
+              unstash 'tar-sources'
+              unstash 'vendor'
+              def acceptanceStatus = sh(
+                script: "./centreon-build/jobs/web/${serie}/mon-web-api-integration-test.sh centos7 tests/api/features/${feature}",
+                returnStatus: true
+              )
+              junit 'xunit-reports/**/*.xml'
+              if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
+                currentBuild.result = 'FAILURE'
+              archiveArtifacts allowEmptyArchive: true, artifacts: 'api-integration-test-logs/*.txt'
+            }
+          }
+        }
+        parallel parallelSteps
+        if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+          error('API integration tests stage failure.');
+        }
+      }
+    }
+
+    stage('E2E tests') {
+      def parallelSteps = [:]
+      for (x in e2eFeatureFiles) {
+        def feature = x
+        parallelSteps[feature] = {
+          node {
+            checkoutCentreonBuild(buildBranch)
+            unstash 'tar-sources'
+            unstash 'cypress-node-modules'
+            timeout(time: 10, unit: 'MINUTES') {
+            def acceptanceStatus = sh(script: "./centreon-build/jobs/web/${serie}/mon-web-e2e-test.sh centos7 tests/e2e/cypress/integration/${feature}", returnStatus: true)
+            junit 'centreon-web*/tests/e2e/cypress/results/reports/junit-report.xml'
+            if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
+              currentBuild.result = 'FAILURE'
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'centreon-web*/tests/e2e/cypress/results/**/*.mp4, centreon-web*/tests/e2e/cypress/results/**/*.png'
+            }
+          }
+        }
+      }
+      parallel parallelSteps
+      if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+        error('E2E tests stage failure.');
+      }
+    }
+
+    stage('Acceptance tests') {
+      if (hasBackendChanges || hasFrontendChanges) {
+        def parallelSteps = [:]
+        for (x in featureFiles) {
+          def feature = x
+          parallelSteps[feature] = {
+            node {
+              checkoutCentreonBuild(buildBranch)
+              unstash 'tar-sources'
+              unstash 'vendor'
+              def acceptanceStatus = sh(
+                script: "./centreon-build/jobs/web/${serie}/mon-web-acceptance.sh centos7 features/${feature} ${acceptanceTag}",
+                returnStatus: true
+              )
+              junit 'xunit-reports/**/*.xml'
+              if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
+                currentBuild.result = 'FAILURE'
+              archiveArtifacts allowEmptyArchive: true, artifacts: 'acceptance-logs/*.txt, acceptance-logs/*.png, acceptance-logs/*.flv'
+            }
+          }
+        }
+        parallel parallelSteps
+        if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+          error('Critical tests stage failure.');
+        }
+      }
+    }
+
     stage('Delivery') {
       node {
         checkoutCentreonBuild(buildBranch)
@@ -443,7 +443,7 @@ try {
         error('Delivery stage failure.');
       }
     }
-
+  }
     if (env.BUILD == 'REFERENCE') {
       build job: "centreon-autodiscovery/${env.BRANCH_NAME}", wait: false
       build job: "centreon-awie/${env.BRANCH_NAME}", wait: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -443,7 +443,6 @@ try {
         error('Delivery stage failure.');
       }
     }
-  }
     if (env.BUILD == 'REFERENCE') {
       build job: "centreon-autodiscovery/${env.BRANCH_NAME}", wait: false
       build job: "centreon-awie/${env.BRANCH_NAME}", wait: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,6 +107,7 @@ def checkoutCentreonBuild(buildBranch) {
     $class: 'GitSCM',
     branches: [[name: "refs/heads/${branchName}"]],
     doGenerateSubmoduleConfigurations: false,
+    extensions: [[$class: 'CloneOption', timeout: 20, noTags: false]]
     userRemoteConfigs: [[
       $class: 'UserRemoteConfig',
       url: "ssh://git@github.com/centreon/centreon-build.git"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,6 @@ def checkoutCentreonBuild(buildBranch) {
     $class: 'GitSCM',
     branches: [[name: "refs/heads/${branchName}"]],
     doGenerateSubmoduleConfigurations: false,
-    extensions: [[$class: 'CloneOption', timeout: 20, noTags: false]],
     userRemoteConfigs: [[
       $class: 'UserRemoteConfig',
       url: "ssh://git@github.com/centreon/centreon-build.git"

--- a/behat.yml
+++ b/behat.yml
@@ -133,9 +133,10 @@ default:
       paths: [ "%paths.base%/features/BrokerConfiguration.feature" ]
       contexts: [ BrokerConfigurationContext ]
 
-    ldap:
-      paths: [ "%paths.base%/features/Ldap.feature" ]
-      contexts: [ LdapContext ]
+    ##FIXME
+    #ldap:
+    #  paths: [ "%paths.base%/features/Ldap.feature" ]
+    #  contexts: [ LdapContext ]
 
     custom_views_locked:
       paths: [ "%paths.base%/features/CustomViews/Locked.feature" ]

--- a/behat.yml
+++ b/behat.yml
@@ -214,9 +214,9 @@ default:
       paths: [ "%paths.base%/features/TrapsSNMPConfiguration.feature" ]
       contexts: [ TrapsSNMPConfigurationContext ]
 
-    ldap_manual_import:
-      paths: [ "%paths.base%/features/LdapManualImport.feature" ]
-      contexts: [ LdapManualImportContext ]
+    #ldap_manual_import:
+    #  paths: [ "%paths.base%/features/LdapManualImport.feature" ]
+    #  contexts: [ LdapManualImportContext ]
 
     modify_default_page_connexion:
       paths: [ "%paths.base%/features/ModifyDefaultPageConnection.feature" ]


### PR DESCRIPTION
## Description

In order to have a shorter feedback loop, the AT and IT tests are moved to only reference release and qa branches (develop and dev-xx).

Also, the ldap feature is commented for now in order to determine the root cause of TA failure for that feature.
## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>


## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
