### PR TITLE
enh(UI): Reduce poller's wizard width by 50%

### DIFF
--- a/www/front_src/src/components/forms/baseWizard.tsx
+++ b/www/front_src/src/components/forms/baseWizard.tsx
@@ -4,8 +4,9 @@ import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   page: {
-    // backgroundColor: theme.palette.common.white,
+    margin: '0 auto',
     padding: theme.spacing(2, 0),
+    width: '50%',
   },
 }));
 


### PR DESCRIPTION
## Description

This reduces the poller's wizard width by 50%.
<img width="1392" alt="Screenshot 2021-10-04 at 16 37 40" src="https://user-images.githubusercontent.com/12515407/135872428-93f9bd51-5903-44dd-9342-f406f63124e9.png">

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to poller's page
- Add a poller
- -> The poller's wizard is not stretched on all the browser's window width

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
