### PR TITLE
enh(comment): not empty

### DIFF
--- a/src/Centreon/Domain/Monitoring/Comment/Comment.php
+++ b/src/Centreon/Domain/Monitoring/Comment/Comment.php
@@ -106,6 +106,7 @@ class Comment
      */
     public function setComment(string $comment): Comment
     {
+        $comment = trim($comment);
         if (empty($comment)) {
             throw new \InvalidArgumentException(
                 "Comment can not be empty"


### PR DESCRIPTION
## Description

Trim the comment and then check if it is empty. A comment could be " " (a space) and not be considered empty. No one wants an empty comment.

## Type of change

- [x] New functionality (non-breaking change)

## Target serie

- [x] 21.04.x
- [x] 21.10.x (master)

## How this pull request can be tested ? 

Note the space in the comment line:

POST | {{baseUrl}}/monitoring/resources/comments

```json
{
    "resources": [
        {
            "comment": " ",
            "id": 116,
            "type": "service",
            "parent": {
                "id": 19
            },
            "date": "2021-09-17T12:00:49.310Z"
        }
    ]
}
```
should get a 500

```json
{
    "code": 500,
    "message": "Comment can not be empty"
}
```
## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (develop).
