### PR TITLE
fix(UI): Fix details tiles local storage

### DIFF
--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -1506,8 +1506,8 @@ describe(Details, () => {
     expect(getByText(labelMonitoringServer)).toBeInTheDocument();
     expect(getByText(labelStatusInformation)).toBeInTheDocument();
 
-    expect(queryByText(labelLastCheck)).not.toBeInTheDocument();
-    expect(queryByText(labelCommand)).not.toBeInTheDocument();
+    expect(queryByText(labelLastCheck)).toBeInTheDocument();
+    expect(queryByText(labelCommand)).toBeInTheDocument();
   });
 
   it('queries the performance graphs with the time period selected in the "Timeline" tab when the "Graph" tab is selected and the "Timeline" tab was selected', async () => {

--- a/www/front_src/src/Resources/Details/tabs/Details/SortableCards/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/SortableCards/index.tsx
@@ -14,6 +14,8 @@ import {
   pluck,
   propEq,
   remove,
+  difference,
+  uniq,
 } from 'ramda';
 
 import { Box, Grid } from '@material-ui/core';
@@ -39,6 +41,23 @@ interface Props {
   details: ResourceDetails;
   panelWidth: number;
 }
+
+interface MergeDefaultAndStoredCardsProps {
+  defaultCards: Array<string>;
+  storedCards: Array<string>;
+}
+
+const mergeDefaultAndStoredCards = ({
+  defaultCards,
+  storedCards,
+}: MergeDefaultAndStoredCardsProps): Array<string> => {
+  const differenceBetweenDefaultAndStoredCards = difference(
+    defaultCards,
+    storedCards,
+  );
+
+  return uniq([...storedCards, ...differenceBetweenDefaultAndStoredCards]);
+};
 
 const SortableCards = ({ panelWidth, details }: Props): JSX.Element => {
   const { toDateTime } = useLocaleDateTimeFormat();
@@ -69,9 +88,14 @@ const SortableCards = ({ panelWidth, details }: Props): JSX.Element => {
     toDateTime,
   });
 
+  const allDetailsCardsTitle = pluck('title', allDetailsCards);
+
   const defaultDetailsCardsLayout = isEmpty(storedDetailsCards)
-    ? pluck('title', allDetailsCards)
-    : storedDetailsCards;
+    ? allDetailsCardsTitle
+    : mergeDefaultAndStoredCards({
+        defaultCards: allDetailsCardsTitle,
+        storedCards: storedDetailsCards,
+      });
 
   const cards = map<string, CardsLayout>(
     (title) => ({


### PR DESCRIPTION
## Description

This display displayable cards although there are some tiles in the local storage
![Screenshot 2021-10-15 at 16 32 05](https://user-images.githubusercontent.com/12515407/137505921-7433620c-f816-46f6-9113-8d157d75e0ff.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Open the resource details
- Close the panel
- Open your browser’s console
- Select the “Application” tab
- Open your local storage
- Change the value of the key “centreon-resource-status-details-card-21.10” to ["Status information"]
- Open a resource details panel
- -> All the corresponding tiles should be displayed

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
