### PR TITLE
Mon 10989 fix side effect

### DIFF
--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2360,8 +2360,8 @@ function createCSRFToken(): string
     $token = bin2hex(openssl_random_pseudo_bytes(16));
 
     if (!isset($_SESSION['x-centreon-token']) || !is_array($_SESSION['x-centreon-token'])) {
-        $_SESSION['x-centreon-token'] = array();
-        $_SESSION['x-centreon-token-generated-at'] = array();
+        $_SESSION['x-centreon-token'] = [];
+        $_SESSION['x-centreon-token-generated-at'] = [];
     }
 
     $_SESSION['x-centreon-token'][] = $token;

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2351,6 +2351,26 @@ function isNotEmptyAfterStringSanitize($test): bool
 }
 
 /**
+ * Create a CSRF token
+ *
+ * @return string
+ */
+function createCSRFToken(): string
+{
+    $token = bin2hex(openssl_random_pseudo_bytes(16));
+
+    if (!isset($_SESSION['x-centreon-token']) || !is_array($_SESSION['x-centreon-token'])) {
+        $_SESSION['x-centreon-token'] = array();
+        $_SESSION['x-centreon-token-generated-at'] = array();
+    }
+
+    $_SESSION['x-centreon-token'][] = $token;
+    $_SESSION['x-centreon-token-generated-at'][(string)$token] = time();
+
+    return $token;
+}
+
+/**
  * Remove CSRF tokens older than 15min form session
  */
 function purgeOutdatedCSRFTokens()

--- a/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+++ b/www/include/configuration/configCentreonBroker/listCentreonBroker.php
@@ -123,10 +123,8 @@ $style = "one";
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 
 for ($i = 0; $config = $dbResult->fetch(); $i++) {
     $moptions = "";

--- a/www/include/configuration/configNagios/listNagios.php
+++ b/www/include/configuration/configNagios/listNagios.php
@@ -113,10 +113,7 @@ $style = "one";
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $nagios = $dbResult->fetch(); $i++) {
     $moptions = "";

--- a/www/include/configuration/configObject/command/DB-Func.php
+++ b/www/include/configuration/configObject/command/DB-Func.php
@@ -147,12 +147,12 @@ function multipleCommandInDB($commands = array(), $nbrDup = array())
                     "a",
                     $fields
                 );
-            }
 
-            /*
-             * Duplicate Arguments
-             */
-            duplicateArgDesc($cmd_id["MAX(command_id)"], $key);
+                /*
+                 * Duplicate Arguments
+                 */
+                duplicateArgDesc($cmd_id["MAX(command_id)"], $key);
+            }
         }
     }
 }
@@ -245,17 +245,17 @@ function insertCommand($ret = array())
     /*
      * Insert
      */
-    $rq = "INSERT INTO `command` (`command_name`, `command_line`, `enable_shell`, `command_example`, `command_type`, 
+    $rq = "INSERT INTO `command` (`command_name`, `command_line`, `enable_shell`, `command_example`, `command_type`,
         `graph_id`, `connector_id`, `command_comment`, `command_activate`) ";
     $rq .= "VALUES (
-            '" . $pearDB->escape($ret["command_name"]) . "', 
-            '" . $pearDB->escape($ret["command_line"]) . "', 
-            " . (int)$ret['enable_shell'] . ", 
-            '" . $pearDB->escape($ret["command_example"]) . "', 
-            " . (int)$ret["command_type"]["command_type"] . ", 
-            " . (!empty($ret["graph_id"]) ? (int)$ret['graph_id'] : "NULL") . ", 
-            " . (!empty($ret["connectors"]) ? (int)$ret['connectors'] : "NULL") . ", 
-            '" . $pearDB->escape($ret["command_comment"]) . "', 
+            '" . $pearDB->escape($ret["command_name"]) . "',
+            '" . $pearDB->escape($ret["command_line"]) . "',
+            " . (int)$ret['enable_shell'] . ",
+            '" . $pearDB->escape($ret["command_example"]) . "',
+            " . (int)$ret["command_type"]["command_type"] . ",
+            " . (!empty($ret["graph_id"]) ? (int)$ret['graph_id'] : "NULL") . ",
+            " . (!empty($ret["connectors"]) ? (int)$ret['connectors'] : "NULL") . ",
+            '" . $pearDB->escape($ret["command_comment"]) . "',
             '" . $pearDB->escape($ret["command_activate"]["command_activate"]) . "'";
     $rq .= ")";
     $pearDB->query($rq);
@@ -355,8 +355,8 @@ function duplicateArgDesc($new_cmd_id, $cmd_id)
 {
     global $pearDB;
 
-    $query = "INSERT INTO `command_arg_description` (cmd_id, macro_name, macro_description) 
-                    SELECT '" . (int)$new_cmd_id . "', macro_name, macro_description 
+    $query = "INSERT INTO `command_arg_description` (cmd_id, macro_name, macro_description)
+                    SELECT '" . (int)$new_cmd_id . "', macro_name, macro_description
                     FROM command_arg_description WHERE cmd_id = '" . (int)$cmd_id . "'";
     $pearDB->query($query);
 }
@@ -482,11 +482,11 @@ function insertMacrosDesc($cmd, $ret)
             }
 
             if (!empty($sName)) {
-                $sQueryInsert = "INSERT INTO `on_demand_macro_command` 
-                    (`command_command_id`, `command_macro_name`, `command_macro_desciption`, `command_macro_type`) 
-                    VALUES (" . (int)$cmd . ", 
-                        '" . $pearDB->escape($sName) . "', 
-                        '" . $pearDB->escape($sDesc) . "', 
+                $sQueryInsert = "INSERT INTO `on_demand_macro_command`
+                    (`command_command_id`, `command_macro_name`, `command_macro_desciption`, `command_macro_type`)
+                    VALUES (" . (int)$cmd . ",
+                        '" . $pearDB->escape($sName) . "',
+                        '" . $pearDB->escape($sDesc) . "',
                         '" . $arr[$sType] . "')";
                 $pearDB->query($sQueryInsert);
             }

--- a/www/include/configuration/configObject/command/listCommand.php
+++ b/www/include/configuration/configObject/command/listCommand.php
@@ -142,10 +142,7 @@ $commandType = array(
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $cmd = $dbResult->fetch(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $cmd['command_id'] . "]");

--- a/www/include/configuration/configObject/connector/listConnector.php
+++ b/www/include/configuration/configObject/connector/listConnector.php
@@ -105,10 +105,7 @@ try {
     $j = 0;
     $attrsText = array("size" => "2");
     $nbConnectors = count($connectorsList);
-    $form->createSecurityToken();
-    $centreonToken = is_array($form->getElementValue('centreon_token')) ?
-        end($form->getElementValue('centreon_token')) :
-        $form->getElementValue('centreon_token');
+    $centreonToken = createCSRFToken();
 
     for ($i = 0; $i < $nbConnectors; $i++) {
         $result = $connectorsList[$i];

--- a/www/include/configuration/configObject/contact/listContact.php
+++ b/www/include/configuration/configObject/contact/listContact.php
@@ -235,10 +235,7 @@ $refreshLdapBadge = array(0 => "");
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 foreach ($contacts as $contact) {
     if ($centreon->user->get_id() == $contact['contact_id']) {

--- a/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+++ b/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
@@ -133,10 +133,8 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 foreach ($contacts as $contact) {
     $selectedElements = $form->addElement('checkbox', "select[" . $contact['contact_id'] . "]");
 

--- a/www/include/configuration/configObject/contactgroup/listContactGroup.php
+++ b/www/include/configuration/configObject/contactgroup/listContactGroup.php
@@ -110,10 +110,8 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 foreach ($cgs as $cg) {
     $selectedElements = $form->addElement('checkbox', "select[" . $cg['cg_id'] . "]");
     if ($cg["cg_activate"]) {

--- a/www/include/configuration/configObject/host/listHost.php
+++ b/www/include/configuration/configObject/host/listHost.php
@@ -314,10 +314,7 @@ $elemArr = array();
 $search = str_replace('\_', "_", $search);
 
 
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token'))
-    ? end($form->getElementValue('centreon_token'))
-    : $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $host = $dbResult->fetch(); $i++) {
     if (

--- a/www/include/configuration/configObject/host_categories/listHostCategories.php
+++ b/www/include/configuration/configObject/host_categories/listHostCategories.php
@@ -109,10 +109,8 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 for ($i = 0; $hc = $DBRESULT->fetch(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $hc['hc_id'] . "]");
     $moptions = "";

--- a/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+++ b/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
@@ -133,10 +133,8 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 /* Fill a tab with a multidimensional Array we put in $tpl */
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 for ($i = 0; $host = $DBRESULT->fetch(); $i++) {
     $moptions = "";
     $selectedElements = $form->addElement('checkbox', "select[" . $host['host_id'] . "]");

--- a/www/include/configuration/configObject/hostgroup/listHostGroup.php
+++ b/www/include/configuration/configObject/hostgroup/listHostGroup.php
@@ -115,10 +115,8 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 for ($i = 0; $hg = $dbResult->fetch(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $hg['hg_id'] . "]");
     $moptions = "";

--- a/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -124,10 +124,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $ms = $dbResult->fetch(); $i++) {
     $moptions = "";

--- a/www/include/configuration/configObject/meta_service/listMetric.php
+++ b/www/include/configuration/configObject/meta_service/listMetric.php
@@ -125,10 +125,7 @@ if ($in_statement != "") {
      */
     $elemArr1 = array();
     $i = 0;
-    $form->createSecurityToken();
-    $centreonToken = is_array($form->getElementValue('centreon_token')) ?
-        end($form->getElementValue('centreon_token')) :
-        $form->getElementValue('centreon_token');
+    $centreonToken = createCSRFToken();
 
     while ($metric = $DBRESULTO->fetchRow()) {
         foreach ($ar_relations[$metric['metric_id']] as $relation) {

--- a/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/www/include/configuration/configObject/service/listServiceByHost.php
@@ -243,10 +243,8 @@ $fgHost = array("value" => null, "print" => null);
 
 $interval_length = $centreon->optGen['interval_length'];
 
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
+
 for ($i = 0; $service = $dbResult->fetch(); $i++) {
     //Get Number of Hosts linked to this one.
     $dbResult2 = $pearDB->query(

--- a/www/include/configuration/configObject/service/listServiceByHostGroup.php
+++ b/www/include/configuration/configObject/service/listServiceByHostGroup.php
@@ -261,10 +261,7 @@ $interval_length = $centreon->optGen['interval_length'];
 $elemArr = array();
 $fgHostgroup = array("value" => null, "print" => null);
 
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $service = $dbResult->fetch(); $i++) {
     $moptions = "";

--- a/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -117,10 +117,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $sc = $dbResult->fetch(); $i++) {
     $moptions = "";

--- a/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
@@ -138,10 +138,7 @@ $interval_length = $oreon->optGen['interval_length'];
 $search = str_replace('#S#', "/", $search);
 $search = str_replace('#BS#', "\\", $search);
 
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $service = $dbResult->fetch(); $i++) {
     $moptions = "";

--- a/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -100,10 +100,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $sg = $dbResult->fetch(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $sg['sg_id'] . "]");

--- a/www/include/configuration/configResources/listResources.php
+++ b/www/include/configuration/configResources/listResources.php
@@ -106,10 +106,7 @@ $style = "one";
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $resource = $dbResult->fetch(); $i++) {
     preg_match("\$USER([0-9]*)\$", $resource["resource_name"], $tabResources);

--- a/www/include/configuration/configServers/listServers.php
+++ b/www/include/configuration/configServers/listServers.php
@@ -172,10 +172,7 @@ $changeStateServers = getChangeState($changeStateServers);
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = [];
 $i = -1;
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 foreach ($servers as $config) {
     $i++;

--- a/www/include/monitoring/recurrentDowntime/listDowntime.php
+++ b/www/include/monitoring/recurrentDowntime/listDowntime.php
@@ -101,10 +101,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
  * Fill a tab with a mutlidimensionnal Array we put in $tpl
  */
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 foreach ($listDowntime as $dt) {
     $moptions = "";

--- a/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+++ b/www/include/options/accessLists/actionsACL/listsActionsAccess.php
@@ -97,10 +97,7 @@ $style = "one";
 
 /* Fill a tab with a mutlidimensionnal Array we put in $tpl */
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $topo = $statement->fetchRow(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $topo['acl_action_id'] . "]");

--- a/www/include/options/accessLists/groupsACL/listGroupConfig.php
+++ b/www/include/options/accessLists/groupsACL/listGroupConfig.php
@@ -102,10 +102,7 @@ $style = "one";
  * Fill a tab with a mutlidimensionnal Array we put in $tpl
  */
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $group = $statement->fetchRow(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $group['acl_group_id'] . "]");

--- a/www/include/options/accessLists/menusACL/listsMenusAccess.php
+++ b/www/include/options/accessLists/menusACL/listsMenusAccess.php
@@ -95,10 +95,7 @@ $style = "one";
  * Fill a tab with a mutlidimensionnal Array we put in $tpl
  */
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $topo = $dbResult->fetchRow(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $topo['acl_topo_id'] . "]");

--- a/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+++ b/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
@@ -107,10 +107,7 @@ $style = "one";
  * Fill a tab with a mutlidimensionnal Array we put in $tpl
  */
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $resources = $statement->fetchRow(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $resources['acl_res_id'] . "]");

--- a/www/include/views/virtualMetrics/listVirtualMetrics.php
+++ b/www/include/views/virtualMetrics/listVirtualMetrics.php
@@ -110,10 +110,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 $deftype = array(0 => "CDEF", 1 => "VDEF");
 $yesOrNo = array(null => "No", 0 => "No", 1 => "Yes");
 $elemArr = array();
-$form->createSecurityToken();
-$centreonToken = is_array($form->getElementValue('centreon_token')) ?
-    end($form->getElementValue('centreon_token')) :
-    $form->getElementValue('centreon_token');
+$centreonToken = createCSRFToken();
 
 for ($i = 0; $vmetric = $stmt->fetch(); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $vmetric['vmetric_id'] . "]");


### PR DESCRIPTION
## Description

Fix side effect of adding csrf token on listing pages forms 

On a list page : 
Select an item→ duplicate it using the quick action menu.
Select more action in the menu to be able to duplicate again (old bug)
Select the duplicated item
Duplicate it a second time using the quick action menu.
The second time, the item is not duplicated and the message related to the token of the form is displayed

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

On a list (ex: contact>contact/user)
Select an item→ duplicate it using the quick action menu.
Select more action in the menu to be able to duplicate again (old bug)
Select the duplicated item
Duplicate it a second time using the quick action menu.
The second time, the item should be duplicated without error message

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
