### PR TITLE
enh(Resource-status/Filter): Fix Filter select width

### DIFF
--- a/www/front_src/src/Resources/Filter/FilterLoadingSkeleton.tsx
+++ b/www/front_src/src/Resources/Filter/FilterLoadingSkeleton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Skeleton } from '@material-ui/lab';
 
 const FilterLoadingSkeleton = (): JSX.Element => {
-  return <Skeleton height={33} style={{ transform: 'none' }} width={200} />;
+  return <Skeleton height={33} style={{ transform: 'none' }} width={175} />;
 };
 
 export default FilterLoadingSkeleton;

--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -79,7 +79,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'grid',
     gridAutoFlow: 'column',
     gridGap: theme.spacing(1),
-    gridTemplateColumns: 'auto auto auto 1fr',
+    gridTemplateColumns: 'auto 175px auto 1fr',
     width: '100%',
   },
   loader: { display: 'flex', justifyContent: 'center' },


### PR DESCRIPTION
## Description

This sets a fix width to the Filter select in order to avoid taking too much space:

![fix-select-size](https://user-images.githubusercontent.com/8367233/137768209-1f661a5d-e65a-4b94-8fad-af5cd0d89163.gif)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.10.x (master)