### PR TITLE
fix(UI): Take into account about the export button parameter

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16289,7 +16289,7 @@ msgid "Export and reload the configuration?"
 msgstr "Export et recharger la configuration ?"
 
 msgid "This will export and reload the configuration on all of your platform"
-msgstr "Cela va export et recharger la configuration sur l'ensemble de votre plateforme"
+msgstr "Cela va exporter et recharger la configuration sur l'ensemble de votre plateforme"
 
 msgid "Exporting and reloading the configuration. Please wait..."
 msgstr "La configuration est en train d'être exportée et rechargée. Veuillez attendre..."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16292,7 +16292,7 @@ msgid "This will export and reload the configuration on all of your platform"
 msgstr "Cela va exporter et recharger la configuration sur l'ensemble de votre plateforme"
 
 msgid "Exporting and reloading the configuration. Please wait..."
-msgstr "La configuration est en train d'être exportée et rechargée. Veuillez attendre..."
+msgstr "La configuration est en train d'être exportée et rechargée. Veuillez patientez ..."
 
 msgid "Configuration exported and reloaded"
 msgstr "Configuration exportée et rechargée"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16281,3 +16281,21 @@ msgstr "L'exécution a été trop longue et a atteint le délai d'attente"
 
 msgid "Last check with OK status"
 msgstr "Dernier contrôle avec un statut OK" 
+
+msgid "Export & reload"
+msgstr "Exporter et recharger"
+
+msgid "Export and reload the configuration?"
+msgstr "Export et recharger la configuration ?"
+
+msgid "This will export and reload the configuration on all of your platform"
+msgstr "Cela va export et recharger la configuration sur l'ensemble de votre plateforme"
+
+msgid "Exporting and reloading the configuration. Please wait..."
+msgstr "La configuration est en train d'être exportée et rechargée. Veuillez attendre..."
+
+msgid "Configuration exported and reloaded"
+msgstr "Configuration exportée et rechargée"
+
+msgid "Failed to export and reload the configuration"
+msgstr "L'export et le rechargement de la configuration a echoué"

--- a/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.test.tsx
+++ b/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.test.tsx
@@ -5,6 +5,7 @@ import { render, waitFor, RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { withSnackbar } from '@centreon/ui';
+import { useUserContext } from '@centreon/ui-context';
 
 import { cancelTokenRequestParam } from '../../../Resources/testUtils';
 import {
@@ -20,17 +21,35 @@ import ExportConfiguration from '.';
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+jest.mock('@centreon/centreon-frontend/packages/ui-context', () => ({
+  ...(jest.requireActual('@centreon/ui-context') as jest.Mocked<unknown>),
+  useUserContext: jest.fn(),
+}));
+
+const mockedUserContext = useUserContext as jest.Mock;
+
+const mockUserContext = {
+  isExportButtonEnabled: true,
+  locale: 'en',
+  refreshInterval: 60,
+  timezone: 'Europe/Paris',
+};
+
+const ExportConfigurationButton = (): JSX.Element => (
+  <ExportConfiguration setIsExportingConfiguration={jest.fn} />
+);
+
 const ExportConfigurationWithSnackbar = withSnackbar({
-  Component: ExportConfiguration,
+  Component: ExportConfigurationButton,
 });
 
 const renderExportConfiguration = (): RenderResult =>
-  render(
-    <ExportConfigurationWithSnackbar setIsExportingConfiguration={jest.fn} />,
-  );
+  render(<ExportConfigurationWithSnackbar />);
 
 describe(ExportConfiguration, () => {
   beforeEach(() => {
+    mockedUserContext.mockReturnValue(mockUserContext);
+
     mockedAxios.get.mockReset();
     mockedAxios.get.mockResolvedValueOnce({
       data: {},

--- a/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.tsx
+++ b/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
 import { useTranslation } from 'react-i18next';
+import { not } from 'ramda';
 
 import { Button, makeStyles, Paper, Typography } from '@material-ui/core';
 
 import { getData, useRequest, useSnackbar, Dialog } from '@centreon/ui';
+import { useUserContext } from '@centreon/ui-context';
 
 import {
   labelCancel,
@@ -38,11 +40,12 @@ const useStyles = makeStyles((theme) => ({
 
 const ExportConfiguration = ({
   setIsExportingConfiguration,
-}: Props): JSX.Element => {
+}: Props): JSX.Element | null => {
   const [askingBeforeExportConfiguration, setAskingBeforeExportConfiguration] =
     React.useState(false);
 
   const { t } = useTranslation();
+  const { isExportButtonEnabled } = useUserContext();
   const { sendRequest, sending } = useRequest({
     defaultFailureMessage: t(labelFailedToExportAndReloadConfiguration),
     request: getData,
@@ -68,6 +71,10 @@ const ExportConfiguration = ({
   React.useEffect(() => {
     setIsExportingConfiguration(sending);
   }, [sending]);
+
+  if (not(isExportButtonEnabled)) {
+    return null;
+  }
 
   const disableButton = sending;
 

--- a/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.tsx
+++ b/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.tsx
@@ -16,7 +16,7 @@ import {
   labelExportConfiguration,
   labelExportingAndReloadingTheConfiguration,
   labelFailedToExportAndReloadConfiguration,
-  labelThisWillExportAndReloadOnAllOfYourPollers,
+  labelThisWillExportAndReloadOnAllOfYourPlatform,
 } from '../translatedLabels';
 
 import { exportAndReloadConfigurationEndpoint } from './api/endpoints';
@@ -101,7 +101,7 @@ const ExportConfiguration = ({
       >
         <div>
           <Typography>
-            {t(labelThisWillExportAndReloadOnAllOfYourPollers)}
+            {t(labelThisWillExportAndReloadOnAllOfYourPlatform)}
           </Typography>
         </div>
       </Dialog>

--- a/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.tsx
+++ b/www/front_src/src/Header/pollerMenu/ExportConfiguration/index.tsx
@@ -16,7 +16,7 @@ import {
   labelExportConfiguration,
   labelExportingAndReloadingTheConfiguration,
   labelFailedToExportAndReloadConfiguration,
-  labelThisWillExportAndReloadOnTheFollowingPollers,
+  labelThisWillExportAndReloadOnAllOfYourPollers,
 } from '../translatedLabels';
 
 import { exportAndReloadConfigurationEndpoint } from './api/endpoints';
@@ -101,7 +101,7 @@ const ExportConfiguration = ({
       >
         <div>
           <Typography>
-            {t(labelThisWillExportAndReloadOnTheFollowingPollers)}:
+            {t(labelThisWillExportAndReloadOnAllOfYourPollers)}
           </Typography>
         </div>
       </Dialog>

--- a/www/front_src/src/Header/pollerMenu/index.js
+++ b/www/front_src/src/Header/pollerMenu/index.js
@@ -321,7 +321,7 @@ class PollerMenu extends Component {
                   size="small"
                   style={{ marginTop: '8px' }}
                   variant="contained"
-                  onClick={this.closeSubmenu}
+                  onClick={this.redirectsToPollersPage}
                 >
                   {t('Configure pollers')}
                 </Button>

--- a/www/front_src/src/Header/pollerMenu/translatedLabels.ts
+++ b/www/front_src/src/Header/pollerMenu/translatedLabels.ts
@@ -3,8 +3,8 @@ export const labelCancel = 'Cancel';
 export const labelExportAndReload = 'Export & reload';
 export const labelExportAndReloadTheConfiguration =
   'Export and reload the configuration?';
-export const labelThisWillExportAndReloadOnAllOfYourPollers =
-  'This will export and reload the configuration on all of your pollers';
+export const labelThisWillExportAndReloadOnAllOfYourPlatform =
+  'This will export and reload the configuration on all of your platform';
 export const labelExportingAndReloadingTheConfiguration =
   'Exporting and reloading the configuration. Please wait...';
 export const labelConfigurationExportedAndReloaded =

--- a/www/front_src/src/Header/pollerMenu/translatedLabels.ts
+++ b/www/front_src/src/Header/pollerMenu/translatedLabels.ts
@@ -3,8 +3,8 @@ export const labelCancel = 'Cancel';
 export const labelExportAndReload = 'Export & reload';
 export const labelExportAndReloadTheConfiguration =
   'Export and reload the configuration?';
-export const labelThisWillExportAndReloadOnTheFollowingPollers =
-  'This will export and reload the configuration on the following pollers';
+export const labelThisWillExportAndReloadOnAllOfYourPollers =
+  'This will export and reload the configuration on all of your pollers';
 export const labelExportingAndReloadingTheConfiguration =
   'Exporting and reloading the configuration. Please wait...';
 export const labelConfigurationExportedAndReloaded =


### PR DESCRIPTION
## Description

This takes into account about the export button parameter to display the export button.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the profile page
- Check 'Enable the one-click export button for poller configuration [BETA]'
- Reload the page
- Expand the poller top counter
- The export button is displayed

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
