### PR TITLE
Mon 6516 empty parameter in lua output broker conf

### DIFF
--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -967,7 +967,7 @@ class CentreonConfigCentreonBroker
      *
      * @param array $values
      * @param integer $key
-     * @return boolean
+     * @return boolean (false if no undefinex index found)
      */
     private function removeUnindexedLuaParameters(array &$values, int $key): bool
     {

--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -967,7 +967,7 @@ class CentreonConfigCentreonBroker
      *
      * @param array $values
      * @param integer $key
-     * @return boolean (false if no undefinex index found)
+     * @return boolean (false if no undefined index found)
      */
     private function removeUnindexedLuaParameters(array &$values, int $key): bool
     {

--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -842,7 +842,7 @@ class CentreonConfigCentreonBroker
         $keepLuaParameters = false;
         if ($values['output'] !== null) {
             foreach ($values['output'] as $key => $output) {
-                if ($output['type'] == 'lua') {
+                if ($output['type'] === 'lua') {
                     if ($this->removeUnindexedLuaParameters($values, $key)) {
                         $keepLuaParameters = true;
                     }
@@ -852,7 +852,7 @@ class CentreonConfigCentreonBroker
             // Clean the informations for this id
             $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
                 . (int) $id
-                . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua_parameter_%"' : '');
+                . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua\_parameter\_%"' : '');
             $this->db->query($query);
         }
 
@@ -909,7 +909,7 @@ class CentreonConfigCentreonBroker
                                         $explodedFieldname2 = explode('__', $fieldname2);
                                         if (
                                             isset($fieldtype[$explodedFieldname2[1]]) &&
-                                            $fieldtype[$explodedFieldname2[1]] == 'radio'
+                                            $fieldtype[$explodedFieldname2[1]] === 'radio'
                                         ) {
                                             $value2 = $value2[$explodedFieldname2[1]];
                                         }

--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
@@ -838,19 +839,20 @@ class CentreonConfigCentreonBroker
     public function updateCentreonBrokerInfos($id, $values)
     {
         // exclude multiple parameters load with broker js hook
-        $condition = '';
+        $keepLuaParameters = false;
         if ($values['output'] !== null) {
             foreach ($values['output'] as $key => $output) {
-                if (array_key_exists('lua_parameter__value_#index#', $output)) {
-                    $condition .= ' AND config_key NOT LIKE "lua_parameter_%"';
-                    unset($values['output'][$key]['lua_parameter__value_#index#']);
-                    unset($values['output'][$key]['lua_parameter__name_#index#']);
-                    unset($values['output'][$key]['lua_parameter__type_#index#']);
+                if ($output['type'] == 'lua') {
+                    if ($this->removeUnindexedLuaParameters($values, $key)) {
+                        $keepLuaParameters = true;
+                    }
+                    $this->removeEmptyLuaParameters($values, $key);
                 }
             }
-
             // Clean the informations for this id
-            $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = ' . (int)$id . $condition;
+            $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
+                . (int) $id
+                . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua_parameter_%"' : '');
             $this->db->query($query);
         }
 
@@ -905,8 +907,10 @@ class CentreonConfigCentreonBroker
                                 foreach ($value as $fieldname2 => $value2) {
                                     if (is_array($value2)) {
                                         $explodedFieldname2 = explode('__', $fieldname2);
-                                        if (isset($fieldtype[$explodedFieldname2[1]]) &&
-                                            $fieldtype[$explodedFieldname2[1]] == 'radio') {
+                                        if (
+                                            isset($fieldtype[$explodedFieldname2[1]]) &&
+                                            $fieldtype[$explodedFieldname2[1]] == 'radio'
+                                        ) {
                                             $value2 = $value2[$explodedFieldname2[1]];
                                         }
                                     }
@@ -956,6 +960,47 @@ class CentreonConfigCentreonBroker
         }
 
         return true;
+    }
+
+    /**
+     * unset lua parameters with undefined index
+     *
+     * @param array $values
+     * @param integer $key
+     * @return boolean
+     */
+    private function removeUnindexedLuaParameters(array &$values, int $key): bool
+    {
+        if (array_key_exists('lua_parameter__value_#index#', $values['output'][$key])) {
+            unset($values['output'][$key]['lua_parameter__value_#index#']);
+            unset($values['output'][$key]['lua_parameter__name_#index#']);
+            unset($values['output'][$key]['lua_parameter__type_#index#']);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * unset lua parameters with value and name empty
+     *
+     * @param array &$values modified parameter
+     * @param integer $key
+     */
+    private function removeEmptyLuaParameters(array &$values, int $key): void
+    {
+        $paramKeys = array_keys($values['output'][$key]);
+        $paramKeysIndexes = preg_filter('/lua_parameter__value_([0-9]*)/', '$1', $paramKeys ?? []);
+
+        foreach ($paramKeysIndexes as $index) {
+            if (
+                !$values['output'][$key]['lua_parameter__name_' . $index]
+                && !$values['output'][$key]['lua_parameter__value_' . $index]
+            ) {
+                unset($values['output'][$key]['lua_parameter__value_' . $index]);
+                unset($values['output'][$key]['lua_parameter__name_' . $index]);
+                unset($values['output'][$key]['lua_parameter__type_' . $index]);
+            }
+        }
     }
 
     /**
@@ -1494,10 +1539,10 @@ class CentreonConfigCentreonBroker
             }
             $row = $res->fetchRow();
             $elemStr = $this->getConfigFieldName(
-                    $configId,
-                    $configGroup,
-                    $row
-                ) . '__' . $info['parent_grp_id'] . '__' . $elemStr;
+                $configId,
+                $configGroup,
+                $row
+            ) . '__' . $info['parent_grp_id'] . '__' . $elemStr;
         }
         return $elemStr;
     }


### PR DESCRIPTION
## Description

I configure a stream connector as broker output from the wui.
Here is the configuration:

Name: Test
Path: /usr/share/centreon-broker/lua/test.lua
Selected filters: empty

Save the configuration.

Go back to the configuration of the streamconnector, you should see a new block at the bottom of the configuration containing:

Type: String
Name: empty
Value: empty

The bug is that even if you don't open the stream connector configuration, once you open the broker output configuration, this empty field is saved in DB and listed in the broker configuration when you export the configuration.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

A lua parameter should not be saved if its name and value are empty and therefore not be exported in broker configuration.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
