### PR TITLE
fix(conf/host) fix enable/disable action anchor

### DIFF
--- a/www/include/configuration/configObject/host/listHost.php
+++ b/www/include/configuration/configObject/host/listHost.php
@@ -315,9 +315,9 @@ $search = str_replace('\_', "_", $search);
 
 
 $form->createSecurityToken();
-$token = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = is_array($form->getElementValue('centreon_token'))
+    ? end($form->getElementValue('centreon_token'))
+    : $form->getElementValue('centreon_token');
 
 for ($i = 0; $host = $dbResult->fetch(); $i++) {
     if (
@@ -332,15 +332,15 @@ for ($i = 0; $host = $dbResult->fetch(); $i++) {
 
         if ($host["host_activate"]) {
             $moptions = "<a href='main.php?p=$p&host_id={$host['host_id']}"
-                . "&o=u&limit=$limit&num=$num&searchH=$search'>"
+                . "&o=u&limit=$limit&num=$num&searchH=$search"
                 . "&centreon_token=" . $centreonToken
-                . "<img src='img/icons/disabled.png' class='ico-14 margin_right' "
+                . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
                 . "border='0' alt='" . _("Disabled") . "'></a>";
         } else {
             $moptions = "<a href='main.php?p=$p&host_id={$host['host_id']}"
-                . "&o=s&limit=$limit&num=$num&searchH=$search'>"
+                . "&o=s&limit=$limit&num=$num&searchH=$search"
                 . "&centreon_token=" . $centreonToken
-                . "<img src='img/icons/enabled.png' class='ico-14 margin_right' "
+                . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
                 . "border='0' alt='" . _("Enabled") . "'></a>";
         }
 


### PR DESCRIPTION
## Description

Fix broken anchors for enable/disable actions in host listing (following MON-10989)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

in configuration/host:  enable/disable icons should display properly and redirect when clicked

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
