### PR TITLE
fix(sec): remove odd characters in gpg check script

### DIFF
--- a/check-centreon-gpg-key.sh
+++ b/check-centreon-gpg-key.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
-​
+
 export LANG=C
-​
+
 AUTO=0
 if [ $# -eq 1 ]; then
   if [ $1 = "-auto" ]; then
     AUTO=1
   fi
 fi
-​
+
 USE_SUDO=""
 if [ ${EUID} -ne 0 ]; then
   USE_SUDO="sudo "
 fi
-​
+
 OLDKEY_NAME="gpg-pubkey-8a7652bc-4cb6f1f6"
 OLDKEY_ID="1024D/8A7652BC"
-​
+
 NEWKEY_NAME="gpg-pubkey-3fc49c1b-6166eb52"
-​
+
 rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep -q "${OLDKEY_NAME}"
-​
+
 if [ $? -eq 0 ]; then
   if [ ${AUTO} -eq 0 ]; then
     echo "
   The old key is in your RPM database, you should remove it.
   You can remove it by running this command:
-​
+
     sudo rpm -e ${OLDKEY_NAME}
-​
+
   Then restart this script.
   "
     exit 1
@@ -41,16 +41,16 @@ if [ $? -eq 0 ]; then
     fi
   fi
 fi
-​
+
 rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep -q "${NEWKEY_NAME}"
 if [ $? -ne 0 ]; then
   if [ ${AUTO} -eq 0 ]; then
     echo "
   The new key is not in your RPM database, you should add it.
   You can add it by running this command:
-​
+
     sudo rpm --import https://yum-gpg.centreon.com/RPM-GPG-KEY-CES
-​
+
   Then restart this script.
   "
     exit 1
@@ -63,7 +63,7 @@ if [ $? -ne 0 ]; then
     fi
   fi
 fi
-​
+
 for key in /etc/pki/rpm-gpg/*
 do
   gpg $key | grep -q "pub  $OLDKEY_ID"
@@ -72,9 +72,9 @@ do
       echo "
   The old key is in your system keys, you should remove it: $key
   Upgrading the centreon-release package will remove it for you:
-​
+
     sudo yum update centreon*release
-​
+
   Then restart this script.
   "
       exit 1
@@ -88,5 +88,5 @@ do
     fi
   fi
 done
-​
+
 echo "The new key is correctly imported."


### PR DESCRIPTION
## Description

Odd characters are in empty lines of the script.
Which causes it to fail.
