### PR TITLE
Mon 7391 fix forbidden actions on remote server

### DIFF
--- a/www/include/configuration/configCentreonBroker/centreon-broker.php
+++ b/www/include/configuration/configCentreonBroker/centreon-broker.php
@@ -38,6 +38,7 @@ if (!isset($centreon)) {
     exit();
 }
 
+
 isset($_GET["id"]) ? $cG = $_GET["id"] : $cG = null;
 isset($_POST["id"]) ? $cP = $_POST["id"] : $cP = null;
 $cG ? $id = $cG : $id = $cP;
@@ -62,6 +63,21 @@ $path = "./include/configuration/configCentreonBroker/";
  */
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
+
+/**
+ *  Page forbidden if server is a remote
+ */
+$isRemote = false;
+
+$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
+if ($row = $result->fetch()) {
+    $isRemote = $row['value'] === 'yes';
+}
+
+if ($isRemote) {
+    require_once($path . "../../core/errors/alt_error.php");
+    exit();
+}
 
 /* Set the real page */
 if (isset($ret) && is_array($ret) && $ret['topology_page'] != "" && $p != $ret['topology_page']) {

--- a/www/include/configuration/configCentreonBroker/centreon-broker.php
+++ b/www/include/configuration/configCentreonBroker/centreon-broker.php
@@ -67,13 +67,6 @@ require_once "./include/common/common-Func.php";
 /**
  *  Page forbidden if server is a remote
  */
-$isRemote = false;
-
-$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
-if ($row = $result->fetch()) {
-    $isRemote = $row['value'] === 'yes';
-}
-
 if ($isRemote) {
     require_once($path . "../../core/errors/alt_error.php");
     exit();

--- a/www/include/configuration/configGenerate/generateFiles.php
+++ b/www/include/configuration/configGenerate/generateFiles.php
@@ -1,39 +1,40 @@
 <?php
+
 /*
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
- * 
- * This program is free software; you can redistribute it and/or modify it under 
- * the terms of the GNU General Public License as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
  * Foundation ; either version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with 
+ *
+ * You should have received a copy of the GNU General Public License along with
  * this program; if not, see <http://www.gnu.org/licenses>.
- * 
- * Linking this program statically or dynamically with other modules is making a 
- * combined work based on this program. Thus, the terms and conditions of the GNU 
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
- * 
- * As a special exception, the copyright holders of this program give Centreon 
- * permission to link this program with independent modules to produce an executable, 
- * regardless of the license terms of these independent modules, and to copy and 
- * distribute the resulting executable under terms of Centreon choice, provided that 
- * Centreon also meet, for each linked independent module, the terms  and conditions 
- * of the license of that module. An independent module is a module which is not 
- * derived from this program. If you modify this program, you may extend this 
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
  * do not wish to do so, delete this exception statement from your version.
- * 
+ *
  * For more information : contact@centreon.com
- * 
+ *
  * SVN : $URL$
  * SVN : $Id$
- * 
+ *
  */
 
 if (!isset($oreon)) {
@@ -50,6 +51,21 @@ $path = "./include/configuration/configGenerate/";
  */
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
+
+/**
+ *  Page forbidden if server is a remote
+ */
+$isRemote = false;
+
+$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
+if ($row = $result->fetch()) {
+    $isRemote = $row['value'] === 'yes';
+}
+
+if ($isRemote) {
+    require_once($path . "../../core/errors/alt_error.php");
+    exit();
+}
 
 switch ($o) {
     default:

--- a/www/include/configuration/configGenerate/generateFiles.php
+++ b/www/include/configuration/configGenerate/generateFiles.php
@@ -55,13 +55,6 @@ require_once "./include/common/common-Func.php";
 /**
  *  Page forbidden if server is a remote
  */
-$isRemote = false;
-
-$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
-if ($row = $result->fetch()) {
-    $isRemote = $row['value'] === 'yes';
-}
-
 if ($isRemote) {
     require_once($path . "../../core/errors/alt_error.php");
     exit();

--- a/www/include/configuration/configNagios/nagios.php
+++ b/www/include/configuration/configNagios/nagios.php
@@ -57,6 +57,21 @@ $dupNbr = filter_var_array(
 require_once __DIR__ . '/DB-Func.php';
 require_once "./include/common/common-Func.php";
 
+/**
+ *  Page forbidden if server is a remote
+ */
+$isRemote = false;
+
+$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
+if ($row = $result->fetch()) {
+    $isRemote = $row['value'] === 'yes';
+}
+
+if ($isRemote) {
+    require_once(__DIR__ . "/../../core/errors/alt_error.php");
+    exit();
+}
+
 /* Set the real page */
 if (isset($ret) && is_array($ret) && $ret['topology_page'] != "" && $p != $ret['topology_page']) {
     $p = $ret['topology_page'];

--- a/www/include/configuration/configNagios/nagios.php
+++ b/www/include/configuration/configNagios/nagios.php
@@ -60,13 +60,6 @@ require_once "./include/common/common-Func.php";
 /**
  *  Page forbidden if server is a remote
  */
-$isRemote = false;
-
-$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
-if ($row = $result->fetch()) {
-    $isRemote = $row['value'] === 'yes';
-}
-
 if ($isRemote) {
     require_once(__DIR__ . "/../../core/errors/alt_error.php");
     exit();

--- a/www/include/configuration/configResources/resources.php
+++ b/www/include/configuration/configResources/resources.php
@@ -55,13 +55,6 @@ require_once "./include/common/common-Func.php";
 /**
  *  Page forbidden if server is a remote
  */
-$isRemote = false;
-
-$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
-if ($row = $result->fetch()) {
-    $isRemote = $row['value'] === 'yes';
-}
-
 if ($isRemote) {
     require_once($path . "../../core/errors/alt_error.php");
     exit();

--- a/www/include/configuration/configResources/resources.php
+++ b/www/include/configuration/configResources/resources.php
@@ -52,6 +52,21 @@ $path = "./include/configuration/configResources/";
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
+/**
+ *  Page forbidden if server is a remote
+ */
+$isRemote = false;
+
+$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
+if ($row = $result->fetch()) {
+    $isRemote = $row['value'] === 'yes';
+}
+
+if ($isRemote) {
+    require_once($path . "../../core/errors/alt_error.php");
+    exit();
+}
+
 define('MACRO_ADD', 'a');
 define('MACRO_DELETE', 'd');
 define('MACRO_DISABLE', 'u');

--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -9,7 +9,7 @@
                 {$form.submitA.html}
             {/if}
             &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-    {else if $o == "w"}
+    {else if $o == "w" && !$isRemote}
         <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
     {/if}
     </div>
@@ -136,7 +136,7 @@
                 {$form.submitA.html}
             {/if}
             &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-    {else if $o == "w"}
+    {else if $o == "w"&& !$isRemote}
         <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
     {/if}
     </div>

--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -136,7 +136,7 @@
                 {$form.submitA.html}
             {/if}
             &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-    {else if $o == "w"&& !$isRemote}
+    {else if $o == "w" && !$isRemote}
         <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
     {/if}
     </div>

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -386,7 +386,7 @@ if ($o == SERVER_WATCH) {
     /*
      * Just watch a nagios information
      */
-    if ($centreon->user->access->page($p) != 2) {
+    if ($centreon->user->access->page($p) != 2 && !$isRemote) {
         $form->addElement(
             "button",
             "change",
@@ -450,6 +450,7 @@ if ($valid) {
     $tpl->assign('engines', $monitoring_engines);
     $tpl->assign('cloneSetCmd', $cloneSetCmd);
     $tpl->assign('centreon_path', $centreon->optGen['oreon_path']);
+    $tpl->assign('isRemote', $isRemote);
     include_once("help.php");
 
     $helptext = "";

--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -49,24 +49,26 @@
     <table class="ToolbarTable table">
         <tr class="ToolbarTR">
             <td>
-                {if $is_admin == 1 || $can_generate == 1}
-                    <button type="button" class="{$exportBtn.class}" name="{$exportBtn.name}" onClick="{$exportBtn.onClickAction}">
-                        <span class="ui-icon ui-icon-white {$exportBtn.iconClass}"></span> {$exportBtn.text}
-                    </button>
-                {/if}
-                {if $mode_access == 'w'}
-                    <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" target="_top">
-                        <span class="ui-icon ui-icon-white {$wizardAddBtn.iconClass}"></span> {$wizardAddBtn.text}
-                    </a>
-                    <a href="{$addBtn.link}" class="{$addBtn.class}">
-                        <span class="ui-icon ui-icon-white {$addBtn.iconClass}"></span> {$addBtn.text}
-                    </a>
-                    <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
-                        <span class="ui-icon ui-icon-white {$duplicateBtn.iconClass}"></span> {$duplicateBtn.text}
-                    </button>
-                    <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
-                        <span class="ui-icon ui-icon-white {$deleteBtn.iconClass}"></span> {$deleteBtn.text}
-                    </button>
+                {if !$isRemote}
+                    {if $is_admin == 1 || $can_generate == 1}
+                        <button type="button" class="{$exportBtn.class}" name="{$exportBtn.name}" onClick="{$exportBtn.onClickAction}">
+                            <span class="ui-icon ui-icon-white {$exportBtn.iconClass}"></span> {$exportBtn.text}
+                        </button>
+                    {/if}
+                    {if $mode_access == 'w'}
+                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" target="_top">
+                            <span class="ui-icon ui-icon-white {$wizardAddBtn.iconClass}"></span> {$wizardAddBtn.text}
+                        </a>
+                        <a href="{$addBtn.link}" class="{$addBtn.class}">
+                            <span class="ui-icon ui-icon-white {$addBtn.iconClass}"></span> {$addBtn.text}
+                        </a>
+                        <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
+                            <span class="ui-icon ui-icon-white {$duplicateBtn.iconClass}"></span> {$duplicateBtn.text}
+                        </button>
+                        <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
+                            <span class="ui-icon ui-icon-white {$deleteBtn.iconClass}"></span> {$deleteBtn.text}
+                        </button>
+                    {/if}
                 {/if}
             </td>
             {php}
@@ -77,11 +79,13 @@
     <table class="ListTable">
         <tr class="ListHeader">
             <td class="ListColHeaderPicker">
+            {if !$isRemote}
                 <div class="md-checkbox md-checkbox-inline">
                     <input type="checkbox" id="checkall" name="checkall"
                         onclick="checkUncheckAll(this); hasPollersSelected();"/>
                     <label class="empty-label" for="checkall"></label>
                 </div>
+            {/if}
             </td>
             <td class="ListColHeaderLeft">{$headerMenu_name}</td>
             <td class="ListColHeaderCenter">{$headerMenu_ip_address}</td>
@@ -99,7 +103,7 @@
         </tr>
         {section name=elem loop=$elemArr}
         <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
+            <td class="ListColPicker">{if !$isRemote}{$elemArr[elem].RowMenu_select} {/if}</td>
             <td class="ListColLeft">{if $mode_access == 'w'}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_name}{if $mode_access == 'w'}</a>{/if}</td>
             <td class="ListColCenter">{if $mode_access == 'w'}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $mode_access == 'w'}</a>{/if}</td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
@@ -121,7 +125,7 @@
             <td class="ListColCenter">{$elemArr[elem].RowMenu_is_default}</td>
             <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
             <td class="ListColCenter">
-                {if $mode_access == 'w' && $elemArr[elem].RowMenu_cfg_id != ""}
+                {if $mode_access == 'w' && $elemArr[elem].RowMenu_cfg_id != "" && !$isRemote}
                 <!-- Link for edit poller monitoring engine configuration -->
                 <a href="./main.php?p=60903&o=c&nagios_id={$elemArr[elem].RowMenu_cfg_id}">
                     <img src="./img/icons/edit_conf.png" class="ico-16" title="Edit monitoring engine configuration">
@@ -136,7 +140,7 @@
                 </span>
                 {/if}
             </td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
+            <td class="ListColRight">{if $mode_access == 'w' && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
         </tr>
         {/section}
     </table>

--- a/www/include/configuration/configServers/servers.php
+++ b/www/include/configuration/configServers/servers.php
@@ -92,6 +92,30 @@ if ($action !== false) {
     $o = $action;
 }
 
+/**
+ * Actions forbidden if server is a remote
+ */
+$forbiddenIfRemote = [
+    SERVER_ADD,
+    SERVER_MODIFY,
+    SERVER_ENABLE,
+    SERVER_DISABLE,
+    SERVER_DUPLICATE,
+    SERVER_DELETE
+];
+
+$isRemote = false;
+
+$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
+if ($row = $result->fetch()) {
+    $isRemote = $row['value'] === 'yes';
+}
+
+if ($isRemote && in_array($o, $forbiddenIfRemote)) {
+    require_once($path . "../../core/errors/alt_error.php");
+    exit();
+}
+
 switch ($o) {
     case SERVER_ADD:
     case SERVER_WATCH:

--- a/www/include/configuration/configServers/servers.php
+++ b/www/include/configuration/configServers/servers.php
@@ -103,14 +103,6 @@ $forbiddenIfRemote = [
     SERVER_DUPLICATE,
     SERVER_DELETE
 ];
-
-$isRemote = false;
-
-$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
-if ($row = $result->fetch()) {
-    $isRemote = $row['value'] === 'yes';
-}
-
 if ($isRemote && in_array($o, $forbiddenIfRemote)) {
     require_once($path . "../../core/errors/alt_error.php");
     exit();

--- a/www/main.get.php
+++ b/www/main.get.php
@@ -219,7 +219,6 @@ if ($redirect !== false && ($acl_page == 1 || $acl_page == 2)) {
             $url = "./include/core/errors/alt_error.php";
         }
     }
-    if ()
 } else {
     $url = "./include/core/errors/alt_error.php";
 }

--- a/www/main.get.php
+++ b/www/main.get.php
@@ -113,6 +113,17 @@ $query = "SELECT topology_parent,topology_name,topology_id,topology_url,topology
 $DBRESULT = $pearDB->query($query);
 $redirect = $DBRESULT->fetch();
 
+/**
+ *  Is server a remote ?
+ */
+global $isRemote;
+$isRemote = false;
+
+$result = $pearDB->query("SELECT `value` FROM `informations` WHERE `key` = 'isRemote'");
+if ($row = $result->fetch()) {
+    $isRemote = $row['value'] === 'yes';
+}
+
 /*
  * Init URL
  */
@@ -208,6 +219,7 @@ if ($redirect !== false && ($acl_page == 1 || $acl_page == 2)) {
             $url = "./include/core/errors/alt_error.php";
         }
     }
+    if ()
 } else {
     $url = "./include/core/errors/alt_error.php";
 }


### PR DESCRIPTION
## Description

On a remote server’s WUI, the poller config menu show all actions buttons (export conf, duplicate, delete ...) and icon buttons (enable/disable, edit monitoring engine conf).
Following page are accessible: 
The following topology pages are accessible : 
- p=60903 (engine configuration)
- p=60902 (config export)
- p=60904 (config resources)
- p=60901&o=c&server_id=x (poller configuration)
- p=60909 (broker configuration)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>
When on a remote server’s WUI:

1. in configuation > pollers list : no action should be possible, the link on a poller name should redirect to a page that show the poller conf detail in read only mode
2. following pages should be inaccessible:
- p=60903 (engine configuration)
- p=60902 (config export)
- p=60904 (config resources)
- p=60901&o=c&server_id=x (poller configuration edition)
- p=60909 (broker configuration)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
