### PR TITLE
fix(UI): Add css style on class container to display correctly all tiles

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles((theme) => ({
   },
   container: {
     height: '100%',
+    overflow: 'hidden',
   },
   title: {
     display: 'flex',


### PR DESCRIPTION
## Description

Add css style on class container to display correctly all tiles because for now tiles are pile up and/or are outside column models.
<img width="549" alt="Capture d’écran 2021-10-15 à 17 43 30" src="https://user-images.githubusercontent.com/16045498/137515782-9e3d6100-3b60-4bb2-b87e-28b2daeb44a7.png">



**Fixes** # (issue)

Add css style on class container to display correctly all tiles

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie


- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go on ressource status, and select a host for sample. If you set a long alias , tile is displayed correctly  and no overflow and do not leave the columns template