### PR TITLE
fix(UI): When closing popup apply current filter

### DIFF
--- a/www/front_src/src/Resources/Filter/Criterias/index.tsx
+++ b/www/front_src/src/Resources/Filter/Criterias/index.tsx
@@ -46,6 +46,7 @@ const CriteriasContent = ({
       icon={<TuneIcon fontSize="small" />}
       popperPlacement="bottom-start"
       title={t(labelSearchOptions)}
+      onClose={applyCurrentFilter}
     >
       {(): JSX.Element => (
         <Grid


### PR DESCRIPTION
## Description

When closing popup current filter wasn't apply if you click outside the icon menu

**Fixes** # (issue)

When closing popup apply current filter by clicking anywhere than the icon menu, or when PopoverMenu was closed by any actions.

https://www.loom.com/share/d984613c61ce471cb69e8ebe19c9ede1

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie


- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go on the ressource status and click on menu to set filter, click outside or anywhere on web page =>

Filter is apply and listing is refresh with the news criterias
