### PR TITLE
fix(UI): Fix colors for host status unreachable

### DIFF
--- a/www/front_src/src/Header/RessourceStatusCounter/Host/index.tsx
+++ b/www/front_src/src/Header/RessourceStatusCounter/Host/index.tsx
@@ -133,7 +133,7 @@ const HostMenu = (): JSX.Element => {
             >
               <StatusCounter
                 count={data.unreachable.unhandled}
-                severityCode={SeverityCode.Medium}
+                severityCode={SeverityCode.Low}
               />
             </Link>
             <Link

--- a/www/front_src/src/Header/RessourceStatusCounter/Host/index.tsx
+++ b/www/front_src/src/Header/RessourceStatusCounter/Host/index.tsx
@@ -140,7 +140,7 @@ const HostMenu = (): JSX.Element => {
               className={classnames(classes.link, styles['wrap-middle-icon'])}
               to={upHostsLink}
             >
-              <StatusCounter count={data.ok} severityCode={SeverityCode.Low} />
+              <StatusCounter count={data.ok} severityCode={SeverityCode.Ok} />
             </Link>
             <IconToggleSubmenu
               iconType="arrow"


### PR DESCRIPTION
## Description

fix colors for host status unreachable

**Fixes** # (issue)

fix colors for host status unreachable 
![Capture d’écran 2021-10-14 à 11 02 38](https://user-images.githubusercontent.com/16045498/137286588-118c32c6-07e0-4a2f-9b7a-e7f8eda232f7.png)



## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go on ressource status and submit UNREACHABLE status for a host and take a look on top counter

