### PR TITLE
fix(pollers) fix check-all enable/disable buttons, buttons alignment

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -2855,7 +2855,7 @@ ul.module_list {
 .bt-poller-action{
     line-height: 20px;
     font-size: 13.3333px;
-    margin: 0px 4px;
+    margin: 4px 6px 0px 0px !important;
 }
 
 .bt-poller-action:disabled {

--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -79,7 +79,8 @@
         <tr class="ListHeader">
             <td class="ListColHeaderPicker">
                 <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
+                    <input type="checkbox" id="checkall" name="checkall"
+                        onclick="checkUncheckAll(this); hasPollersSelected();"/>
                     <label class="empty-label" for="checkall"></label>
                 </div>
             </td>


### PR DESCRIPTION
## Description

Quick fixes for the new poller management interface ( selectAll does'nt enable/disable duplicate and delete actions, + buttons alignement)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Buttons are left align to the list table.
Click on selectAll enable and disable duplicate and delete buttons accordingly : 
- if no pollers selected buttons should be blocked
- if one or more pollers selected buttons should be clickable

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
