### PR TITLE
enh(conf/poller) change pollers actions from select to buttons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "behat/mink": "dev-master#a534fe7dac9525e8e10ca68e737c3d7e5058ec83",
         "behat/mink-extension": "^2.3",
         "behat/mink-selenium2-driver": "^1.4",
-        "centreon/centreon-test-lib": "dev-master",
+        "centreon/centreon-test-lib": "dev-MON-6671-redesign-poller-actions",
         "phpstan/phpstan": "^0.12.59",
         "phpstan/phpstan-beberlei-assert": "^0.12",
         "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "behat/mink": "dev-master#a534fe7dac9525e8e10ca68e737c3d7e5058ec83",
         "behat/mink-extension": "^2.3",
         "behat/mink-selenium2-driver": "^1.4",
-        "centreon/centreon-test-lib": "dev-MON-6671-redesign-poller-actions",
+        "centreon/centreon-test-lib": "dev-master",
         "phpstan/phpstan": "^0.12.59",
         "phpstan/phpstan-beberlei-assert": "^0.12",
         "phpunit/phpunit": "^8.5",

--- a/features/bootstrap/GeneratePollerContext.php
+++ b/features/bootstrap/GeneratePollerContext.php
@@ -18,7 +18,7 @@ class GeneratePollerContext extends CentreonContext
         $this->pollers_page = new PollerConfigurationListingPage($this);
         $this->setConfirmBox(true);
         $this->pollers_page->selectEntry('Central');
-        $this->pollers_page->moreActions(PollerConfigurationListingPage::ACTION_DUPLICATE);
+        $this->pollers_page->duplicateAction();
         $this->pollers_page->enableEntry('Central_1');
     }
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -863,6 +863,10 @@ msgstr "Sélectionné"
 msgid "Add"
 msgstr "Ajouter"
 
+#: centreon-web/www/include/configuration/configServers/listServers.php:318
+msgid "Add (advanced)"
+msgstr "Ajouter (avancé)"
+
 #: centreon-web/www/class/centreonConfigCentreonBroker.php:390
 #: centreon-web/www/include/options/accessLists/resourcesACL/formResourcesAccess.php:260
 #: centreon-web/www/include/options/accessLists/resourcesACL/formResourcesAccess.php:276
@@ -1924,6 +1928,10 @@ msgstr "Mise à jour"
 #: centreon-web/www/install/smarty_translate.php:351
 msgid "Do you confirm the deletion?"
 msgstr "Confirmez-vous la suppression ?"
+
+#: centreon-web/www/include/configuration/configServers/listServers.php:351
+msgid "You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?"
+msgstr "Vous êtes sur le point de supprimer un ou plusieurs collecteurs.\\nCette action est IRREVERSIBLE.\\nConfirmez-vous la suppression ?"
 
 #: centreon-web/www/install/smarty_translate.php:354
 #: centreon-web/www/install/smarty_translate.php:357

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -2846,3 +2846,19 @@ ul.module_list {
     margin: 0;
     line-height: 14px;
 }
+
+/* configuration pollers action buttons */
+.ui-icon-white {
+  background-image: url("./jquery-ui/images/ui-icons_ffffff_256x240.png") !important;
+}
+
+.bt-poller-action{
+    line-height: 20px;
+    font-size: 13.3333px;
+    margin: 0px 4px;
+}
+
+.bt-poller-action:disabled {
+    background: #cdcdcd !important;
+    cursor: not-allowed;
+}

--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -1,14 +1,33 @@
 {literal}
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 <script type='text/javascript'>
-
     function applyConfiguration() {
         var pollers = [];
-        jQuery('form tr').not('.row_disabled').find('input[id^="poller_"]:checked').each(function(){
+        jQuery('form tr').not('.row_disabled').find('input[id^="poller_"]:checked').each(function() {
             pollers.push(this.id.substr(7));
         });
         window.location.href = "?p=60902&poller=" + pollers.join(',');
     }
+
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+
+    function hasPollersSelected(){
+        var nbSelectedPollers = jQuery('form tr').find('input[id^="poller_"]:checked').length;
+        var buttons = jQuery('form').find('button[name="delete_action"],button[name="duplicate_action"]');
+
+        if (nbSelectedPollers > 0) {
+            buttons.each(function() {
+                $(this).prop("disabled",false);
+            });
+        } else {
+            buttons.each(function() {
+                $(this).prop("disabled",true);
+            });
+        }
+    }
+    hasPollersSelected();
 
 </script>
 {/literal}
@@ -30,16 +49,24 @@
     <table class="ToolbarTable table">
         <tr class="ToolbarTR">
             <td>
-                {if $mode_access == 'w'}
-                {$msg.options} {$form.o1.html}
-                &nbsp;&nbsp;&nbsp;
-                <a href="{$msg.addL}" class="btc bt_success">{$msg.addT}</a>
-                <a href="./poller-wizard/1" target="_top" class="btc bt_info">{t}Add server with wizard{/t}</a>
-                {else}
-                &nbsp;
-                {/if}
                 {if $is_admin == 1 || $can_generate == 1}
-                    {$form.apply_configuration.html}
+                    <button type="button" class="{$exportBtn.class}" name="{$exportBtn.name}" onClick="{$exportBtn.onClickAction}">
+                        <span class="ui-icon ui-icon-white {$exportBtn.iconClass}"></span> {$exportBtn.text}
+                    </button>
+                {/if}
+                {if $mode_access == 'w'}
+                    <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" target="_top">
+                        <span class="ui-icon ui-icon-white {$wizardAddBtn.iconClass}"></span> {$wizardAddBtn.text}
+                    </a>
+                    <a href="{$addBtn.link}" class="{$addBtn.class}">
+                        <span class="ui-icon ui-icon-white {$addBtn.iconClass}"></span> {$addBtn.text}
+                    </a>
+                    <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
+                        <span class="ui-icon ui-icon-white {$duplicateBtn.iconClass}"></span> {$duplicateBtn.text}
+                    </button>
+                    <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
+                        <span class="ui-icon ui-icon-white {$deleteBtn.iconClass}"></span> {$deleteBtn.text}
+                    </button>
                 {/if}
             </td>
             <input name="p" value="{$p}" type="hidden">
@@ -115,15 +142,6 @@
     </table>
     <table class="ToolbarTable table">
         <tr class="ToolbarTR">
-            { if $mode_access == 'w' }
-            <td>
-                {$msg.options} {$form.o2.html}
-                &nbsp;&nbsp;&nbsp;
-                <a href="{$msg.addL}" class="btc bt_success">{$msg.addT}</a>
-            </td>
-            { else }
-            <td>&nbsp;</td>
-            { /if }
             <input name="p" value="{$p}" type="hidden">
             {php}
                include('./include/common/pagination.php');
@@ -134,7 +152,7 @@
         </tr>
     </table>
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>  
+<input type='hidden' id='limit' name='limit' value='{$limit}'>
 {$form.hidden}
 </form>
 {literal}
@@ -159,5 +177,9 @@
     setDisabledRowStyle();
     //formatting the tags containing a class isTimestamp
     formatDateMoment();
+
+    jQuery(document).ready(function () {
+        hasPollersSelected();
+    });
 </script>
 {/literal}

--- a/www/include/configuration/configServers/listServers.php
+++ b/www/include/configuration/configServers/listServers.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2019 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -179,7 +180,7 @@ foreach ($servers as $config) {
         "select[" . $config['id'] . "]",
         null,
         '',
-        array('id' => 'poller_' . $config['id'])
+        array('id' => 'poller_' . $config['id'], 'onClick' => 'hasPollersSelected();')
     );
     if ($config["ns_activate"]) {
         $moptions .= "<a href='main.php?p=" . $p . "&server_id=" . $config['id'] . "&o=u&limit=" . $limit .
@@ -240,11 +241,12 @@ foreach ($servers as $config) {
         ? _('Remote Server')
         : $serverType;
 
-    if (isset($nagiosInfo[$config['id']]['is_currently_running'])
+    if (
+        isset($nagiosInfo[$config['id']]['is_currently_running'])
         && $nagiosInfo[$config['id']]['is_currently_running'] == 1
     ) {
-        $now = new DateTime;
-        $startDate = (new DateTime)->setTimestamp($nagiosInfo[$config['id']]['program_start_time']);
+        $now = new DateTime();
+        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$config['id']]['program_start_time']);
         $interval = date_diff($now, $startDate);
         if (intval($interval->format('%a')) >= 2) {
             $uptime = $interval->format('%a days');
@@ -303,59 +305,66 @@ $tpl->assign(
 
 // Different messages we put in the template
 $tpl->assign(
-    'msg',
+    'wizardAddBtn',
     array(
-        "addL" => "main.php?p=" . $p . "&o=a",
-        "addT" => _("Add"),
-        "delConfirm" => _("Do you confirm the deletion ?")
+        "link" => "./poller-wizard/1",
+        "text" => _("Add"),
+        "class" => "btc bt-poller-action bt_success",
+        "iconClass" => "ui-icon-plus"
     )
 );
 
-// Toolbar select
-?>
-<script type="text/javascript">
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-</script>
-<?php
+$tpl->assign(
+    'addBtn',
+    array(
+        "link" => "main.php?p=" . $p . "&o=a",
+        "text" => _("Add (advanced)"),
+        "class" => "btc bt-poller-action bt_success",
+        "iconClass" => "ui-icon-plus"
+    )
+);
 
-foreach (array('o1', 'o2') as $option) {
-    $attrs = array(
-        'onchange' => "javascript: " .
+
+$tpl->assign(
+    'duplicateBtn',
+    array(
+        "text" => _("Duplicate"),
+        "class" => "btc bt-poller-action bt_success",
+        "name" => "duplicate_action",
+        "iconClass" => "ui-icon-copy",
+        "onClickAction" => "javascript: " .
             " var bChecked = isChecked(); " .
-            " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {" .
-            " alert('" . _("Please select one or more items") . "'); return false;} " .
-            " if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('" .
-            _("Do you confirm the duplication ?") . "')) {" .
-            " 	setO(this.form.elements['" . $option . "'].value); submit();} " .
-            "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('" .
-            _("Do you confirm the deletion ?") . "')) {" .
-            " 	setO(this.form.elements['" . $option . "'].value); submit();} " .
-            ""
-    );
-    $form->addElement(
-        'select',
-        $option,
-        null,
-        array(
-            null => _("More actions..."),
-            "m" => _("Duplicate"),
-            "d" => _("Delete")
-        ),
-        $attrs
-    );
-    $form->setDefaults(array($option => null));
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
-}
+            " if (!bChecked) { alert('" . _("Please select one or more items") . "'); return false;} " .
+            " if (confirm('" . _("Do you confirm the duplication ?") . "')) { setO('m'); submit();} "
+    )
+);
 
-// Apply configuration button
-$form->addElement(
-    'button',
-    'apply_configuration',
-    _("Export configuration"),
-    array('onClick' => 'applyConfiguration();', 'class' => 'btc bt_info')
+$tpl->assign(
+    'deleteBtn',
+    array(
+        "text" => _("Delete"),
+        "class" => "btc bt-poller-action bt_danger",
+        "name" => "delete_action",
+        "iconClass" => "ui-icon-trash",
+        "onClickAction" => "javascript: " .
+            " var bChecked = isChecked(); " .
+            " if (!bChecked) { alert('" . _("Please select one or more items") . "'); return false;} " .
+            " if (confirm('" .
+            _("You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\n" .
+            "Do you confirm the deletion ?") .
+            "')) { setO('d'); submit();} "
+    )
+);
+
+$tpl->assign(
+    'exportBtn',
+    array(
+        "text" => _("Export configuration"),
+        "class" => "btc bt-poller-action bt_info",
+        "name" => "apply_configuration",
+        "iconClass" => "ui-icon-extlink",
+        "onClickAction" => "applyConfiguration();"
+    )
 );
 
 $tpl->assign('limit', $limit);


### PR DESCRIPTION
## Description

Replace the drop-down menu with buttons, and use an explicit icon for the “delete” action (and for the other actions as well).
Add icons on buttons.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Drop-down menu should be replace by buttons.
- Duplicate and delete buttons should not be clickable if no pollers are selected.
- Add buttons -> add poller with wizard
- Add (advanced) -> add poller without wizard
- Icons on all buttons (export conf, duplicate, add, add advanced, delete)
- No more buttons at the bottom of the poller list.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
