### PR TITLE
MON-11174-reorder-button-poller-conf

### DIFF
--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -50,11 +50,6 @@
         <tr class="ToolbarTR">
             <td>
                 {if !$isRemote}
-                    {if $is_admin == 1 || $can_generate == 1}
-                        <button type="button" class="{$exportBtn.class}" name="{$exportBtn.name}" onClick="{$exportBtn.onClickAction}">
-                            <span class="ui-icon ui-icon-white {$exportBtn.iconClass}"></span> {$exportBtn.text}
-                        </button>
-                    {/if}
                     {if $mode_access == 'w'}
                         <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" target="_top">
                             <span class="ui-icon ui-icon-white {$wizardAddBtn.iconClass}"></span> {$wizardAddBtn.text}
@@ -62,6 +57,14 @@
                         <a href="{$addBtn.link}" class="{$addBtn.class}">
                             <span class="ui-icon ui-icon-white {$addBtn.iconClass}"></span> {$addBtn.text}
                         </a>
+                    {/if}
+                    {if $is_admin == 1 || $can_generate == 1}
+                         <button type="button" class="{$exportBtn.class}" name="{$exportBtn.name}"
+                             onClick="{$exportBtn.onClickAction}">
+                             <span class="ui-icon ui-icon-white {$exportBtn.iconClass}"></span> {$exportBtn.text}
+                         </button>
+                    {/if}
+                    {if $mode_access == 'w'}
                         <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
                             <span class="ui-icon ui-icon-white {$duplicateBtn.iconClass}"></span> {$duplicateBtn.text}
                         </button>


### PR DESCRIPTION
## Description
Changing buttons order from this:

![image](https://user-images.githubusercontent.com/88387848/136587822-7988e5d9-649a-47d1-800a-0bf01fa0fd78.png)

to this:

![image](https://user-images.githubusercontent.com/88387848/136587906-99cb31a3-31f4-41f2-990b-956669791d29.png)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
