### PR TITLE
fix(conf/host) Preserves property values unchanged during a massive change

### DIFF
--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -1387,6 +1387,12 @@ function updateHost_MC($host_id = null)
         $ret["host_template_model_htm_id"] = $result["host_id"];
         $dbResult->closeCursor();
     }
+    // Remove all parameters that have an empty value in order to keep the host properties that have not been modified
+    foreach ($ret as $name => $value) {
+        if (is_string($value) && empty($value)) {
+            unset($ret[$name]);
+        }
+    }
 
     $bindParams = sanitizeFormHostParameters($ret);
     $rq = "UPDATE host SET ";


### PR DESCRIPTION
## Description

When performing a massive change on the check timeperiod, max check attempts, retry interval and check interval are reset to their default value. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
