### PR TITLE
Removed animation effect option in account parameters

### DIFF
--- a/tests/clapi_export/clapi-configuration.txt
+++ b/tests/clapi_export/clapi-configuration.txt
@@ -607,7 +607,6 @@ ENGINECFG;setparam;Centreon Engine Central;broker_module;/usr/lib64/centreon-eng
 CONTACTTPL;ADD;contact_template;contact_template;;md5__d41d8cd98f00b204e9800998ecf8427e;0;1;;local
 CONTACTTPL;setparam;contact_template;hostnotifopt;n
 CONTACTTPL;setparam;contact_template;servicenotifopt;n
-CONTACTTPL;setparam;contact_template;contact_js_effects;0
 CONTACTTPL;setparam;contact_template;timezone;0
 CONTACTTPL;setparam;contact_template;reach_api;0
 CONTACTTPL;setparam;contact_template;reach_api_rt;0
@@ -621,7 +620,6 @@ CONTACTTPL;setparam;contact_template;enable_one_click_export;0
 CONTACTTPL;ADD;test_name;test_contact-template;;md5__b0e52a1510c9012ebae9e9dc1ae0c46e;0;1;;local
 CONTACTTPL;setparam;test_contact-template;hostnotifopt;n
 CONTACTTPL;setparam;test_contact-template;servicenotifopt;n
-CONTACTTPL;setparam;test_contact-template;contact_js_effects;0
 CONTACTTPL;setparam;test_contact-template;timezone;0
 CONTACTTPL;setparam;test_contact-template;reach_api;0
 CONTACTTPL;setparam;test_contact-template;reach_api_rt;0
@@ -637,7 +635,6 @@ CONTACT;setparam;admin;hostnotifperiod;24x7
 CONTACT;setparam;admin;svcnotifperiod;24x7
 CONTACT;setparam;admin;hostnotifopt;n
 CONTACT;setparam;admin;servicenotifopt;n
-CONTACT;setparam;admin;contact_js_effects;0
 CONTACT;setparam;admin;timezone;0
 CONTACT;setparam;admin;reach_api;0
 CONTACT;setparam;admin;reach_api_rt;0
@@ -655,7 +652,6 @@ CONTACT;setparam;guest;hostnotifperiod;24x7
 CONTACT;setparam;guest;svcnotifperiod;24x7
 CONTACT;setparam;guest;hostnotifopt;n
 CONTACT;setparam;guest;servicenotifopt;n
-CONTACT;setparam;guest;contact_js_effects;0
 CONTACT;setparam;guest;timezone;0
 CONTACT;setparam;guest;reach_api;0
 CONTACT;setparam;guest;reach_api_rt;0
@@ -671,7 +667,6 @@ CONTACT;setparam;guest;svcnotifcmd;service-notify-by-email
 CONTACT;ADD;Jean-Pierre;jeanpierre;Jean-Pierre@hotmail.fr;md5__d41d8cd98f00b204e9800998ecf8427e;0;1;browser;local
 CONTACT;setparam;jeanpierre;hostnotifopt;n
 CONTACT;setparam;jeanpierre;servicenotifopt;n
-CONTACT;setparam;jeanpierre;contact_js_effects;0
 CONTACT;setparam;jeanpierre;timezone;0
 CONTACT;setparam;jeanpierre;reach_api;0
 CONTACT;setparam;jeanpierre;reach_api_rt;0
@@ -685,7 +680,6 @@ CONTACT;setparam;jeanpierre;enable_one_click_export;0
 CONTACT;ADD;test_contact;test_contact;test@localhost;md5__b0e52a1510c9012ebae9e9dc1ae0c46e;0;0;en_US.UTF-8;local
 CONTACT;setparam;test_contact;hostnotifopt;n
 CONTACT;setparam;test_contact;servicenotifopt;n
-CONTACT;setparam;test_contact;contact_js_effects;0
 CONTACT;setparam;test_contact;timezone;0
 CONTACT;setparam;test_contact;reach_api;0
 CONTACT;setparam;test_contact;reach_api_rt;0
@@ -701,7 +695,6 @@ CONTACT;setparam;user;hostnotifperiod;24x7
 CONTACT;setparam;user;svcnotifperiod;24x7
 CONTACT;setparam;user;hostnotifopt;n
 CONTACT;setparam;user;servicenotifopt;n
-CONTACT;setparam;user;contact_js_effects;0
 CONTACT;setparam;user;timezone;0
 CONTACT;setparam;user;reach_api;0
 CONTACT;setparam;user;reach_api_rt;0

--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -652,7 +652,6 @@ class CentreonAPI
      */
     public function launchAction($exit = true)
     {
-        
         $action = strtoupper($this->action);
 
         /**
@@ -871,7 +870,6 @@ class CentreonAPI
                     if ($this->objectTable[$splits[0]]->getObjectId($name, CentreonObject::MULTIPLE_VALUE) == 0) {
                         echo "Unknown object : $splits[0];$splits[1]\n";
                         $this->setReturnCode(1);
-                        
                         if ($withoutClose === false) {
                             $this->close();
                         } else {

--- a/www/class/centreonUser.class.php
+++ b/www/class/centreonUser.class.php
@@ -49,7 +49,6 @@ class CentreonUser
     public $version;
     public $admin;
     public $limit;
-    public $js_effects;
     public $num;
     public $gmt;
     public $is_admin;
@@ -96,7 +95,6 @@ class CentreonUser
         $this->version = 3;
         $this->default_page = $user["default_page"] ?? CentreonAuth::DEFAULT_PAGE;
         $this->gmt = $user["contact_location"];
-        $this->js_effects = $user["contact_js_effects"];
         $this->showDeprecatedPages = (bool) $user["show_deprecated_pages"];
         $this->is_admin = null;
         /*
@@ -296,25 +294,6 @@ class CentreonUser
         $this->showDeprecatedPages = $showDeprecatedPages;
     }
 
-    /**
-     *
-     * @global type $pearDB
-     * @return type
-     */
-    public function get_js_effects()
-    {
-        global $pearDB;
-
-        $DBRESULT = $pearDB->query('SELECT contact_js_effects FROM contact WHERE contact_id = ' . $this->user_id);
-        if (($jsEffectsEnabled = $DBRESULT->fetch()) && isset($jsEffectsEnabled['contact_js_effects'])) {
-            $this->js_effects = $jsEffectsEnabled['contact_js_effects'];
-        } else {
-            $this->js_effects = 0;
-        }
-
-        return $this->js_effects;
-    }
-
     // Set
 
     /**
@@ -369,15 +348,6 @@ class CentreonUser
     public function set_version($version)
     {
         $this->version = $version;
-    }
-
-    /**
-     *
-     * @param type $js_effects
-     */
-    public function set_js_effects($js_effects)
-    {
-        $this->js_effects = $js_effects;
     }
 
     /**

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -143,7 +143,6 @@ function updateContact($contact_id = null)
           'contact_email = :contactEmail, ' .
           'contact_pager = :contactPager, ' .
           'default_page = :defaultPage, ' .
-          'contact_js_effects = :contactJsEffects, ' .
           'show_deprecated_pages = :showDeprecatedPages, ' .
           'contact_autologin_key = :contactAutologinKey, ' .
           'enable_one_click_export = :enableOneClickExport';
@@ -185,7 +184,6 @@ function updateContact($contact_id = null)
         \PDO::PARAM_INT
     );
     $stmt->bindValue(':defaultPage', !empty($ret['default_page']) ? $ret['default_page'] : null, \PDO::PARAM_INT);
-    $stmt->bindValue(':contactJsEffects', isset($ret['contact_js_effects']) ? 1 : 0, \PDO::PARAM_STR);
     $stmt->bindValue(':showDeprecatedPages', isset($ret['show_deprecated_pages']) ? 1 : 0, \PDO::PARAM_STR);
     $stmt->bindValue(':enableOneClickExport', isset($ret['enable_one_click_export']) ? '1' : '0', \PDO::PARAM_STR);
     $stmt->bindValue(':contactId', $contact_id, \PDO::PARAM_INT);

--- a/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -54,7 +54,6 @@
             </tr>
             <tr class="list_two"><td class="FormRowField">{$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td></tr>
-            <tr class="list_two"><td class="FormRowField">{$form.contact_js_effects.label}</td><td class="FormRowValue">{$form.contact_js_effects.html}</td></tr>
             {if $contactIsAdmin}
             <tr class="list_one"><td class="FormRowField">{$form.enable_one_click_export.label}</td><td class="FormRowValue">{$form.enable_one_click_export.html}</td></tr>
             {/if}

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -62,6 +62,9 @@ if (!isset($centreonFeature)) {
  */
 $cct = array();
 if ($o == "c") {
+    $query_js_effect_drop = $pearDB->prepare("alter table contact drop column if exists contact_js_effects");
+    $query_js_effect_drop->execute();
+
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
         enable_one_click_export

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -62,9 +62,6 @@ if (!isset($centreonFeature)) {
  */
 $cct = array();
 if ($o == "c") {
-    $query_js_effect_drop = $pearDB->prepare("alter table contact drop column if exists contact_js_effects");
-    $query_js_effect_drop->execute();
-
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
         enable_one_click_export

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -62,8 +62,6 @@ if (!isset($centreonFeature)) {
  */
 $cct = array();
 if ($o == "c") {
-    $query_js_effect_drop = $pearDB->prepare("alter table contact drop column if exists contact_js_effects");
-    $query_js_effect_drop->execute();
 
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -61,7 +61,7 @@ if (!isset($centreonFeature)) {
  * Database retrieve information for the User
  */
 $cct = array();
-if ($o == "c") {<f
+if ($o == "c") {
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
         enable_one_click_export

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -137,7 +137,7 @@ $form->addElement(
 );
 $form->addElement('select', 'contact_lang', _("Language"), $langs);
 $form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
-$form->addElement('checkbox', 'contact_js_effects', _("Animation effects"), null, $attrsText);
+//$form->addElement('checkbox', 'contact_js_effects', _("Animation effects"), null, $attrsText);
 $form->addElement(
     'checkbox',
     'enable_one_click_export',

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -61,9 +61,9 @@ if (!isset($centreonFeature)) {
  * Database retrieve information for the User
  */
 $cct = array();
-if ($o == "c") {
+if ($o == "c") {<f
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
-        contact_js_effects, contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
+        contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
         enable_one_click_export
         FROM contact WHERE contact_id = :id";
     $DBRESULT = $pearDB->prepare($query);
@@ -137,7 +137,6 @@ $form->addElement(
 );
 $form->addElement('select', 'contact_lang', _("Language"), $langs);
 $form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
-//$form->addElement('checkbox', 'contact_js_effects', _("Animation effects"), null, $attrsText);
 $form->addElement(
     'checkbox',
     'enable_one_click_export',

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -90,7 +90,6 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
         'contact_admin' => $contact->isAdmin(),
         'contact_lang' => null,
         'contact_passwd' => null,
-        'contact_js_effects' => null,
         'contact_autologin_key' => null,
         'contact_location' => null,
         'reach_api' => $contact->hasAccessToApiConfiguration(),

--- a/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -95,7 +95,6 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
         'contact_admin' => $contact->isAdmin(),
         'contact_lang' => null,
         'contact_passwd' => null,
-        'contact_js_effects' => null,
         'contact_autologin_key' => null,
         'contact_location' => null,
         'reach_api' => $contact->hasAccessToApiConfiguration(),

--- a/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -278,7 +278,7 @@ try {
                 /*
                  * Check if monitoring engine's configuration directory existss
                  */
-                 $dbResult = $pearDB->query("
+                $dbResult = $pearDB->query("
                     SELECT cfg_dir FROM cfg_nagios, nagios_server
                     WHERE nagios_server.id = cfg_nagios.nagios_server_id
                     AND nagios_server.localhost = '1'

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -95,7 +95,6 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
         'contact_admin' => $contact->isAdmin(),
         'contact_lang' => null,
         'contact_passwd' => null,
-        'contact_js_effects' => null,
         'contact_autologin_key' => null,
         'contact_location' => null,
         'reach_api' => $contact->hasAccessToApiConfiguration(),

--- a/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+++ b/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
@@ -98,7 +98,6 @@ if (false === $svcId) {
         WHERE host_id = :hostId
         AND type = 2
         AND cancelled = 0
-        AND UNIX_TIMESTAMP(NOW()) >= actual_start_time
         AND end_time > UNIX_TIMESTAMP(NOW())
         ORDER BY actual_start_time'
     );
@@ -112,7 +111,6 @@ if (false === $svcId) {
         AND service_id = :svcId
         AND type = 1
         AND cancelled = 0
-        AND UNIX_TIMESTAMP(NOW()) >= actual_start_time
         AND end_time > UNIX_TIMESTAMP(NOW())
         ORDER BY actual_start_time'
     );

--- a/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+++ b/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
@@ -98,6 +98,7 @@ if (false === $svcId) {
         WHERE host_id = :hostId
         AND type = 2
         AND cancelled = 0
+        AND UNIX_TIMESTAMP(NOW()) >= actual_start_time
         AND end_time > UNIX_TIMESTAMP(NOW())
         ORDER BY actual_start_time'
     );
@@ -111,6 +112,7 @@ if (false === $svcId) {
         AND service_id = :svcId
         AND type = 1
         AND cancelled = 0
+        AND UNIX_TIMESTAMP(NOW()) >= actual_start_time
         AND end_time > UNIX_TIMESTAMP(NOW())
         ORDER BY actual_start_time'
     );

--- a/www/include/monitoring/status/Common/commonJS.php
+++ b/www/include/monitoring/status/Common/commonJS.php
@@ -947,15 +947,6 @@ var func_popupXsltCallback = function(trans_obj) {
     }
 
     jQuery('.popup_volante .container-load').empty();
-<?php   if ($centreon->user->get_js_effects() > 0) { ?>
-    jQuery('.popup_volante').stop(true, true).animate(
-    {
-        width: jQuery('#' + target_element).width(),
-        height: jQuery('#' + target_element).height(),
-        top: (jQuery(window).height() / 2) - (jQuery('#' + target_element).height() / 2)
-    }, 25);
-    jQuery('#' + target_element).stop(true, true).fadeIn(1000);
-<?php } else { ?>
 
     jQuery('.popup_volante').css('left', jQuery('#' + target_element).attr('left'));
 
@@ -977,7 +968,7 @@ var func_popupXsltCallback = function(trans_obj) {
     }
     jQuery('.popup_volante').css('top', positionY);
     jQuery('#' + target_element).show();
-<?php } ?>
+
     formatDateMoment();
 };
 

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -742,7 +742,6 @@ CREATE TABLE `contact` (
   `contact_address5` varchar(200) DEFAULT NULL,
   `contact_address6` varchar(200) DEFAULT NULL,
   `contact_comment` text,
-  `contact_js_effects` enum('0','1') DEFAULT '0',
   `contact_location` int(11) DEFAULT '0',
   `contact_oreon` enum('0','1') DEFAULT NULL,
   `reach_api` int(11) DEFAULT '0',

--- a/www/install/sql/centreon/Update-DB-21.10.0-beta.2.sql
+++ b/www/install/sql/centreon/Update-DB-21.10.0-beta.2.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `contact` DROP COLUMN IF EXISTS `contact_js_effects`
+ALTER TABLE `contact` DROP COLUMN IF EXISTS `contact_js_effects`;

--- a/www/install/sql/centreon/Update-DB-21.10.0-beta.2.sql
+++ b/www/install/sql/centreon/Update-DB-21.10.0-beta.2.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `contact` DROP COLUMN IF EXISTS `contact_js_effects`;
+ALTER TABLE `contact` DROP COLUMN `contact_js_effects`;

--- a/www/install/sql/centreon/Update-DB-21.10.0-beta.2.sql
+++ b/www/install/sql/centreon/Update-DB-21.10.0-beta.2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `contact` DROP COLUMN IF EXISTS `contact_js_effects`


### PR DESCRIPTION
## Description

Fixes MON-11359

Removed animation effect option in account parameters

Commented line 140 of file www/include/Administration/myAccount/formMyAccount.php

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Create a downtime for a service who start immediatly
* Go to Monitoring > Status details > Services
* Move the cursor on the downtime icon
* Check if the animation is good or not
