### PR TITLE
fix(UI): Fix the double click on the menu

### DIFF
--- a/www/front_src/src/Navigation/Sidebar/Menu/index.js
+++ b/www/front_src/src/Navigation/Sidebar/Menu/index.js
@@ -14,6 +14,7 @@ import React, { Component } from 'react';
 
 import clsx from 'clsx';
 import { Link as RouterLink } from 'react-router-dom';
+import { withRouter } from 'react-router';
 
 import Link from '@material-ui/core/Link';
 import { Typography, styled } from '@material-ui/core';
@@ -102,7 +103,7 @@ class NavigationMenu extends Component {
   };
 
   render() {
-    const { navigationData, sidebarActive, reactRoutes } = this.props;
+    const { navigationData, sidebarActive, reactRoutes, history } = this.props;
     const {
       activeSecondLevel,
       doubleClickedLevel,
@@ -183,15 +184,14 @@ class NavigationMenu extends Component {
                       e.preventDefault();
                     }
                   }}
-                  onDoubleClick={(e) => {
-                    const target = e.target;
+                  onDoubleClick={() => {
                     this.setState(
                       {
                         doubleClickedLevel: firstLevel,
                         hrefOfIframe: false,
                       },
                       () => {
-                        target.click();
+                        history.push(this.getUrlFromEntry(firstLevel));
                       },
                     );
                   }}
@@ -401,4 +401,4 @@ class NavigationMenu extends Component {
   }
 }
 
-export default NavigationMenu;
+export default withRouter(NavigationMenu);


### PR DESCRIPTION
## Description

This fixes the double click on the menu

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Double click on the "Home" icon
- -> You are redirected to the custom Views
- Double click on the "Monitoring" icon
- -> You are redirected to the Resource Status
- Double click on the "Reporting"
- -> You are redirected to "Dashboard Hosts"
- Double click on the "Configuration" icon
- -> You are redirected to "Configuration Hosts"
- Double click on the "Administration"
- -> You are redirected to "Centreon UI" page

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
