### PR TITLE
fix(conf) check if contact's notifications are enabled when exporting…

### DIFF
--- a/www/class/config-generate/contact.class.php
+++ b/www/class/config-generate/contact.class.php
@@ -216,11 +216,11 @@ class Contact extends AbstractObject
      */
     protected function shouldContactBeNotified(int $contactId): bool
     {
-        if ($this->contacts[$contactId]['enable_notifications'] == self::ENABLE_NOTIFICATIONS) {
+        if ($this->contacts[$contactId]['enable_notifications'] === self::ENABLE_NOTIFICATIONS) {
             return true;
         } elseif (
             $this->contacts[$contactId]['contact_template_id'] !== null
-            && $this->contacts[$contactId]['enable_notifications'] == self::DEFAULT_NOTIFICATIONS
+            && $this->contacts[$contactId]['enable_notifications'] === self::DEFAULT_NOTIFICATIONS
         ) {
             return $this->shouldContactBeNotified($this->contacts[$contactId]['contact_template_id']);
         }

--- a/www/class/config-generate/contact.class.php
+++ b/www/class/config-generate/contact.class.php
@@ -96,6 +96,9 @@ class Contact extends AbstractObject
     protected $stmt_commands = array('host' => null, 'service' => null);
     protected $stmt_contact_service = null;
 
+    public const ENABLE_NOTIFICATIONS = '1';
+    public const DEFAULT_NOTIFICATIONS = '2';
+
     private function getContactCache()
     {
         $stmt = $this->backend_instance->db->prepare("SELECT
@@ -213,11 +216,11 @@ class Contact extends AbstractObject
      */
     protected function shouldContactBeNotified(int $contactId): bool
     {
-        if ($this->contacts[$contactId]['enable_notifications'] == '1') {
+        if ($this->contacts[$contactId]['enable_notifications'] == self::ENABLE_NOTIFICATIONS) {
             return true;
         } elseif (
             $this->contacts[$contactId]['contact_template_id'] !== null
-            && $this->contacts[$contactId]['enable_notifications'] == '2'
+            && $this->contacts[$contactId]['enable_notifications'] == self::DEFAULT_NOTIFICATIONS
         ) {
             return $this->shouldContactBeNotified($this->contacts[$contactId]['contact_template_id']);
         }

--- a/www/class/config-generate/contact.class.php
+++ b/www/class/config-generate/contact.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2019 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -109,7 +110,7 @@ class Contact extends AbstractObject
     /**
      * @see Contact::$contacts_service_linked_cache
      */
-    private function getContactForServiceCache() : void
+    private function getContactForServiceCache(): void
     {
         $stmt = $this->backend_instance->db->prepare("
             SELECT csr.contact_id, service_service_id
@@ -210,13 +211,14 @@ class Contact extends AbstractObject
      * @param integer $contactId
      * @return boolean
      */
-    protected function shouldContactBeNotified(int $contactId) : bool
+    protected function shouldContactBeNotified(int $contactId): bool
     {
         if ($this->contacts[$contactId]['enable_notifications'] == '1') {
             return true;
         } elseif (
             $this->contacts[$contactId]['contact_template_id'] !== null
-            && $this->contacts[$contactId]['enable_notifications'] == '2') {
+            && $this->contacts[$contactId]['enable_notifications'] == '2'
+        ) {
             return $this->shouldContactBeNotified($this->contacts[$contactId]['contact_template_id']);
         }
 
@@ -226,7 +228,7 @@ class Contact extends AbstractObject
      * @see Contact::getContactCache()
      * @see Contact::getContactForServiceCache()
      */
-    protected function buildCache() : void
+    protected function buildCache(): void
     {
         if ($this->done_cache == 1) {
             return;
@@ -271,7 +273,7 @@ class Contact extends AbstractObject
         $this->contacts[$contact_id]['use'] = [
             $this->generateFromContactId($this->contacts[$contact_id]['contact_template_id'])
         ];
-        if (!$this->shouldContactBeNotified($contact_id)){
+        if (!$this->shouldContactBeNotified($contact_id)) {
             return null;
         }
         $this->getContactNotificationCommands($contact_id, 'host');


### PR DESCRIPTION
## Description
When you create a contact that should not receive mail, but is in a contact group where other users should receive notifications, the generation process blocks with an error.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a contact with “Enable Notifications” set to “No” and without notification commands,
2. Add this user as a “Notification receivers” for a service or a host,
3. (Or create a contact group, add this user to this contact group, and add this group as a “Notification receivers” for a service or a host
4. Generate the configuration of the Poller from which the service or host is monitoring.
5. Configuration files should generate without error

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
