### PR TITLE
fix(conf) move sql update from sql file to php script

### DIFF
--- a/www/install/php/Update-21.04.7.php
+++ b/www/install/php/Update-21.04.7.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+include_once __DIR__ . "/../../class/centreonLog.class.php";
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 21.04.7: ';
+
+$pearDB = new CentreonDB('centreon', 3, false);
+
+/**
+ * Query with transaction
+ */
+try {
+    $pearDB->beginTransaction();
+
+    // Add TLS hostname in config brocker for input/outputs IPV4
+    $statement = $pearDB->query("SELECT cb_field_id from cb_field WHERE fieldname = 'tls_hostname'");
+    if ($statement->fetchColumn() === false) {
+        $errorMessage  = 'Unable to update cb_field';
+        $pearDB->query("
+            INSERT INTO `cb_field` (
+                `cb_field_id`, `fieldname`,`displayname`,
+                `description`,
+                `fieldtype`, `external`
+            ) VALUES (
+                null, 'tls_hostname', 'TLS Host name',
+                'Expected TLS certificate common name (CN) - leave blank if unsure.',
+                'text', NULL
+            )
+        ");
+
+        $errorMessage  = 'Unable to update cb_type_field_relation';
+        $fieldId = $pearDB->lastInsertId();
+        $pearDB->query("
+            INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`) VALUES
+            (3, " . $fieldId . ", 0, 5)
+        ");
+    }
+
+    $pearDB->commit();
+} catch (\Exception $e) {
+    $pearDB->rollBack();
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage .
+        " - Code : " . (int)$e->getCode() .
+        " - Error : " . $e->getMessage() .
+        " - Trace : " . $e->getTraceAsString()
+    );
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int)$e->getCode(), $e);
+}

--- a/www/install/sql/centreon/Update-DB-21.04.7.sql
+++ b/www/install/sql/centreon/Update-DB-21.04.7.sql
@@ -1,6 +1,0 @@
--- Add TLS hostname in config brocker input/outputs IPV4
-INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`, `fieldtype`, `external`) VALUES
-(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
-
-INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`) VALUES
-(3, 76, 0, 5);


### PR DESCRIPTION
## Description

Move update sql from sql file to php script

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
