### PR TITLE
fix(ext/manager): Align tiles buttons & blinking images popup

### DIFF
--- a/www/front_src/src/Extensions/ExtensionDetailsPopup/index.js
+++ b/www/front_src/src/Extensions/ExtensionDetailsPopup/index.js
@@ -54,7 +54,7 @@ class ExtensionDetailPopup extends React.Component {
         onConfirm={onCloseClicked}
       >
         <Grid container direction="column" spacing={2} style={{ width: 520 }}>
-          <Grid item>
+          <Grid item style={{ height: 300 }}>
             <Responsive.ParentSize>
               {({ width }) =>
                 loading ? (
@@ -73,6 +73,8 @@ class ExtensionDetailPopup extends React.Component {
                 )
               }
             </Responsive.ParentSize>
+          </Grid>
+          <Grid item>
             {modalDetails.version.installed && modalDetails.version.outdated ? (
               <IconButton
                 onClick={() => {

--- a/www/front_src/src/Extensions/ExtensionsHolder/index.js
+++ b/www/front_src/src/Extensions/ExtensionsHolder/index.js
@@ -185,6 +185,7 @@ class ExtensionsHolder extends React.Component {
 
                   <Paper
                     square
+                    elevation={0}
                     style={{
                       alignItems: 'center',
                       backgroundColor: licenseInfo?.color || '#FFFFFF',

--- a/www/front_src/src/Extensions/ExtensionsHolder/index.js
+++ b/www/front_src/src/Extensions/ExtensionsHolder/index.js
@@ -115,10 +115,8 @@ class ExtensionsHolder extends React.Component {
                   style={{ display: 'grid', height: '100%' }}
                   variant="outlined"
                 >
-                  <div style={{ height: 10 }}>
-                    {isLoading && <LinearProgress />}
-                  </div>
-                  <CardContent>
+                  {isLoading && <LinearProgress />}
+                  <CardContent style={{ padding: '10px' }}>
                     <Typography style={{ fontWeight: 'bold' }} variant="body1">
                       {this.parseDescription(entity.description)}
                     </Typography>
@@ -126,7 +124,7 @@ class ExtensionsHolder extends React.Component {
                       {`by ${entity.label}`}
                     </Typography>
                   </CardContent>
-                  <CardActions>
+                  <CardActions style={{ justifyContent: 'center' }}>
                     {entity.version.installed ? (
                       <Chip
                         avatar={
@@ -185,23 +183,23 @@ class ExtensionsHolder extends React.Component {
                     )}
                   </CardActions>
 
-                  {licenseInfo && (
-                    <Paper
-                      square
-                      style={{
-                        alignItems: 'center',
-                        backgroundColor: licenseInfo.color,
-                        cursor: 'pointer',
-                        display: 'flex',
-                        justifyContent: 'center',
-                      }}
-                      variant="outlined"
-                    >
+                  <Paper
+                    square
+                    style={{
+                      alignItems: 'center',
+                      backgroundColor: licenseInfo?.color || '#FFFFFF',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      minHeight: '20px',
+                    }}
+                  >
+                    {licenseInfo?.label && (
                       <Typography style={{ color: '#FFFFFF' }} variant="body2">
                         {licenseInfo.label}
                       </Typography>
-                    </Paper>
-                  )}
+                    )}
+                  </Paper>
                 </Card>
               </Grid>
             );


### PR DESCRIPTION
Now,
The buttons within the extension tiles are centered horizontally
The extension details popup remains stable when swapping the preview images

Refs: MON-11176

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
