### PR TITLE
enh(resource-status): performance optimizations

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/HostProvider.php
@@ -69,9 +69,9 @@ final class HostProvider extends Provider
         StatementCollector $collector,
         array $accessGroupIds
     ): string {
-        $aclSubQuery = ' INNER JOIN `:dbstg`.`centreon_acl` AS host_acl ON host_acl.host_id = h.host_id
+        $aclSubQuery = ' EXISTS (SELECT 1 FROM `:dbstg`.`centreon_acl` AS host_acl WHERE host_acl.host_id = h.host_id
             AND host_acl.service_id IS NULL
-            AND host_acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+            AND host_acl.group_id IN (' . implode(',', $accessGroupIds) . ') LIMIT 1) ';
 
         return $this->prepareSubQuery($filter, $collector, $aclSubQuery);
     }
@@ -89,7 +89,7 @@ final class HostProvider extends Provider
         StatementCollector $collector,
         ?string $aclSubQuery
     ): string {
-        $sql = "SELECT DISTINCT
+        $sql = "SELECT
             h.host_id AS `id`,
             'host' AS `type`,
             h.name AS `name`,
@@ -164,11 +164,6 @@ final class HostProvider extends Provider
             AND host_cvl.service_id = 0
             AND host_cvl.name = "CRITICALITY_LEVEL"';
 
-        // set ACL limitations
-        if ($aclSubQuery !== null) {
-            $sql .= $aclSubQuery;
-        }
-
         $hasWhereCondition = false;
 
         $this->sqlRequestTranslator->setConcordanceArray($this->hostConcordances);
@@ -183,9 +178,15 @@ final class HostProvider extends Provider
             $sql .= $searchRequest;
         }
 
+        // set ACL limitations
+        if ($aclSubQuery !== null) {
+            $sql .= ($hasWhereCondition ? ' AND ' : ' WHERE ') . $aclSubQuery;
+            $hasWhereCondition = true;
+        }
+
         // show active hosts and aren't related to some module
         $sql .= ($hasWhereCondition ? ' AND ' : ' WHERE ')
-            . 'h.enabled = 1 AND h.name NOT LIKE "_Module_%"';
+            . 'h.enabled = 1 AND h.name NOT LIKE "\_Module\_%"';
 
         // apply the state filter to SQL query
         if ($filter->getStates() && !$filter->hasState(ResourceServiceInterface::STATE_ALL)) {

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
@@ -156,7 +156,7 @@ final class MetaServiceProvider extends Provider
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`hosts` sh
             ON sh.host_id = s.host_id
-            AND sh.name LIKE '_Module_Meta%'
+            AND sh.name LIKE '\_Module\_Meta%'
             AND sh.enabled = 1";
 
         // set ACL limitations

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
@@ -69,9 +69,12 @@ final class MetaServiceProvider extends Provider
         StatementCollector $collector,
         array $accessGroupIds
     ): string {
-        $aclSubQuery = ' INNER JOIN `:dbstg`.`centreon_acl` AS service_acl ON service_acl.host_id = s.host_id
-            AND service_acl.service_id = s.service_id
-            AND service_acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        $aclSubQuery = ' EXISTS (
+            SELECT 1 FROM `:dbstg`.`centreon_acl` AS service_acl
+            WHERE service_acl.host_id = s.host_id
+                AND service_acl.service_id = s.service_id
+                AND service_acl.group_id IN (' . implode(',', $accessGroupIds) . ')
+            LIMIT 1) ';
 
         return $this->prepareSubQuery($filter, $collector, $aclSubQuery);
     }
@@ -89,7 +92,7 @@ final class MetaServiceProvider extends Provider
         StatementCollector $collector,
         ?string $aclSubQuery
     ): string {
-        $sql = "SELECT DISTINCT
+        $sql = "SELECT
             SUBSTRING(s.description, 6) AS `id`,
             'metaservice' AS `type`,
             s.display_name AS `name`,
@@ -159,13 +162,14 @@ final class MetaServiceProvider extends Provider
             AND sh.name LIKE '\_Module\_Meta%'
             AND sh.enabled = 1";
 
+        // show active services only
+        $sql .= ' WHERE s.enabled = 1 ';
+
+
         // set ACL limitations
         if ($aclSubQuery !== null) {
-            $sql .= $aclSubQuery;
+            $sql .= ' AND ' . $aclSubQuery;
         }
-
-        // show active services only
-        $sql .= ' WHERE s.enabled = 1';
 
         // apply the state filter to SQL query
         if ($filter->getStates() && !$filter->hasState(ResourceServiceInterface::STATE_ALL)) {

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
@@ -71,9 +71,12 @@ final class ServiceProvider extends Provider
         StatementCollector $collector,
         array $accessGroupIds
     ): string {
-        $aclSubQuery = ' INNER JOIN `:dbstg`.`centreon_acl` AS service_acl ON service_acl.host_id = s.host_id
-            AND service_acl.service_id = s.service_id
-            AND service_acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+        $aclSubQuery = ' EXISTS (
+            SELECT 1 FROM `:dbstg`.`centreon_acl` AS service_acl
+            WHERE service_acl.host_id = s.host_id
+                AND service_acl.service_id = s.service_id
+                AND service_acl.group_id IN (' . implode(',', $accessGroupIds) . ')
+            LIMIT 1) ';
 
         return $this->prepareSubQuery($filter, $collector, $aclSubQuery);
     }
@@ -182,28 +185,6 @@ final class ServiceProvider extends Provider
             AND service_cvl.service_id = s.service_id
             AND service_cvl.name = "CRITICALITY_LEVEL"';
 
-        // set ACL limitations
-        if ($aclSubQuery !== null) {
-            $sql .= $aclSubQuery;
-        }
-
-        // apply the service group filter to SQL query
-        if ($filter->getServicegroupNames()) {
-            $groupList = [];
-
-            foreach ($filter->getServicegroupNames() as $index => $groupName) {
-                $key = ":serviceServicegroupName_{$index}";
-
-                $groupList[] = $key;
-                $collector->addValue($key, $groupName, \PDO::PARAM_STR);
-            }
-
-            $sql .= ' INNER JOIN `:dbstg`.`services_servicegroups` AS ssg
-                  ON ssg.host_id = s.host_id AND ssg.service_id = s.service_id
-                  INNER JOIN `:dbstg`.`servicegroups` AS sg
-                  ON ssg.servicegroup_id = sg.servicegroup_id AND sg.name IN (' . implode(', ', $groupList) . ') ';
-        }
-
         $hasWhereCondition = false;
 
         $this->sqlRequestTranslator->setConcordanceArray($this->serviceConcordances);
@@ -221,6 +202,29 @@ final class ServiceProvider extends Provider
         // show active services only
         $sql .= ($hasWhereCondition ? ' AND ' : ' WHERE ')
             . 's.enabled = 1';
+
+        // set ACL limitations
+        if ($aclSubQuery !== null) {
+            $sql .= ' AND ' . $aclSubQuery;
+        }
+
+        // apply the service group filter to SQL query
+        if ($filter->getServicegroupNames()) {
+            $groupList = [];
+
+            foreach ($filter->getServicegroupNames() as $index => $groupName) {
+                $key = ":serviceServicegroupName_{$index}";
+
+                $groupList[] = $key;
+                $collector->addValue($key, $groupName, \PDO::PARAM_STR);
+            }
+
+            $sql .= ' AND EXISTS (SELECT 1 FROM `:dbstg`.`services_servicegroups` AS ssg
+                  WHERE ssg.host_id = s.host_id AND ssg.service_id = s.service_id
+                    AND EXISTS (SELECT 1 FROM `:dbstg`.`servicegroups` AS sg
+                  WHERE ssg.servicegroup_id = sg.servicegroup_id
+                    AND sg.id = ssg.id AND sg.name IN (' . implode(', ', $groupList) . ') LIMIT 1) LIMIT 1)';
+        }
 
         // apply the state filter to SQL query
         if ($filter->getStates() && !$filter->hasState(ResourceServiceInterface::STATE_ALL)) {

--- a/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
@@ -68,7 +68,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
     private $accessGroups = [];
 
     /**
-     * @var array Association of resource search parameters
+     * @var array<string, string> Association of resource search parameters
      */
     private $resourceConcordances = [
         'id' => 'resource.id',
@@ -162,7 +162,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         }
 
         $collector = new StatementCollector();
-        $request = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT '
+        $request = 'SELECT SQL_CALC_FOUND_ROWS '
             . 'resource.id, resource.type, resource.name, resource.alias, resource.fqdn, '
             . 'resource.host_id, resource.service_id, '
             . 'resource.status_code, resource.status_name, resource.status_severity_code, ' // status
@@ -211,10 +211,25 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             return [];
         }
 
-        $request .= implode('UNION ALL ', $subRequests);
+        $request .= implode(' UNION ALL ', $subRequests);
         unset($subRequests);
 
         $request .= ') AS `resource`';
+
+        $hasWhereCondition = false;
+
+        // Search
+        $this->sqlRequestTranslator->setConcordanceArray($this->resourceConcordances);
+        try {
+            $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
+        } catch (RequestParametersTranslatorException $ex) {
+            throw new RepositoryException($ex->getMessage(), 0, $ex);
+        }
+
+        if ($searchRequest !== null) {
+            $hasWhereCondition = true;
+            $request .= $searchRequest;
+        }
 
         // apply the host group filter to SQL query
         if ($filter->getHostgroupNames()) {
@@ -226,10 +241,17 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
                 $collector->addValue($key, $groupName, \PDO::PARAM_STR);
             }
 
-            $request .= ' INNER JOIN `:dbstg`.`hosts_hostgroups` AS hhg
-                ON hhg.host_id = resource.host_id
-                INNER JOIN `:dbstg`.`hostgroups` AS hg
-                ON hg.name IN (' . implode(', ', $groupList) . ') ';
+            $request .= ($hasWhereCondition === false) ? ' WHERE ' : ' AND ';
+            $hasWhereCondition = true;
+
+            $request .= ' EXISTS (
+                SELECT 1 FROM `:dbstg`.`hosts_hostgroups` AS hhg
+                WHERE hhg.host_id = resource.host_id
+                    AND EXISTS (
+                        SELECT 1 FROM `:dbstg`.`hostgroups` AS hg
+                        WHERE hg.hostgroup_id = hhg.hostgroup_id AND hg.name IN (' . implode(', ', $groupList) . ')
+                        LIMIT 1)
+                LIMIT 1) ';
         }
 
         /**
@@ -237,24 +259,16 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
          * Then only resources with existing metrics referencing index_data services will be returned.
          */
         if ($filter->getOnlyWithPerformanceData() === true) {
-            $request .= ' INNER JOIN `:dbstg`.index_data AS idata
-                  ON idata.host_id = resource.parent_id
+            $request .= $hasWhereCondition ? ' AND ' : ' WHERE ';
+            $request .= ' EXISTS (
+                SELECT 1 FROM `:dbstg`.index_data AS idata
+                  WHERE idata.host_id = resource.parent_id
                   AND idata.service_id = resource.id
                   AND resource.type = "service"
-                INNER JOIN `:dbstg`.metrics AS m
-                  ON m.index_id = idata.id
-                  AND m.hidden = "0" ';
+                AND EXISTS (SELECT 1 FROM `:dbstg`.metrics AS m
+                  WHERE m.index_id = idata.id
+                  AND m.hidden = "0" LIMIT 1) LIMIT 1) ';
         }
-
-        // Search
-        $this->sqlRequestTranslator->setConcordanceArray($this->resourceConcordances);
-        try {
-            $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
-        } catch (RequestParametersTranslatorException $ex) {
-            throw new RepositoryException($ex->getMessage(), 0, $ex);
-        }
-
-        $request .= $searchRequest !== null ? $searchRequest : '';
 
         foreach ($this->sqlRequestTranslator->getSearchValues() as $key => $data) {
             $collector->addValue($key, current($data), key($data));


### PR DESCRIPTION
- Replace INNER JOIN with EXISTS statements
- Escape '_' character in LIKE statements for metaservices


**Tests were done following the following procedure**

- User belonging to several ACL groups with different resource access rights
- 20 consecutive calls to the API with a different limit set (using JMeter)
- Tests realized before and after optimizations

**Results of the tests**

_For a small amount of resources (limit 100)_

Before: Response Time - 600ms
After: Response Time ~ 450ms

_For a large amount of resources (limit 1000)_

Before: Response Time - 2s
After: Response Time ~ 1s

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Details in Jira ticket

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
