### PR TITLE
fix(customViews): list ldap groups when concerned by shared views

### DIFF
--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -2455,6 +2455,7 @@ class CentreonACL
      * @access public
      * @param array $options
      * @param boolean $localOnly Indicates if only local contactgroups should be searched
+     * @return void
      */
     public function getContactGroupAclConf(array $options = [], bool $localOnly = true)
     {

--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -2454,9 +2454,9 @@ class CentreonACL
      *
      * @access public
      * @param array $options
-     * @return void
+     * @param boolean $localOnly Indicates if only local contactgroups should be searched
      */
-    public function getContactGroupAclConf($options = array(), $localOnly = true)
+    public function getContactGroupAclConf(array $options = [], bool $localOnly = true)
     {
         $request = $this->constructRequest($options, true);
 

--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -2455,7 +2455,7 @@ class CentreonACL
      * @access public
      * @param array $options
      * @param boolean $localOnly Indicates if only local contactgroups should be searched
-     * @return void
+     * @return mixed[]
      */
     public function getContactGroupAclConf(array $options = [], bool $localOnly = true)
     {

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -1129,7 +1129,8 @@ class CentreonCustomView
                     ],
                     'keys' => ['cg_id'],
                     'order' => ['cg_id']
-                ]
+                ],
+                false
             );
 
             $allowedGroupIds = '';


### PR DESCRIPTION
This PR intends to not only list local contact groups but also ldap groups in the shared views information.
This can be achieved by providing to the `getContactGroupAclConf` method the second boolean argument `$localOnly` to false.

Here is the signature of the `getContactGroupAclConf` method

`public function getContactGroupAclConf(array $options = [], bool $localOnly = true)`

See Jira ticket for details on the issue

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
