### PR TITLE
fix(conf) move sql update from sql file to php script

### DIFF
--- a/www/install/php/Update-21.04.7.php
+++ b/www/install/php/Update-21.04.7.php
@@ -23,7 +23,7 @@ include_once __DIR__ . "/../../class/centreonLog.class.php";
 $centreonLog = new CentreonLog();
 
 //error specific content
-$versionOfTheUpgrade = 'UPGRADE - 21.10.0-beta.1: ';
+$versionOfTheUpgrade = 'UPGRADE - 21.04.7: ';
 
 $pearDB = new CentreonDB('centreon', 3, false);
 
@@ -32,21 +32,6 @@ $pearDB = new CentreonDB('centreon', 3, false);
  */
 try {
     $pearDB->beginTransaction();
-
-    //Purge all session.
-    $errorMessage = 'Impossible to purge the table session';
-    $pearDB->query("DELETE FROM `session`");
-
-    $constraintStatement = $pearDB->query(
-        "SELECT COUNT(*) as count FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME='session_ibfk_1'"
-    );
-    if (($constraint = $constraintStatement->fetch()) && (int) $constraint['count'] === 0) {
-        $errorMessage = 'Impossible to add Delete Cascade constraint on the table session';
-        $pearDB->query(
-            "ALTER TABLE `session` ADD CONSTRAINT `session_ibfk_1` FOREIGN KEY (`user_id`) " .
-            "REFERENCES `contact` (`contact_id`) ON DELETE CASCADE"
-        );
-    }
 
     // Add TLS hostname in config brocker for input/outputs IPV4
     $statement = $pearDB->query("SELECT cb_field_id from cb_field WHERE fieldname = 'tls_hostname'");

--- a/www/install/sql/centreon/Update-DB-21.10.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-21.10.0-beta.1.sql
@@ -52,10 +52,3 @@ ALTER TABLE `session` MODIFY `last_reload` BIGINT UNSIGNED;
 
 -- Add one-click export button column to contact
 ALTER TABLE `contact` ADD COLUMN `enable_one_click_export` enum('0','1') DEFAULT '0';
-
--- Add TLS hostname in config brocker input/outputs IPV4
-INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`, `fieldtype`, `external`) VALUES
-(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
-
-INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`) VALUES
-(3, 76, 0, 5);


### PR DESCRIPTION
## Description

Move update sql to php script, add php script for 21.04.7

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
