### PR TITLE
fix(UI): Fix crash issue on graphs on Firefox

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { path, isNil, equals, last, pipe, not } from 'ramda';
 
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core';
 
 import { Resource } from '../../../models';
 import ExportablePerformanceGraphWithTimeline from '../../../Graph/Performance/ExportableGraphWithTimeline';
@@ -41,11 +41,19 @@ interface Props {
   services: Array<Resource>;
 }
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
+  graphs: {
+    columnGap: '8px',
+    display: 'grid',
+    gridTemplateColumns: `repeat(auto-fill, minmax(${theme.spacing(
+      40,
+    )}px, auto))`,
+    rowGap: '8px',
+  },
   serviceGraph: {
     display: 'contents',
   },
-});
+}));
 
 const ServiceGraphs = ({
   services,
@@ -65,7 +73,7 @@ const ServiceGraphs = ({
   );
 
   return (
-    <>
+    <div className={classes.graphs}>
       <MousePositionContext.Provider value={mousePositionProps}>
         {servicesWithGraph.map((service) => {
           const { id } = service;
@@ -89,7 +97,7 @@ const ServiceGraphs = ({
           );
         })}
       </MousePositionContext.Provider>
-    </>
+    </div>
   );
 };
 

--- a/www/front_src/src/Resources/Graph/Performance/Lines/RegularLine.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines/RegularLine.tsx
@@ -69,16 +69,22 @@ export default React.memo(RegularLine, (prevProps, nextProps) => {
     timeSeries: prevTimeSeries,
     graphHeight: prevGraphHeight,
     highlight: prevHighlight,
+    xScale: prevXScale,
   } = prevProps;
   const {
     timeSeries: nextTimeSeries,
     graphHeight: nextGraphHeight,
     highlight: nextHighlight,
+    xScale: nextXScale,
   } = nextProps;
+
+  const prevXScaleRange = prevXScale.range();
+  const nextXScaleRange = nextXScale.range();
 
   return (
     equals(prevTimeSeries, nextTimeSeries) &&
     equals(prevGraphHeight, nextGraphHeight) &&
-    equals(prevHighlight, nextHighlight)
+    equals(prevHighlight, nextHighlight) &&
+    equals(prevXScaleRange, nextXScaleRange)
   );
 });


### PR DESCRIPTION
## Description

This fix some crash issue on services graphs on Firefox.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Open the details of a host with several services
- Select the 'services' tab
- Change to graph mode
- Move you mouse over graphs / Scroll down the services graphs
- -> The graphs should not crash anymore

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
