### PR TITLE
fix(configuration): set correct right for centreon.conf.php

### DIFF
--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -99,6 +99,7 @@ $contents = preg_replace($patterns, $replacements, $contents);
 file_put_contents($centreonConfFile, $contents);
 chmod($centreonConfFile, 0660);
 chown($centreonConfFile, 'apache');
+chgrp($centreonConfFile, 'apache');
 
 /**
  * conf.pm

--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -98,6 +98,7 @@ $contents = file_get_contents('../../var/configFileTemplate');
 $contents = preg_replace($patterns, $replacements, $contents);
 file_put_contents($centreonConfFile, $contents);
 chmod($centreonConfFile, 0660);
+chown($centreonConfFile, 'apache');
 
 /**
  * conf.pm

--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -97,6 +97,7 @@ $centreonConfFile = $centreonEtcPath . '/centreon.conf.php';
 $contents = file_get_contents('../../var/configFileTemplate');
 $contents = preg_replace($patterns, $replacements, $contents);
 file_put_contents($centreonConfFile, $contents);
+chmod($centreonConfFile, 0660);
 
 /**
  * conf.pm


### PR DESCRIPTION
## Description

This PR intends to fix invalid right on centreon.conf.php

**Fixes** # MON-10878

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
