### PR TITLE
bugfix: command_command_id_arg can't be cleared

### DIFF
--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -2501,6 +2501,12 @@ function sanitizeFormHostParameters(array $ret): array
                 break;
             case 'command_command_id_arg1':
             case 'command_command_id_arg2':
+                    $bindParams[':' . $inputName] = [
+                        \PDO::PARAM_STR => (($inputValue = filter_var($inputValue, FILTER_SANITIZE_STRING)) === '')
+                            ? null
+                            : $inputValue
+                    ];
+                break;
             case 'host_name':
             case 'host_alias':
             case 'host_address':


### PR DESCRIPTION
## Description

Unable to remove check command arguments from Host configuration. When I'm editing a host and accidentally I write something in the command argument field or the browser do this (by Password-manager) and I save the host, I can no longer delete it from the GUI. After that I can no longer export to the poller because the configuration is invalid. You have to go to the DB to reset the field.

I changed the DB-Func.php of the host configuration object and inserted a separate case statement for the two command_command_id_arg fields

**Fixes** https://github.com/centreon/centreon/issues/9993

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

see the description. 
