### PR TITLE
fix(myAccount): SQL error fixed on update contact

### DIFF
--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -145,7 +145,7 @@ function updateContact($contact_id = null)
           'default_page = :defaultPage, ' .
           'contact_js_effects = :contactJsEffects, ' .
           'show_deprecated_pages = :showDeprecatedPages, ' .
-          'contact_autologin_key = :contactAutologinKey ' .
+          'contact_autologin_key = :contactAutologinKey, ' .
           'enable_one_click_export = :enableOneClickExport';
 
     $password_encrypted = null;

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -145,7 +145,7 @@ function updateContact($contact_id = null)
           'default_page = :defaultPage, ' .
           'contact_js_effects = :contactJsEffects, ' .
           'show_deprecated_pages = :showDeprecatedPages, ' .
-          'contact_autologin_key = :contactAutologinKey';
+          'contact_autologin_key = :contactAutologinKey ' .
           'enable_one_click_export = :enableOneClickExport';
 
     $password_encrypted = null;


### PR DESCRIPTION
## Description

This PR intends to fix a SQL error that occured when saving the MyAccount form

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

SAve the My Account form

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
