### PR TITLE
enh(ci): reintroduce api and e2e tests in PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -351,60 +351,60 @@ try {
     }
   }
 
-  if (isStableBuild()) {
-    stage('API integration tests') {
-      if (hasBackendChanges) {
-        def parallelSteps = [:]
-        for (x in apiFeatureFiles) {
-          def feature = x
-          parallelSteps[feature] = {
-            node {
-              checkoutCentreonBuild(buildBranch)
-              unstash 'tar-sources'
-              unstash 'vendor'
-              def acceptanceStatus = sh(
-                script: "./centreon-build/jobs/web/${serie}/mon-web-api-integration-test.sh centos7 tests/api/features/${feature}",
-                returnStatus: true
-              )
-              junit 'xunit-reports/**/*.xml'
-              if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
-                currentBuild.result = 'FAILURE'
-              archiveArtifacts allowEmptyArchive: true, artifacts: 'api-integration-test-logs/*.txt'
-            }
-          }
-        }
-        parallel parallelSteps
-        if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-          error('API integration tests stage failure.');
-        }
-      }
-    }
-
-    stage('E2E tests') {
+  stage('API integration tests') {
+    if (hasBackendChanges) {
       def parallelSteps = [:]
-      for (x in e2eFeatureFiles) {
+      for (x in apiFeatureFiles) {
         def feature = x
         parallelSteps[feature] = {
           node {
             checkoutCentreonBuild(buildBranch)
             unstash 'tar-sources'
-            unstash 'cypress-node-modules'
-            timeout(time: 10, unit: 'MINUTES') {
-            def acceptanceStatus = sh(script: "./centreon-build/jobs/web/${serie}/mon-web-e2e-test.sh centos7 tests/e2e/cypress/integration/${feature}", returnStatus: true)
-            junit 'centreon-web*/tests/e2e/cypress/results/reports/junit-report.xml'
+            unstash 'vendor'
+            def acceptanceStatus = sh(
+              script: "./centreon-build/jobs/web/${serie}/mon-web-api-integration-test.sh centos7 tests/api/features/${feature}",
+              returnStatus: true
+            )
+            junit 'xunit-reports/**/*.xml'
             if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
               currentBuild.result = 'FAILURE'
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'centreon-web*/tests/e2e/cypress/results/**/*.mp4, centreon-web*/tests/e2e/cypress/results/**/*.png'
-            }
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'api-integration-test-logs/*.txt'
           }
         }
       }
       parallel parallelSteps
       if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-        error('E2E tests stage failure.');
+        error('API integration tests stage failure.');
       }
     }
+  }
 
+  stage('E2E tests') {
+    def parallelSteps = [:]
+    for (x in e2eFeatureFiles) {
+      def feature = x
+      parallelSteps[feature] = {
+        node {
+          checkoutCentreonBuild(buildBranch)
+          unstash 'tar-sources'
+          unstash 'cypress-node-modules'
+          timeout(time: 10, unit: 'MINUTES') {
+          def acceptanceStatus = sh(script: "./centreon-build/jobs/web/${serie}/mon-web-e2e-test.sh centos7 tests/e2e/cypress/integration/${feature}", returnStatus: true)
+          junit 'centreon-web*/tests/e2e/cypress/results/reports/junit-report.xml'
+          if ((currentBuild.result == 'UNSTABLE') || (acceptanceStatus != 0))
+            currentBuild.result = 'FAILURE'
+          archiveArtifacts allowEmptyArchive: true, artifacts: 'centreon-web*/tests/e2e/cypress/results/**/*.mp4, centreon-web*/tests/e2e/cypress/results/**/*.png'
+          }
+        }
+      }
+    }
+    parallel parallelSteps
+    if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+      error('E2E tests stage failure.');
+    }
+  }
+  
+  if (isStableBuild()) {
     stage('Acceptance tests') {
       if (hasBackendChanges || hasFrontendChanges) {
         def parallelSteps = [:]


### PR DESCRIPTION
## Description

Because they are reliable and not too long, we reintroduce here the e2e and api integration tests for PR


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Stages E2E tests and API Tests should appear on PR jenkins job

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
