### PR TITLE
MON-11182-remove-old-broker-log-in-conf

### DIFF
--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -201,6 +201,7 @@ class CentreonConfigCentreonBroker
         }
         $query = "SELECT cb_tag_id, tagname
             FROM cb_tag
+            WHERE tagname <> 'logger'
             ORDER BY tagname";
         try {
             $res = $this->db->query($query);

--- a/www/class/config-generate-remote/Relations/BrokerInfo.php
+++ b/www/class/config-generate-remote/Relations/BrokerInfo.php
@@ -128,7 +128,8 @@ class BrokerInfo extends AbstractObject
             $this->stmtBrokerInfo = $this->backendInstance->db->prepare(
                 "SELECT *
                 FROM cfg_centreonbroker_info
-                WHERE config_id = :config_id"
+                WHERE config_id = :config_id
+                AND config_group <> 'logger'"
             );
         }
 

--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -152,6 +152,7 @@ class Broker extends AbstractObjectJSON
               $this->attributes_select_parameters
             FROM cfg_centreonbroker_info
             WHERE config_id = :config_id
+            AND config_group <> 'logger'
             ORDER BY config_group, config_group_id
             ");
         }


### PR DESCRIPTION
## Description

The deprecated logger tab  in broker configuration must disappear
The configuration export process should ignore the related parameters

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Test case 1
As a Centreon user allowed to configure broker
Open the central broker configuration menu
_Expected result_: The deprecated tab must not appear

- Test case 2
Without performing any modifications on the form (and without saving it!) 
Export the central/poller configuration  and systemctl restart cbd centengine
_Expected result_: If a logger configuration existed previously, no items from this configuration should appear in the exported config files, and no warnings should appear in the broker log.

- Test case 3
Open the central broker configuration menu
Save the form
Open the broker module configuration menu
Save the form
Export the central/poller configuration  and systemctl restart cbd centengine
_Expected result:_ If a logger configuration existed previously, no items from this configuration should appear in the exported config files, and no warnings should appear in the broker log.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
