### PR TITLE
nullable host-fields not more clearable after saving

### DIFF
--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -2477,13 +2477,19 @@ function sanitizeFormHostParameters(array $ret): array
                 break;
             case 'command_command_id_arg1':
             case 'command_command_id_arg2':
-            case 'host_name':
             case 'host_alias':
-            case 'host_address':
             case 'host_snmp_community':
             case 'host_snmp_version':
             case 'host_comment':
+            case 'host_address':
             case 'geo_coords':
+                $bindParams[':' . $inputName] = [
+                    \PDO::PARAM_STR => (($inputValue = filter_var($inputValue, FILTER_SANITIZE_STRING)) === '')
+                        ? null
+                        : $inputValue
+                ];
+                break;
+            case 'host_name':
                 if (!empty($inputValue)) {
                     $bindParams[':' . $inputName] = [
                         \PDO::PARAM_STR => (($inputValue = filter_var($inputValue, FILTER_SANITIZE_STRING)) === '')
@@ -2512,11 +2518,11 @@ function sanitizeFormHostParameters(array $ret): array
                 if (!empty($inputValue)) {
                     $bindParams[':host_notification_options'] = [
                         \PDO::PARAM_STR => (($inputValue = filter_var(
-                            implode(",", array_keys($inputValue)),
-                            FILTER_SANITIZE_STRING
-                        )) === '')
-                        ? null
-                        : $inputValue
+                                implode(",", array_keys($inputValue)),
+                                FILTER_SANITIZE_STRING
+                            )) === '')
+                            ? null
+                            : $inputValue
                     ];
                 }
                 break;
@@ -2536,11 +2542,11 @@ function sanitizeFormHostParameters(array $ret): array
                 if (!empty($inputValue)) {
                     $bindParams[':host_stalking_options'] = [
                         \PDO::PARAM_STR => (($inputValue = filter_var(
-                            implode(",", array_keys($inputValue)),
-                            FILTER_SANITIZE_STRING
-                        )) === '')
-                        ? null
-                        : $inputValue
+                                implode(",", array_keys($inputValue)),
+                                FILTER_SANITIZE_STRING
+                            )) === '')
+                            ? null
+                            : $inputValue
                     ];
                 }
                 break;


### PR DESCRIPTION
I changed the DB-Func.php of the host configuration object and inserted a separate case statement for the nullable fields host_alias,
host_address, host_snmp_community, host_snmp_version, command_command_id_arg1, command_command_id_arg2, host_comment, geo_coords

**Fixes** https://github.com/centreon/centreon/issues/9993

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

see the description. 