### PR TITLE
fix(sql) move sql update to new file for 21.04.7

### DIFF
--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '21.04.6');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '21.04.7');
 
 --
 -- Contenu de la table `contact`

--- a/www/install/sql/centreon/Update-DB-21.04.2.sql
+++ b/www/install/sql/centreon/Update-DB-21.04.2.sql
@@ -1,9 +1,2 @@
 -- Delete obsolete topologies
 DELETE FROM `topology` WHERE `topology_page` IN (6090901, 6090902);
-
--- Add TLS hostname in config brocker input/outputs IPV4
-INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`, `fieldtype`, `external`) VALUES
-(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
-
-INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`) VALUES
-(3, 76, 0, 5);

--- a/www/install/sql/centreon/Update-DB-21.04.7.sql
+++ b/www/install/sql/centreon/Update-DB-21.04.7.sql
@@ -1,0 +1,6 @@
+-- Add TLS hostname in config brocker input/outputs IPV4
+INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`, `fieldtype`, `external`) VALUES
+(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
+
+INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`) VALUES
+(3, 76, 0, 5);


### PR DESCRIPTION
## Description

Move sql modifications to new sql update file for 21.04.7

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x
- [ ] 21.10.x (master)

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
