### PR TITLE
enh(ci): deliver api doc by version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -366,6 +366,20 @@ try {
     }
   }
 
+  if ((env.BUILD == 'REFERENCE')) {
+    stage('Delivery API documentation') {
+      node {
+        checkoutCentreonBuild()    
+        unstash 'tar-sources'
+        unstash 'api-doc'
+        sh "./centreon-build/jobs/web/${serie}/mon-web-delivery.sh"
+      }
+      if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+        error('Delivery stage failure');
+      }
+    }
+  }
+  
   // TODO : add canary management in centreon-build
   /*if ((env.BUILD == 'CI')) {
     stage('Docker packaging with canary rpms') {


### PR DESCRIPTION
## Description

In order to deliver api doc by version, we need to implement a REFERENCE branch delivery.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)