### PR TITLE
fix(UI): Fix menu with a scrollbar while expanded

### DIFF
--- a/www/front_src/src/Navigation/Sidebar/sidebar.scss
+++ b/www/front_src/src/Navigation/Sidebar/sidebar.scss
@@ -11,7 +11,7 @@
   }
   &.active {
     min-width: 160px;
-    max-width: 160px;
+    max-width: 180px;
     .sidebar-toggle-wrap {
       width: 160px;
     }


### PR DESCRIPTION
## Description

When the menu is expanded and it contains a very long content, this adds the scrollbar width to the menu.
![Screenshot 2021-10-13 at 09 47 47](https://user-images.githubusercontent.com/12515407/137090345-bd03f70a-e393-4c75-be31-235db0f6a9df.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- With the menu, go to Administration > Parameters > Centreon UI
- Expand the menu
- -> The submenu is no longer wider than the menu (such as the image above)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
