### PR TITLE
enh(UI): Make the duration as second sorting criteria

### DIFF
--- a/www/front_src/src/Resources/Filter/Criterias/default.ts
+++ b/www/front_src/src/Resources/Filter/Criterias/default.ts
@@ -1,5 +1,7 @@
 import { SelectEntry } from '@centreon/ui';
 
+import { SortOrder } from '../../models';
+
 import { Criteria } from './models';
 
 interface DefaultCriteriaValues {
@@ -12,7 +14,7 @@ interface DefaultCriteriaValues {
 }
 
 const defaultSortField = 'status_severity_code';
-const defaultSortOrder = 'asc';
+const defaultSortOrder = SortOrder.asc;
 
 const getDefaultCriterias = (
   {

--- a/www/front_src/src/Resources/Filter/api/decoders.ts
+++ b/www/front_src/src/Resources/Filter/api/decoders.ts
@@ -38,11 +38,8 @@ const entityDecoder = JsonDecoder.object<Filter>(
                 JsonDecoder.tuple(
                   [
                     JsonDecoder.string,
-                    JsonDecoder.oneOf<'asc' | 'desc'>(
-                      [
-                        JsonDecoder.isExactly('asc'),
-                        JsonDecoder.isExactly('desc'),
-                      ],
+                    JsonDecoder.enumeration<SortOrder>(
+                      SortOrder,
                       'FilterCriteriaSortOrder',
                     ),
                   ],

--- a/www/front_src/src/Resources/Listing/index.test.tsx
+++ b/www/front_src/src/Resources/Listing/index.test.tsx
@@ -26,6 +26,8 @@ import {
   find,
   isNil,
   last,
+  equals,
+  not,
 } from 'ramda';
 import userEvent from '@testing-library/user-event';
 
@@ -38,7 +40,11 @@ import useActions from '../Actions/useActions';
 import useDetails from '../Details/useDetails';
 import useFilter from '../Filter/useFilter';
 import { labelInDowntime, labelAcknowledged } from '../translatedLabels';
-import { getListingEndpoint, cancelTokenRequestParam } from '../testUtils';
+import {
+  getListingEndpoint,
+  cancelTokenRequestParam,
+  secondSortCriteria,
+} from '../testUtils';
 import { unhandledProblemsFilter } from '../Filter/models';
 
 import useListing from './useListing';
@@ -237,7 +243,11 @@ describe(Listing, () => {
         await waitFor(() => {
           expect(mockedAxios.get).toHaveBeenLastCalledWith(
             getListingEndpoint({
-              sort: { [sortBy]: 'desc' },
+              sort: {
+                [sortBy]: 'desc',
+                ...(not(equals(sortBy, 'last_status_change')) &&
+                  secondSortCriteria),
+              },
             }),
             cancelTokenRequestParam,
           );
@@ -248,7 +258,11 @@ describe(Listing, () => {
         await waitFor(() =>
           expect(mockedAxios.get).toHaveBeenLastCalledWith(
             getListingEndpoint({
-              sort: { [sortBy]: 'asc' },
+              sort: {
+                [sortBy]: 'asc',
+                ...(not(equals(sortBy, 'last_status_change')) &&
+                  secondSortCriteria),
+              },
             }),
             cancelTokenRequestParam,
           ),

--- a/www/front_src/src/Resources/Listing/index.test.tsx
+++ b/www/front_src/src/Resources/Listing/index.test.tsx
@@ -43,7 +43,7 @@ import { labelInDowntime, labelAcknowledged } from '../translatedLabels';
 import {
   getListingEndpoint,
   cancelTokenRequestParam,
-  secondSortCriteria,
+  defaultSecondSortCriteria,
 } from '../testUtils';
 import { unhandledProblemsFilter } from '../Filter/models';
 
@@ -240,13 +240,16 @@ describe(Listing, () => {
 
         userEvent.click(getByLabelText(`Column ${label}`));
 
+        const secondSortCriteria =
+          not(equals(sortField, 'last_status_change')) &&
+          defaultSecondSortCriteria;
+
         await waitFor(() => {
           expect(mockedAxios.get).toHaveBeenLastCalledWith(
             getListingEndpoint({
               sort: {
                 [sortBy]: 'desc',
-                ...(not(equals(sortBy, 'last_status_change')) &&
-                  secondSortCriteria),
+                ...secondSortCriteria,
               },
             }),
             cancelTokenRequestParam,
@@ -260,8 +263,7 @@ describe(Listing, () => {
             getListingEndpoint({
               sort: {
                 [sortBy]: 'asc',
-                ...(not(equals(sortBy, 'last_status_change')) &&
-                  secondSortCriteria),
+                ...secondSortCriteria,
               },
             }),
             cancelTokenRequestParam,

--- a/www/front_src/src/Resources/Listing/models.ts
+++ b/www/front_src/src/Resources/Listing/models.ts
@@ -1,1 +1,0 @@
-export type SortOrder = 'asc' | 'desc';

--- a/www/front_src/src/Resources/Listing/useLoadResources/index.ts
+++ b/www/front_src/src/Resources/Listing/useLoadResources/index.ts
@@ -14,6 +14,7 @@ export interface LoadResources {
 }
 
 const secondSortField = 'last_status_change';
+const defaultSecondSortCriteria = { [secondSortField]: SortOrder.desc };
 
 const useLoadResources = (): LoadResources => {
   const {
@@ -46,11 +47,12 @@ const useLoadResources = (): LoadResources => {
 
     const [sortField, sortOrder] = sort as [string, SortOrder];
 
-    const secondSortCriteria = { [secondSortField]: SortOrder.desc };
+    const secondSortCriteria =
+      not(equals(sortField, secondSortField)) && defaultSecondSortCriteria;
 
     return {
       [sortField]: sortOrder,
-      ...(not(equals(sortField, secondSortField)) && secondSortCriteria),
+      ...secondSortCriteria,
     };
   };
 

--- a/www/front_src/src/Resources/Listing/useLoadResources/index.ts
+++ b/www/front_src/src/Resources/Listing/useLoadResources/index.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { isNil, prop } from 'ramda';
+import { equals, isNil, not, prop } from 'ramda';
 
 import { SelectEntry } from '@centreon/ui';
 import { useUserContext } from '@centreon/ui-context';
@@ -12,6 +12,8 @@ import { searchableFields } from '../../Filter/Criterias/searchQueryLanguage';
 export interface LoadResources {
   initAutorefreshAndLoad: () => void;
 }
+
+const secondSortField = 'last_status_change';
 
 const useLoadResources = (): LoadResources => {
   const {
@@ -44,7 +46,12 @@ const useLoadResources = (): LoadResources => {
 
     const [sortField, sortOrder] = sort as [string, SortOrder];
 
-    return { [sortField]: sortOrder };
+    const secondSortCriteria = { [secondSortField]: SortOrder.desc };
+
+    return {
+      [sortField]: sortOrder,
+      ...(not(equals(sortField, secondSortField)) && secondSortCriteria),
+    };
   };
 
   const load = (): void => {

--- a/www/front_src/src/Resources/models.ts
+++ b/www/front_src/src/Resources/models.ts
@@ -96,4 +96,7 @@ export interface ResourceLinks {
 
 export type TranslationType = (label: string) => string;
 
-export type SortOrder = 'asc' | 'desc';
+export enum SortOrder {
+  asc = 'asc',
+  desc = 'desc',
+}

--- a/www/front_src/src/Resources/testUtils/index.ts
+++ b/www/front_src/src/Resources/testUtils/index.ts
@@ -23,14 +23,14 @@ const defaultStatuses = ['WARNING', 'DOWN', 'CRITICAL', 'UNKNOWN'];
 const defaultResourceTypes = [];
 const defaultStates = ['unhandled_problems'];
 
-const secondSortCriteria = { last_status_change: SortOrder.desc };
+const defaultSecondSortCriteria = { last_status_change: SortOrder.desc };
 
 const getListingEndpoint = ({
   page = 1,
   limit = 30,
   sort = {
     status_severity_code: SortOrder.asc,
-    ...secondSortCriteria,
+    ...defaultSecondSortCriteria,
   },
   statuses = defaultStatuses,
   states = defaultStates,
@@ -100,5 +100,5 @@ export {
   searchableFields,
   getCriteriaValue,
   getFilterWithUpdatedCriteria,
-  secondSortCriteria,
+  defaultSecondSortCriteria,
 };

--- a/www/front_src/src/Resources/testUtils/index.ts
+++ b/www/front_src/src/Resources/testUtils/index.ts
@@ -4,6 +4,7 @@ import { CriteriaValue } from '../Filter/Criterias/models';
 import { searchableFields } from '../Filter/Criterias/searchQueryLanguage';
 import { Filter } from '../Filter/models';
 import { buildResourcesEndpoint } from '../Listing/api/endpoint';
+import { SortOrder } from '../models';
 
 interface EndpointParams {
   hostGroups?: Array<string>;
@@ -22,10 +23,15 @@ const defaultStatuses = ['WARNING', 'DOWN', 'CRITICAL', 'UNKNOWN'];
 const defaultResourceTypes = [];
 const defaultStates = ['unhandled_problems'];
 
+const secondSortCriteria = { last_status_change: SortOrder.desc };
+
 const getListingEndpoint = ({
   page = 1,
   limit = 30,
-  sort = { status_severity_code: 'asc' },
+  sort = {
+    status_severity_code: SortOrder.asc,
+    ...secondSortCriteria,
+  },
   statuses = defaultStatuses,
   states = defaultStates,
   resourceTypes = defaultResourceTypes,
@@ -94,4 +100,5 @@ export {
   searchableFields,
   getCriteriaValue,
   getFilterWithUpdatedCriteria,
+  secondSortCriteria,
 };


### PR DESCRIPTION
## Description

This adds the "duration" column as second sorting criteria

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Have at least 2 resources with the same status
- Sort resources by status
- -> Within the same status, the resources are also sorted by duration from the newest to the oldest

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
