### PR TITLE
Mon 10852 add tls common name on broker config

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7240,3 +7240,6 @@ msgstr ""
 "Si l'option est activée l'utilisation des pages dépréciées sera totalement rétablie"
 "Cela inclu: l'affichage des pages mais également toutes les redirections entre pages dépréciées"
 "Si l'option n'est pas activée l'utilisation de la nouvelle page de Monitoring Resource Status sera pleinement activée"
+
+msgid "Expected TLS certificate common name (CN) - leave blank if unsure."
+msgstr "Champ common name (CN) attendu dans le certificat TLS - laisser vide en cas de doute"

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -601,7 +601,8 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (68, 'storage_db_port', 'Storage DB port', 'Port on which the DB server listens', 'int', NULL),
 (69, 'storage_db_type', 'Storage DB type', 'Target DBMS.', 'select', NULL),
 (74, 'path', 'Path', 'Path of the lua script.', 'text', NULL),
-(75, 'connections_count', 'Number of connection to the database', 'Usually cpus/2', 'int', NULL);
+(75, 'connections_count', 'Number of connection to the database', 'Usually cpus/2', 'int', NULL),
+(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
 
 INSERT INTO `cb_fieldgroup` (`cb_fieldgroup_id`, `groupname`, `displayname`, `multiple`, `group_parent_id`) VALUES
 (1, 'filters', '', 0, NULL),
@@ -869,7 +870,8 @@ INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`
 (33, 74, 1, 1),
 (33, 47, 0, 2),
 (33, 72, 0, 3),
-(33, 71, 0, 4);
+(33, 71, 0, 4),
+(3, 76, 0, 5);
 
 --
 -- Contenu de la table `cb_type_field_relation`

--- a/www/install/sql/centreon/Update-DB-21.10.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-21.10.0-beta.1.sql
@@ -52,3 +52,10 @@ ALTER TABLE `session` MODIFY `last_reload` BIGINT UNSIGNED;
 
 -- Add one-click export button column to contact
 ALTER TABLE `contact` ADD COLUMN `enable_one_click_export` enum('0','1') DEFAULT '0';
+
+-- Add TLS hostname in config brocker input/outputs IPV4
+INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`, `fieldtype`, `external`) VALUES
+(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
+
+INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`) VALUES
+(3, 76, 0, 5);


### PR DESCRIPTION
## Description

As a centreon administrator

I want to encrypt my broker flows, having a Host to connect to field different from the certificate’s common name (eg. the server’s IP address)

I need to be able to specify the right “Common Name” (CN) in the broker config form for IPV4 inputs and outputs.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add a TLS Host Name to IPv4 to a brocker config inputs and/or outputs

Export conf, its value should appear in the broker config file

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
