### PR TITLE
enh(monitoring): avoid double INNER JOIN to handle ACLs

### DIFF
--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -62,7 +62,7 @@ interface MonitoringRepositoryInterface
      * Find the hosts of the services groups ids given.
      *
      * @param int[] $servicesGroupsIds List of services groups Ids for which we want to retrieve the hosts
-     * @return array<int, array<int, mixed>> [serviceGroupId => hostId,...]
+     * @return array<int, array<int, Host>> [serviceGroupId => hostId,...]
      * @throws \Exception
      */
     public function findHostsByServiceGroups(array $servicesGroupsIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -122,7 +122,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for a non admin user
      *
-     * @param int[] $serviceIds
+     * @param array<string, mixed> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForNonAdminUser(array $serviceIds): array;
@@ -130,7 +130,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for an admin user
      *
-     * @param int[] $serviceIds
+     * @param array<string, mixed> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForAdminUser(array $serviceIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -122,7 +122,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for a non admin user
      *
-     * @param array<string, mixed> $serviceIds
+     * @param @param array<int, <array<string, int>> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForNonAdminUser(array $serviceIds): array;
@@ -130,7 +130,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for an admin user
      *
-     * @param array<string, mixed> $serviceIds
+     * @param array<int, <array<string, int>> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForAdminUser(array $serviceIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -122,7 +122,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for a non admin user
      *
-     * @param array<string, mixed> $serviceIds
+     * @param int[] $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForNonAdminUser(array $serviceIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -122,7 +122,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for a non admin user
      *
-     * @param @param array<int, <array<string, int>> $serviceIds
+     * @param array<int, array<string, int>> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForNonAdminUser(array $serviceIds): array;
@@ -130,7 +130,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for an admin user
      *
-     * @param array<int, <array<string, int>> $serviceIds
+     * @param array<int, array<string, int>> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForAdminUser(array $serviceIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -87,7 +87,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all hosts from an array of hostIds for a non admin user
      *
-     * @param array<string, mixed> $hostIds
+     * @param int[] $hostIds
      * @return Host[]
      */
     public function findHostsByIdsForNonAdminUser(array $hostIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -185,7 +185,7 @@ interface MonitoringRepositoryInterface
      * Finds services from a list of hosts.
      *
      * @param int[] $hostIds List of host for which we want to get services
-     * @return array<int, array<int, mixed>> Return a list of services indexed by host
+     * @return array<int, array<int, Service>> Return a list of services indexed by host
      */
     public function findServicesByHosts(array $hostIds): array;
 

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -95,7 +95,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all hosts from an array of hostIds for an admin user
      *
-     * @param array<string, mixed> $hostIds
+     * @param int[] $hostIds
      * @return Host[]
      */
     public function findHostsByIdsForAdminUser(array $hostIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -197,7 +197,7 @@ interface MonitoringRepositoryInterface
 
     /**
      * @param int[] $serviceGroupIds
-     * @return array<int, array<int, mixed>>
+     * @return array<int, array<int, Service>>
      * @throws \Exception
      */
     public function findServicesByServiceGroups(array $serviceGroupIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -130,7 +130,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for an admin user
      *
-     * @param array<string, mixed> $serviceIds
+     * @param int[] $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForAdminUser(array $serviceIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -53,7 +53,7 @@ interface MonitoringRepositoryInterface
      * Find the hosts of the hosts groups ids given.
      *
      * @param int[] $hostsGroupsIds List of hosts groups Ids for which we want to retrieve the hosts
-     * @return array<int, array<int, mixed>> [hostGroupId => hostId,...]
+     * @return array<int, array<int, Host>> [hostGroupId => hostId,...]
      * @throws \Exception
      */
     public function findHostsByHostsGroups(array $hostsGroupsIds): array;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -205,7 +205,7 @@ interface MonitoringRepositoryInterface
     /**
      * @param int $hostId
      * @param int $serviceId
-     * @return array<int, ServiceGroup>
+     * @return ServiceGroup[]
      */
     public function findServiceGroupsByHostAndService(int $hostId, int $serviceId): array;
 

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -52,8 +52,8 @@ interface MonitoringRepositoryInterface
     /**
      * Find the hosts of the hosts groups ids given.
      *
-     * @param array $hostsGroupsIds List of hosts groups Ids for which we want to retrieve the hosts
-     * @return array [hostGroupId => hostId,...]
+     * @param int[] $hostsGroupsIds List of hosts groups Ids for which we want to retrieve the hosts
+     * @return array<int, array<int, mixed>> [hostGroupId => hostId,...]
      * @throws \Exception
      */
     public function findHostsByHostsGroups(array $hostsGroupsIds): array;
@@ -61,8 +61,8 @@ interface MonitoringRepositoryInterface
     /**
      * Find the hosts of the services groups ids given.
      *
-     * @param array $servicesGroupsIds List of services groups Ids for which we want to retrieve the hosts
-     * @return Host[] [serviceGroupId => hostId,...]
+     * @param int[] $servicesGroupsIds List of services groups Ids for which we want to retrieve the hosts
+     * @return array<int, array<int, mixed>> [serviceGroupId => hostId,...]
      * @throws \Exception
      */
     public function findHostsByServiceGroups(array $servicesGroupsIds): array;
@@ -87,7 +87,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all hosts from an array of hostIds for a non admin user
      *
-     * @param array $hostIds
+     * @param array<string, mixed> $hostIds
      * @return Host[]
      */
     public function findHostsByIdsForNonAdminUser(array $hostIds): array;
@@ -95,7 +95,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all hosts from an array of hostIds for an admin user
      *
-     * @param array $hostIds
+     * @param array<string, mixed> $hostIds
      * @return Host[]
      */
     public function findHostsByIdsForAdminUser(array $hostIds): array;
@@ -122,7 +122,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for a non admin user
      *
-     * @param array $serviceIds
+     * @param array<string, mixed> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForNonAdminUser(array $serviceIds): array;
@@ -130,7 +130,7 @@ interface MonitoringRepositoryInterface
     /**
      * Find all services from an array of serviceIds for an admin user
      *
-     * @param array $serviceIds
+     * @param array<string, mixed> $serviceIds
      * @return Service[]
      */
     public function findServicesByIdsForAdminUser(array $serviceIds): array;
@@ -184,9 +184,8 @@ interface MonitoringRepositoryInterface
     /**
      * Finds services from a list of hosts.
      *
-     * @param array $hostIds List of host for which we want to get services
-     * @return array Return a list of services indexed by host
-     * [host_id => Service[], ...]
+     * @param int[] $hostIds List of host for which we want to get services
+     * @return array<int, array<int, mixed>> Return a list of services indexed by host
      */
     public function findServicesByHosts(array $hostIds): array;
 
@@ -197,16 +196,16 @@ interface MonitoringRepositoryInterface
     public function setContact(ContactInterface $contact): self;
 
     /**
-     * @param array $serviceGroups
-     * @return array
+     * @param int[] $serviceGroupIds
+     * @return array<int, array<int, mixed>>
      * @throws \Exception
      */
-    public function findServicesByServiceGroups(array $serviceGroups): array;
+    public function findServicesByServiceGroups(array $serviceGroupIds): array;
 
     /**
      * @param int $hostId
      * @param int $serviceId
-     * @return array
+     * @return array<int, ServiceGroup>
      */
     public function findServiceGroupsByHostAndService(int $hostId, int $serviceId): array;
 

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -198,9 +198,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $result = $this->db->query('SELECT FOUND_ROWS()');
-        $this->sqlRequestTranslator->getRequestParameters()->setTotal(
-            (int) $result->fetchColumn()
-        );
+
+        if ($result !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal(
+                (int) $result->fetchColumn()
+            );
+        }
 
         $hostIds = [];
 
@@ -476,9 +479,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         $result = $this->db->query('SELECT FOUND_ROWS()');
-        $this->sqlRequestTranslator->getRequestParameters()->setTotal(
-            (int) $result->fetchColumn()
-        );
+
+        if ($result !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal(
+                (int) $result->fetchColumn()
+            );
+        }
 
         while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $hostGroups[] = EntityCreator::createEntityByArray(
@@ -1128,9 +1134,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $result = $this->db->query('SELECT FOUND_ROWS()');
-        $this->sqlRequestTranslator->getRequestParameters()->setTotal(
-            (int) $result->fetchColumn()
-        );
+
+        if ($result !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal(
+                (int) $result->fetchColumn()
+            );
+        }
 
         while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $service = EntityCreator::createEntityByArray(
@@ -1288,9 +1297,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $result = $this->db->query('SELECT FOUND_ROWS()');
-        $this->sqlRequestTranslator->getRequestParameters()->setTotal(
-            (int) $result->fetchColumn()
-        );
+
+        if ($result !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal(
+                (int) $result->fetchColumn()
+            );
+        }
 
         while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $service = EntityCreator::createEntityByArray(
@@ -1390,9 +1402,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         $result = $this->db->query('SELECT FOUND_ROWS()');
-        $this->sqlRequestTranslator->getRequestParameters()->setTotal(
-            (int) $result->fetchColumn()
-        );
+
+        if ($result !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal(
+                (int) $result->fetchColumn()
+            );
+        }
 
         while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $serviceGroups[] = EntityCreator::createEntityByArray(
@@ -1533,15 +1548,13 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     }
 
     /**
-     * @param array $serviceGroups
-     * @return array
-     * @throws \Exception
+     * @inheritDoc
      */
-    public function findServicesByServiceGroups(array $serviceGroups): array
+    public function findServicesByServiceGroups(array $serviceGroupIds): array
     {
         $servicesByServiceGroupId = [];
 
-        if ($this->hasNotEnoughRightsToContinue() || empty($serviceGroups)) {
+        if ($this->hasNotEnoughRightsToContinue() || empty($serviceGroupIds)) {
             return $servicesByServiceGroupId;
         }
 
@@ -1574,14 +1587,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               ON ssg.service_id = srv.service_id
               AND ssg.host_id = srv.host_id'
             . $subRequest
-            . 'WHERE ssg.servicegroup_id IN (' . str_repeat('?,', count($serviceGroups) - 1) . '?)
+            . 'WHERE ssg.servicegroup_id IN (' . str_repeat('?,', count($serviceGroupIds) - 1) . '?)
                 AND srv.enabled = 1
             GROUP by ssg.servicegroup_id, srv.host_id, srv.service_id';
 
         $request = $this->translateDbName($request);
 
         $statement = $this->db->prepare($request);
-        $statement->execute($serviceGroups);
+        $statement->execute($serviceGroupIds);
 
         while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $service = EntityCreator::createEntityByArray(
@@ -1602,7 +1615,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @param int $hostId
      * @param int $serviceId
-     * @return array
+     * @return array<int, ServiceGroup>
      */
     public function findServiceGroupsByHostAndService(int $hostId, int $serviceId): array
     {
@@ -1691,9 +1704,12 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         $result = $this->db->query('SELECT FOUND_ROWS()');
-        $this->sqlRequestTranslator->getRequestParameters()->setTotal(
-            (int)$result->fetchColumn()
-        );
+
+        if ($result !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal(
+                (int) $result->fetchColumn()
+            );
+        }
 
         while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $serviceGroups[] = EntityCreator::createEntityByArray(

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -133,15 +133,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'host.criticality' => 'cv.value'
         ]);
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ''
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id IS NULL
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id IS NULL
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT
@@ -218,15 +224,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return [];
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id IS NULL
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id IS NULL
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT
@@ -274,15 +286,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return [];
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT
@@ -481,15 +499,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return null;
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id IS NULL
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id IS NULL
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT h.*,
@@ -726,15 +750,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return null;
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT DISTINCT srv.*, h.host_id AS `host_host_id`,
@@ -815,15 +845,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return null;
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT DISTINCT srv.*, h.host_id AS `host_host_id`,
@@ -1005,15 +1041,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'service.criticality' => 'cv.value'
         ]);
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = srv.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = srv.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT
@@ -1172,15 +1214,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $services;
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = srv.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = srv.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT srv.*,
@@ -1377,16 +1425,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             $serviceIds
         );
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
 
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT DISTINCT 
@@ -1431,15 +1484,21 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $services;
         }
 
-        $accessGroupFilter = $this->isAdmin()
-            ? ' '
-            : ' INNER JOIN `:dbstg`.`centreon_acl` acl
-                  ON acl.host_id = h.host_id
-                  AND acl.service_id = srv.service_id
-                INNER JOIN `:db`.`acl_groups` acg
-                  ON acg.acl_group_id = acl.group_id
-                  AND acg.acl_group_activate = \'1\'
-                  AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
+        $accessGroupFilter = '';
+
+        if ($this->isAdmin() === false) {
+            $accessGroupIds = array_map(
+                function ($accessGroup) {
+                    return $accessGroup->getId();
+                },
+                $this->accessGroups
+            );
+
+            $accessGroupFilter = ' INNER JOIN `:dbstg`.`centreon_acl` acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = srv.service_id
+                AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        }
 
         $request =
             'SELECT DISTINCT

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1615,7 +1615,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @param int $hostId
      * @param int $serviceId
-     * @return array<int, ServiceGroup>
+     * @return ServiceGroup[]
      */
     public function findServiceGroupsByHostAndService(int $hostId, int $serviceId): array
     {


### PR DESCRIPTION
This PR intends to remove the double inner join to calculate the users ACL.
ACLs with accessgroups ids are already computed and available in the centreon_acl realtime database table.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
