### PR TITLE
fix(security): Delete session for non-existing contact 21.04 

### DIFF
--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -1895,7 +1895,8 @@ CREATE TABLE `session` (
   `update_acl` enum('0','1') DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `session_id` (`session_id`(255)),
-  KEY `user_id` (`user_id`)
+  KEY `user_id` (`user_id`),
+  CONSTRAINT `session_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/www/install/php/Update-21.04.5.php
+++ b/www/install/php/Update-21.04.5.php
@@ -38,6 +38,25 @@ try {
             "ALTER TABLE `contact` ADD COLUMN `contact_platform_data_sending` ENUM('0', '1', '2')"
         );
     }
+
+    //Purge all session.
+    $errorMessage = 'Impossible to purge the table session';
+    $pearDB->query("DELETE * FROM `session`");
+
+    $errorMessage = 'Impossible to purge the table ws_token';
+    $pearDB->query("DELETE * FROM `ws_token`");
+
+    $constraintStatement = $pearDB->query(
+        "SELECT COUNT(*) as count FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME='session_ibfk_1'"
+    );
+    if (($constraint = $constraintStatement->fetch()) && $constraint['count'] === 0) {
+        $errorMessage = 'Impossible to add Delete Cascade constraint on the table session';
+        $pearDB->query(
+            "ALTER TABLE `session` ADD CONSTRAINT `session_ibfk_1` FOREIGN KEY (`user_id`) " .
+            "REFERENCES `contact` (`contact_id`) ON DELETE CASCADE"
+        );
+    }
+
     $pearDB->commit();
 } catch (\Exception $e) {
     $pearDB->rollBack();


### PR DESCRIPTION
## Description

This PR intends to fix an issue where a non existing user could still navigate in Centreon and perform action because his session wasn't deleted.

Fixes # MON-10994

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
