### PR TITLE
enh(build): Add centreon-map on Dev server

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -39,6 +39,7 @@ const modules = [
   'centreon-autodiscovery-server',
   'centreon-bam-server',
   'centreon-augmented-services',
+  'centreon-map4-web-client',
 ];
 
 module.exports = merge(baseConfig, devConfig, {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -50,8 +50,8 @@ module.exports = merge(baseConfig, devConfig, {
     hot: true,
     port: devServerPort,
 
-    static: modules.map((module) => ({
-      directory: path.resolve(`${__dirname}/www/modules/${module}/static`),
+    static: modules.map((module, outputPath = 'static') => ({
+      directory: path.resolve(`${__dirname}/www/modules/${module}/${outputPath}`),
       publicPath,
       watch: true,
     })),


### PR DESCRIPTION
To obtain the development watcher on the Centreon MAP module, it is necessary to add it to the WebPack configuration of Centreon with the other modules already declared

MON-10997

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
