### PR TITLE
fix(UI): Add condition for display timezone tile

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -118,7 +118,7 @@ const getDetailCardLines = ({
     },
     {
       line: <DetailsLine line={details.timezone} />,
-      shouldBeDisplayed: !isNil(details.timezone),
+      shouldBeDisplayed: !isNil(details.timezone) && !isEmpty(details.timezone),
       title: labelTimezone,
     },
     {


### PR DESCRIPTION
## Description

In Resources status, when  is empty Timezone tile is still displayed.

**Fixes** # (issue)

 When Timezone tile is empty and she is not displayed

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go in ressource status , click on host , then in the details panel timezone's tile is not displayed if timezone is not set for a host or service.

