### PR TITLE
enh(UI): Do not trigger search when selecting list items

### DIFF
--- a/www/front_src/src/Resources/Filter/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/index.test.tsx
@@ -10,7 +10,6 @@ import {
 } from '@testing-library/react';
 import { Simulate } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
-import { keyboardState } from '@testing-library/user-event/dist/keyboard/types';
 
 import { setUrlQueryParameters, getUrlQueryParameters } from '@centreon/ui';
 
@@ -446,7 +445,12 @@ describe(Filter, () => {
 
   it.each([
     ['tab', (): void => userEvent.tab()],
-    ['enter', (): keyboardState => userEvent.keyboard('{Enter}')],
+    [
+      'enter',
+      (): void => {
+        userEvent.keyboard('{Enter}');
+      },
+    ],
   ])(
     'accepts the selected autocomplete suggestion when the beginning of a dynamic criteria is input and the %p key is pressed',
     async (_, keyboardAction) => {

--- a/www/front_src/src/Resources/Filter/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/index.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@testing-library/react';
 import { Simulate } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
+import { keyboardState } from '@testing-library/user-event/dist/keyboard/types';
 
 import { setUrlQueryParameters, getUrlQueryParameters } from '@centreon/ui';
 
@@ -443,80 +444,86 @@ describe(Filter, () => {
     },
   );
 
-  it('accepts the selected autocomplete suggestion when the beginning of a dynamic criteria is input and the tab key is pressed', async () => {
-    dynamicCriteriaRequests();
-    const { getByPlaceholderText } = renderFilter();
+  it.each([
+    ['tab', (): void => userEvent.tab()],
+    ['enter', (): keyboardState => userEvent.keyboard('{Enter}')],
+  ])(
+    'accepts the selected autocomplete suggestion when the beginning of a dynamic criteria is input and the %p key is pressed',
+    async (_, keyboardAction) => {
+      dynamicCriteriaRequests();
+      const { getByPlaceholderText } = renderFilter();
 
-    await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
-    });
+      await waitFor(() => {
+        expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+      });
 
-    userEvent.type(
-      getByPlaceholderText(labelSearch),
-      '{selectall}{backspace}host',
-    );
-
-    userEvent.tab();
-
-    expect(getByPlaceholderText(labelSearch)).toHaveValue('host_group:');
-
-    userEvent.type(getByPlaceholderText(labelSearch), 'ESX');
-
-    await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        buildHostGroupsEndpoint({
-          limit: 5,
-          page: 1,
-          search: {
-            conditions: [],
-            regex: {
-              fields: ['name'],
-              value: 'ESX',
-            },
-          },
-        }),
-        cancelTokenRequestParam,
+      userEvent.type(
+        getByPlaceholderText(labelSearch),
+        '{selectall}{backspace}host',
       );
-    });
 
-    userEvent.tab();
+      keyboardAction();
 
-    expect(getByPlaceholderText(labelSearch)).toHaveValue(
-      'host_group:ESX-Servers',
-    );
+      expect(getByPlaceholderText(labelSearch)).toHaveValue('host_group:');
 
-    userEvent.type(getByPlaceholderText(labelSearch), ',');
+      userEvent.type(getByPlaceholderText(labelSearch), 'ESX');
 
-    await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        buildHostGroupsEndpoint({
-          limit: 5,
-          page: 1,
-          search: {
-            conditions: [
-              {
-                field: 'name',
-                values: { $ni: ['ESX-Servers'] },
+      await waitFor(() => {
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+          buildHostGroupsEndpoint({
+            limit: 5,
+            page: 1,
+            search: {
+              conditions: [],
+              regex: {
+                fields: ['name'],
+                value: 'ESX',
               },
-            ],
-            regex: {
-              fields: ['name'],
-              value: '',
             },
-          },
-        }),
-        cancelTokenRequestParam,
+          }),
+          cancelTokenRequestParam,
+        );
+      });
+
+      keyboardAction();
+
+      expect(getByPlaceholderText(labelSearch)).toHaveValue(
+        'host_group:ESX-Servers',
       );
-    });
 
-    userEvent.keyboard('{ArrowDown}');
+      userEvent.type(getByPlaceholderText(labelSearch), ',');
 
-    userEvent.tab();
+      await waitFor(() => {
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+          buildHostGroupsEndpoint({
+            limit: 5,
+            page: 1,
+            search: {
+              conditions: [
+                {
+                  field: 'name',
+                  values: { $ni: ['ESX-Servers'] },
+                },
+              ],
+              regex: {
+                fields: ['name'],
+                value: '',
+              },
+            },
+          }),
+          cancelTokenRequestParam,
+        );
+      });
 
-    expect(getByPlaceholderText(labelSearch)).toHaveValue(
-      'host_group:ESX-Servers,Firewall',
-    );
-  });
+      userEvent.keyboard('{ArrowDown}');
+
+      keyboardAction();
+
+      expect(getByPlaceholderText(labelSearch)).toHaveValue(
+        'host_group:ESX-Servers,Firewall',
+      );
+    },
+  );
 
   it('accepts the selected autocomplete suggestion when the beginning of a criteria is input and the tab key is pressed', async () => {
     const { getByPlaceholderText } = renderFilter();

--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -389,11 +389,18 @@ const Filter = (): JSX.Element => {
 
     if (escapeKeyPressed) {
       closeSuggestionPopover();
+      setAutoCompleteSuggestions([]);
 
       return;
     }
 
-    if (tabKeyPressed && hasAutocompleteSuggestions) {
+    const isSearchFieldFocusedAndEnterKeyPressed =
+      enterKeyPressed && isSearchFieldFocus;
+
+    const canAcceptSuggestion =
+      tabKeyPressed || isSearchFieldFocusedAndEnterKeyPressed;
+
+    if (canAcceptSuggestion && hasAutocompleteSuggestions) {
       event.preventDefault();
       acceptAutocompleteSuggestionAtIndex(selectedSuggestionIndex);
 


### PR DESCRIPTION
## Description

This allows to accept a suggestion by pressing "Enter" key
https://user-images.githubusercontent.com/12515407/136790936-67dc3821-5974-4aea-b7e2-fff3f5ff7253.mov

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- On Resources Status, click on the search bar
- Type "ty"
- Press the "Enter" key to accept "type:"
- -> "type:" is in the search input
- Press the "Enter" key again
- -> The first suggestion is accepted in the search input

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
