### PR TITLE
fix(timeperiod): avoid js exception when saving timeperiod form

### DIFF
--- a/www/include/configuration/configObject/timeperiod/formTimeperiod.ihtml
+++ b/www/include/configuration/configObject/timeperiod/formTimeperiod.ihtml
@@ -90,3 +90,6 @@
 </form>
 {$helptext}
 
+<script type="text/javascript">
+  displayExistingExceptions({$countExceptions});
+</script>

--- a/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+++ b/www/include/configuration/configObject/timeperiod/formTimeperiod.php
@@ -312,9 +312,6 @@ if ($valid) {
     $tpl->assign('gmtUsed', $centreon->CentreonGMT->used());
     $tpl->assign('noExceptionMessage', _('GMT is activated on your system. Exceptions will not be generated.'));
     $tpl->assign('exceptionLabel', _('Exceptions'));
+    $tpl->assign('countExceptions', $k);
     $tpl->display("formTimeperiod.ihtml");
 }
-?>
-<script type="text/javascript">
-    displayExistingExceptions(<?php echo $k;?>);
-</script>


### PR DESCRIPTION
## Description

avoid js exception when saving timeperiod form

**Fixes** MON-7342

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Create a timeperiod
* Save the form
* ==> check javascript console that there are no errors