### PR TITLE
Mon 4783 show only started downtimes

### DIFF
--- a/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+++ b/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
@@ -98,6 +98,7 @@ if (false === $svcId) {
         WHERE host_id = :hostId
         AND type = 2
         AND cancelled = 0
+        AND UNIX_TIMESTAMP(NOW()) >= actual_start_time
         AND end_time > UNIX_TIMESTAMP(NOW())
         ORDER BY actual_start_time'
     );
@@ -111,6 +112,7 @@ if (false === $svcId) {
         AND service_id = :svcId
         AND type = 1
         AND cancelled = 0
+        AND UNIX_TIMESTAMP(NOW()) >= actual_start_time
         AND end_time > UNIX_TIMESTAMP(NOW())
         ORDER BY actual_start_time'
     );


### PR DESCRIPTION
## Description

Fixed the display of downtimes

**Fixes** MON-4783

* add a condition on the sql statements at lines 101 and 115 to display only started downtimes

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* create a downtime on a service that will start later<br>
* create another downtime on the same service who start immedialy
* go to Monitoring > Status Details > Services
* check if only the downtimes who already started are shown 
