### PR TITLE
enh(UI): Add new tile with the last ok status

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -133,7 +133,7 @@ Centreon\Domain\Monitoring\Resource:
             type: DateTime<'Y-m-d\TH:i:sP'>
             groups:
                 - 'resource_main'
-              lastTimeWithNoIssue:
+        lastTimeWithNoIssue:
             type: DateTime<'Y-m-d\TH:i:sP'>
             groups:
                 - 'resource_details'  

--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -133,6 +133,10 @@ Centreon\Domain\Monitoring\Resource:
             type: DateTime<'Y-m-d\TH:i:sP'>
             groups:
                 - 'resource_main'
+              lastTimeWithNoIssue:
+            type: DateTime<'Y-m-d\TH:i:sP'>
+            groups:
+                - 'resource_details'  
         lastNotification:
             type: DateTime
             groups:

--- a/doc/API/centreon-api-v21.10.yaml
+++ b/doc/API/centreon-api-v21.10.yaml
@@ -5000,6 +5000,11 @@ components:
           format: date-time
           nullable: true
           description: "Date of the last status change (ISO8601)"
+        last_time_with_no_issue:
+          type: string
+          format: date-time
+          nullable: true
+          description: "Date of the last status change (ISO8601)"
         tries:
           type: string
           nullable: true

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14743,3 +14743,6 @@ msgstr "Permitir certificado autofirmado"
 
 msgid "Clear filter"
 msgstr ""
+
+msgid "Last check with OK status"
+msgstr "" 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16243,3 +16243,5 @@ msgstr "Graphiques de services"
 msgid "Clear filter"
 msgstr "Effacer le filtre"
 
+msgid "Last check with OK status"
+msgstr "Dernier contrôle avec un statut OK" 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15194,3 +15194,6 @@ msgstr "Erro ao remover tokens de um contato"
 
 msgid "Clear filter"
 msgstr ""
+
+msgid "Last check with OK status"
+msgstr "" 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15182,3 +15182,6 @@ msgstr "Erro ao remover tokens de um contato"
 
 msgid "Clear filter"
 msgstr ""
+
+msgid "Last check with OK status"
+msgstr "" 

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -180,6 +180,11 @@ class Resource
     /**
      * @var \DateTime|null
      */
+    private $lastTimeWithNoIssue;
+
+    /**
+     * @var \DateTime|null
+     */
     private $lastNotification;
 
     /**
@@ -772,6 +777,23 @@ class Resource
         return $this;
     }
 
+   /**
+     * @return \DateTime|null
+     */
+    public function getLastTimeWithNoIssue(): ?\DateTime
+    {
+        return $this->lastTimeWithNoIssue;
+    }
+
+    /**
+     * @param \DateTime|null $lastTimeWithNoIssue
+     * @return self
+     */
+    public function setLastTimeWithNoIssue(?\DateTime $lastTimeWithNoIssue): self
+    {
+        $this->lastTimeWithNoIssue = $lastTimeWithNoIssue;
+        return $this;
+    }
     /**
      * @return \DateTime|null
      */

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
@@ -152,7 +152,7 @@ final class HostProvider extends Provider
             h.perfdata AS `performance_data`,
             h.execution_time AS `execution_time`,
             h.latency AS `latency`,
-            h.notify AS `notification_enabled`
+            h.notify AS `notification_enabled`,
             h.last_time_up AS `last_time_with_no_issue`
             FROM `:dbstg`.`hosts` AS h";
 

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
@@ -153,6 +153,7 @@ final class HostProvider extends Provider
             h.execution_time AS `execution_time`,
             h.latency AS `latency`,
             h.notify AS `notification_enabled`
+            h.last_time_up AS `last_time_with_no_issue`
             FROM `:dbstg`.`hosts` AS h";
 
         // get monitoring server information

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
@@ -152,6 +152,7 @@ final class MetaServiceProvider extends Provider
             s.execution_time AS `execution_time`,
             s.latency AS `latency`,
             s.notify AS `notification_enabled`
+            s.last_time_ok AS `last_time_with_no_issue`
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`hosts` sh
             ON sh.host_id = s.host_id

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
@@ -151,7 +151,7 @@ final class MetaServiceProvider extends Provider
             s.perfdata AS `performance_data`,
             s.execution_time AS `execution_time`,
             s.latency AS `latency`,
-            s.notify AS `notification_enabled`
+            s.notify AS `notification_enabled`,
             s.last_time_ok AS `last_time_with_no_issue`
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`hosts` sh

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
@@ -166,7 +166,7 @@ final class ServiceProvider extends Provider
             s.perfdata AS `performance_data`,
             s.execution_time AS `execution_time`,
             s.latency AS `latency`,
-            s.notify AS `notification_enabled`
+            s.notify AS `notification_enabled`,
             s.last_time_ok AS `last_time_with_no_issue`
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`hosts` sh

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
@@ -167,6 +167,7 @@ final class ServiceProvider extends Provider
             s.execution_time AS `execution_time`,
             s.latency AS `latency`,
             s.notify AS `notification_enabled`
+            s.last_time_ok AS `last_time_with_no_issue`
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`hosts` sh
                 ON sh.host_id = s.host_id

--- a/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
@@ -184,7 +184,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             . 'resource.tries, resource.last_check, resource.next_check, '
             . 'resource.information, resource.performance_data, '
             . 'resource.execution_time, resource.latency, '
-            . 'resource.notification_enabled '
+            . 'resource.notification_enabled, resource.last_time_with_no_issue '
             . 'FROM (';
 
         $subRequests = [];

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -524,7 +524,6 @@ describe(Details, () => {
     expect(getByText('10')).toBeInTheDocument();
     expect(getByText('CRITICAL')).toBeInTheDocument();
     expect(getByText('Centreon')).toBeInTheDocument();
-    expect(getByText(labelLastCheckWithOkStatus)).toBeInTheDocument();
     expect(getByText(labelFqdn)).toBeInTheDocument();
     expect(getByText('central.centreon.com')).toBeInTheDocument();
     expect(getByText(labelAlias)).toBeInTheDocument();

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -74,6 +74,7 @@ import {
   labelLastMonth,
   labelLastYear,
   labelBeforeLastYear,
+  labelLastCheckWithOkStatus,
 } from '../translatedLabels';
 import Context, { ResourceContext } from '../Context';
 import useListing from '../Listing/useListing';
@@ -150,6 +151,7 @@ const retrievedDetails = {
   last_check: '2020-05-18T16:00Z',
   last_notification: '2020-07-18T17:30:00Z',
   last_status_change: '2020-04-18T15:00Z',
+  last_time_with_no_issue: '2021-09-23T15:49:50+02:00',
   last_update: '2020-03-18T16:30:00Z',
   latency: 0.005,
   links: {
@@ -522,7 +524,7 @@ describe(Details, () => {
     expect(getByText('10')).toBeInTheDocument();
     expect(getByText('CRITICAL')).toBeInTheDocument();
     expect(getByText('Centreon')).toBeInTheDocument();
-
+    expect(getByText(labelLastCheckWithOkStatus)).toBeInTheDocument();
     expect(getByText(labelFqdn)).toBeInTheDocument();
     expect(getByText('central.centreon.com')).toBeInTheDocument();
     expect(getByText(labelAlias)).toBeInTheDocument();
@@ -571,6 +573,9 @@ describe(Details, () => {
 
     expect(getByText(labelCheckDuration)).toBeInTheDocument();
     expect(getByText('0.070906 s')).toBeInTheDocument();
+
+    expect(getByText(labelLastCheckWithOkStatus)).toBeInTheDocument();
+    expect(getByText('06/18/2020 7:15 PM')).toBeInTheDocument();
 
     expect(getByText(labelLatency)).toBeInTheDocument();
     expect(getByText('0.005 s')).toBeInTheDocument();

--- a/www/front_src/src/Resources/Details/models.ts
+++ b/www/front_src/src/Resources/Details/models.ts
@@ -28,6 +28,7 @@ export interface ResourceDetails extends NamedEntity {
   last_check: string;
   last_notification: string;
   last_status_change: string;
+  last_time_with_no_issue: string;
   latency: number;
   links: ResourceLinks;
   monitoring_server_name?: string;

--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -43,7 +43,7 @@ export interface DetailCardLine {
   active?: boolean;
   isCustomCard?: boolean;
   line: JSX.Element;
-  shouldBeDisplayed?: boolean;
+  shouldBeDisplayed: boolean;
   title: string;
   xs?: 6 | 12;
 }
@@ -89,7 +89,7 @@ const getDetailCardLines = ({
     {
       isCustomCard: true,
       line: <AcknowledgementCard details={details} />,
-      shouldBeDisplayed: !isEmpty(details.acknowledgement),
+      shouldBeDisplayed: !isNil(details.acknowledgement),
       title: labelAcknowledgement,
       xs: 12,
     },
@@ -192,7 +192,7 @@ const getDetailCardLines = ({
           title={t(labelPerformanceData)}
         />
       ),
-      shouldBeDisplayed: !isNil(details.performance_data),
+      shouldBeDisplayed: !isEmpty(details.performance_data),
       title: labelPerformanceData,
       xs: 12,
     },

--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-import { pick, isEmpty, isNil } from 'ramda';
+import { pick, isEmpty, isNil, equals } from 'ramda';
+
+import { SeverityCode } from '@centreon/ui';
 
 import ChecksIcon from '../../../../ChecksIcon';
 import {
@@ -25,6 +27,7 @@ import {
   labelAcknowledgement,
   labelPerformanceData,
   labelCommand,
+  labelLastCheckWithOkStatus,
 } from '../../../../translatedLabels';
 import { ResourceDetails } from '../../../models';
 import ExpandableCard from '../ExpandableCard';
@@ -127,10 +130,17 @@ const getDetailCardLines = ({
       title: labelLastCheck,
     },
     {
+      line: <DetailsLine line={toDateTime(details.last_time_with_no_issue)} />,
+      shouldBeDisplayed:
+        !isNil(details.last_time_with_no_issue) &&
+        !equals(details.status.severity_code, SeverityCode.Ok),
+      title: labelLastCheckWithOkStatus,
+    },
+    {
       line: (
         <ChecksIcon {...pick(['active_checks', 'passive_checks'], details)} />
       ),
-      shouldBeDisplayed: displayChecksIcon ? true : undefined,
+      shouldBeDisplayed: displayChecksIcon,
       title: labelCheck,
     },
     {

--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { pick } from 'ramda';
+import { pick, isEmpty, isNil } from 'ramda';
 
 import ChecksIcon from '../../../../ChecksIcon';
 import {
@@ -38,9 +38,9 @@ import CommandLineCard from './CommandLineCard';
 
 export interface DetailCardLine {
   active?: boolean;
-  field?: string | number | boolean | Array<unknown>;
   isCustomCard?: boolean;
   line: JSX.Element;
+  shouldBeDisplayed?: boolean;
   title: string;
   xs?: 6 | 12;
 }
@@ -64,7 +64,6 @@ const getDetailCardLines = ({
 
   return [
     {
-      field: details.information,
       isCustomCard: true,
       line: (
         <ExpandableCard
@@ -73,109 +72,109 @@ const getDetailCardLines = ({
           title={t(labelStatusInformation)}
         />
       ),
+      shouldBeDisplayed: !isNil(details.information),
       title: labelStatusInformation,
       xs: 12,
     },
     {
-      field: details.downtimes,
       isCustomCard: true,
       line: <DowntimesCard details={details} />,
+      shouldBeDisplayed: !isEmpty(details.downtimes),
       title: labelDowntimeDuration,
       xs: 12,
     },
     {
-      field: details.acknowledgement ? true : undefined,
       isCustomCard: true,
       line: <AcknowledgementCard details={details} />,
+      shouldBeDisplayed: !isEmpty(details.acknowledgement),
       title: labelAcknowledgement,
       xs: 12,
     },
     {
-      field: details.fqdn,
       line: <DetailsLine line={details.fqdn} />,
+      shouldBeDisplayed: !isNil(details.fqdn),
       title: labelFqdn,
       xs: 12,
     },
     {
-      field: details.alias,
       line: <DetailsLine line={details.alias} />,
+      shouldBeDisplayed: !isNil(details.alias),
       title: labelAlias,
     },
     {
-      field: details.monitoring_server_name,
       line: <DetailsLine line={details.monitoring_server_name} />,
+      shouldBeDisplayed: !isNil(details.monitoring_server_name),
       title: labelMonitoringServer,
     },
     {
-      field: details.timezone,
       line: <DetailsLine line={details.timezone} />,
+      shouldBeDisplayed: !isNil(details.timezone),
       title: labelTimezone,
     },
     {
-      field: details.duration,
       line: <DetailsLine line={`${details.duration} - ${details.tries}`} />,
+      shouldBeDisplayed: !isNil(details.duration),
       title: labelCurrentStateDuration,
     },
     {
-      field: details.last_status_change,
       line: <DetailsLine line={toDateTime(details.last_status_change)} />,
+      shouldBeDisplayed: !isNil(details.last_status_change),
       title: labelLastStateChange,
     },
     {
-      field: details.last_check,
       line: <DetailsLine line={toDateTime(details.last_check)} />,
+      shouldBeDisplayed: !isNil(details.last_check),
       title: labelLastCheck,
     },
     {
-      field: displayChecksIcon ? true : undefined,
       line: (
         <ChecksIcon {...pick(['active_checks', 'passive_checks'], details)} />
       ),
+      shouldBeDisplayed: displayChecksIcon ? true : undefined,
       title: labelCheck,
     },
     {
-      field: details.next_check,
       line: <DetailsLine line={toDateTime(details.next_check)} />,
+      shouldBeDisplayed: !isNil(details.next_check),
       title: labelNextCheck,
     },
     {
-      field: details.execution_time,
       line: <DetailsLine line={`${details.execution_time} s`} />,
+      shouldBeDisplayed: !isNil(details.execution_time),
       title: labelCheckDuration,
     },
     {
-      field: details.latency,
       line: <DetailsLine line={`${details.latency} s`} />,
+      shouldBeDisplayed: !isNil(details.latency),
       title: labelLatency,
     },
     {
-      field: details.percent_state_change,
       line: <PercentStateChangeCard details={details} />,
+      shouldBeDisplayed: !isNil(details.percent_state_change),
       title: labelPercentStateChange,
     },
     {
-      field: details.last_notification,
       line: <DetailsLine line={toDateTime(details.last_notification)} />,
+      shouldBeDisplayed: !isNil(details.last_notification),
       title: labelLastNotification,
     },
     {
-      field: details.notification_number,
       line: <DetailsLine line={details.notification_number.toString()} />,
+      shouldBeDisplayed: !isNil(details.notification_number),
       title: labelCurrentNotificationNumber,
     },
     {
-      field: details.calculation_type,
       line: <DetailsLine line={details.calculation_type} />,
+      shouldBeDisplayed: !isNil(details.calculation_type),
       title: labelCalculationType,
     },
     {
-      field: details.groups,
       line: <Groups details={details} />,
+      shouldBeDisplayed: !isEmpty(details.groups),
       title: labelGroups,
       xs: 12,
     },
     {
-      field: details.performance_data,
       isCustomCard: true,
       line: (
         <ExpandableCard
@@ -183,13 +182,14 @@ const getDetailCardLines = ({
           title={t(labelPerformanceData)}
         />
       ),
+      shouldBeDisplayed: !isNil(details.performance_data),
       title: labelPerformanceData,
       xs: 12,
     },
     {
-      field: details.command_line,
       isCustomCard: true,
       line: <CommandLineCard details={details} />,
+      shouldBeDisplayed: !isNil(details.command_line),
       title: labelCommand,
       xs: 12,
     },

--- a/www/front_src/src/Resources/Details/tabs/Details/SortableCards/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/SortableCards/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { rectIntersection } from '@dnd-kit/core';
 import { rectSortingStrategy } from '@dnd-kit/sortable';
-import { filter, find, isEmpty, isNil, map, pluck, propEq } from 'ramda';
+import { filter, find, isEmpty, map, pluck, propEq } from 'ramda';
 
 import { Box, Grid } from '@material-ui/core';
 

--- a/www/front_src/src/Resources/Details/tabs/Details/SortableCards/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/SortableCards/index.tsx
@@ -50,10 +50,9 @@ const SortableCards = ({ panelWidth, details }: Props): JSX.Element => {
   );
 
   const displayedCards = filter(
-    ({ field }) => !isNil(field) && !isEmpty(field),
+    ({ shouldBeDisplayed }) => shouldBeDisplayed,
     cards,
   );
-
   const RootComponent = ({ children }: RootComponentProps): JSX.Element => (
     <Grid container spacing={1} style={{ width: panelWidth }}>
       {children}
@@ -71,7 +70,7 @@ const SortableCards = ({ panelWidth, details }: Props): JSX.Element => {
         RootComponent={RootComponent}
         collisionDetection={rectIntersection}
         itemProps={[
-          'field',
+          'shouldBeDisplayed',
           'line',
           'xs',
           'active',

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -230,3 +230,4 @@ export const labelLastYear = 'Last year';
 export const labelBeforeLastYear = 'Before last year';
 export const labelServiceGraphs = 'Service graphs';
 export const labelClearFilter = 'Clear filter';
+export const labelLastCheckWithOkStatus = 'Last check with OK status';


### PR DESCRIPTION
## Description

As a user, I want to know for a resource not OK when was the last time it was OK.


**Fixes** # (issue)

A new tiles will be displayed for service in not OK state, nothing for resources in OK state.


<img width="539" alt="Capture d’écran 2021-09-29 à 10 27 17" src="https://user-images.githubusercontent.com/16045498/135243362-849e3928-15fc-4658-b8c4-66a9729c1bc2.png">


<img width="365" alt="Capture d’écran 2021-09-30 à 11 32 12" src="https://user-images.githubusercontent.com/16045498/135427990-8f9b8170-5da2-4b97-b919-a2fb9e6db6c0.png">


## Type of change

- [x] New functionality (non-breaking change)


## Target serie


- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to ressource status and selected resource with a non OK status, you can see now the new tile with informations about the last ok status for this resource.

