### PR TITLE
fix(filter): handle name when saving criterias hg/sg

### DIFF
--- a/src/Centreon/Domain/Filter/FilterService.php
+++ b/src/Centreon/Domain/Filter/FilterService.php
@@ -133,10 +133,10 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
             if ($criteria->getType() === 'multi_select' && is_array($criteria->getValue())) {
                 switch ($criteria->getObjectType()) {
                     case 'host_groups':
-                        $hostGroupIds = array_column($criteria->getValue(), 'id');
+                        $hostGroupNames = array_column($criteria->getValue(), 'name');
                         $hostGroups = $this->hostGroupService
                             ->filterByContact($this->contact)
-                            ->findHostGroupsByIds($hostGroupIds);
+                            ->findHostGroupsByNames($hostGroupNames);
                         $criteria->setValue(array_map(
                             function ($hostGroup) {
                                 return [
@@ -148,10 +148,10 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
                         ));
                         break;
                     case 'service_groups':
-                        $serviceGroupIds = array_column($criteria->getValue(), 'id');
+                        $serviceGroupNames = array_column($criteria->getValue(), 'name');
                         $serviceGroups = $this->serviceGroupService
                             ->filterByContact($this->contact)
-                            ->findServiceGroupsByIds($serviceGroupIds);
+                            ->findServiceGroupsByNames($serviceGroupNames);
                         $criteria->setValue(array_map(
                             function ($serviceGroup) {
                                 return [

--- a/src/Centreon/Domain/Monitoring/HostGroup/HostGroupService.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/HostGroupService.php
@@ -76,4 +76,16 @@ final class HostGroupService extends AbstractCentreonService implements HostGrou
             throw new HostGroupException(_('Error when searching hostgroups'), 0, $e);
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function findHostGroupsByNames(array $hostGroupIds): array
+    {
+        try {
+            return $this->hostGroupRepository->findHostGroupsByNames($hostGroupIds);
+        } catch (\Throwable $e) {
+            throw new HostGroupException(_('Error when searching hostgroups'), 0, $e);
+        }
+    }
 }

--- a/src/Centreon/Domain/Monitoring/HostGroup/HostGroupService.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/HostGroupService.php
@@ -80,10 +80,10 @@ final class HostGroupService extends AbstractCentreonService implements HostGrou
     /**
      * @inheritDoc
      */
-    public function findHostGroupsByNames(array $hostGroupIds): array
+    public function findHostGroupsByNames(array $hostGroupNames): array
     {
         try {
-            return $this->hostGroupRepository->findHostGroupsByNames($hostGroupIds);
+            return $this->hostGroupRepository->findHostGroupsByNames($hostGroupNames);
         } catch (\Throwable $e) {
             throw new HostGroupException(_('Error when searching hostgroups'), 0, $e);
         }

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
@@ -38,7 +38,7 @@ interface HostGroupRepositoryInterface
     /**
      * Retrieve hostgroups from their names
      *
-     * @param array<int, string> $hostGroupNames
+     * @param string[] $hostGroupNames
      * @return HostGroup[]
      */
     public function findHostGroupsByNames(array $hostGroupNames): array;

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
@@ -36,6 +36,14 @@ interface HostGroupRepositoryInterface
     public function findHostGroupsByIds(array $hostGroupIds): array;
 
     /**
+     * Retrieve hostgroups from their names
+     *
+     * @param array $hostGroupNames
+     * @return HostGroup[]
+     */
+    public function findHostGroupsByNames(array $hostGroupNames): array;
+
+    /**
      * @param ContactInterface $contact
      * @return HostGroupRepositoryInterface
      */

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
@@ -30,7 +30,7 @@ interface HostGroupRepositoryInterface
     /**
      * Retrieve hostgroups from their ids
      *
-     * @param array $hostGroupIds
+     * @param array<int, int> $hostGroupIds
      * @return HostGroup[]
      */
     public function findHostGroupsByIds(array $hostGroupIds): array;
@@ -38,7 +38,7 @@ interface HostGroupRepositoryInterface
     /**
      * Retrieve hostgroups from their names
      *
-     * @param array $hostGroupNames
+     * @param array<int, string> $hostGroupNames
      * @return HostGroup[]
      */
     public function findHostGroupsByNames(array $hostGroupNames): array;

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupRepositoryInterface.php
@@ -30,7 +30,7 @@ interface HostGroupRepositoryInterface
     /**
      * Retrieve hostgroups from their ids
      *
-     * @param array<int, int> $hostGroupIds
+     * @param int[] $hostGroupIds
      * @return HostGroup[]
      */
     public function findHostGroupsByIds(array $hostGroupIds): array;

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
@@ -41,7 +41,7 @@ interface HostGroupServiceInterface
     /**
      * Retrieve hostgroups from their ids
      *
-     * @param array $hostGroupIds
+     * @param array<int, int> $hostGroupIds
      * @return HostGroup[]
      * @throws HostGroupException
      */
@@ -50,7 +50,7 @@ interface HostGroupServiceInterface
     /**
      * Retrieve hostgroups from their names
      *
-     * @param array $hostGroupNames
+     * @param array<int, string> $hostGroupNames
      * @return HostGroup[]
      * @throws HostGroupException
      */

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
@@ -41,7 +41,7 @@ interface HostGroupServiceInterface
     /**
      * Retrieve hostgroups from their ids
      *
-     * @param array<int, int> $hostGroupIds
+     * @param int[] $hostGroupIds
      * @return HostGroup[]
      * @throws HostGroupException
      */

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
@@ -50,7 +50,7 @@ interface HostGroupServiceInterface
     /**
      * Retrieve hostgroups from their names
      *
-     * @param array<int, string> $hostGroupNames
+     * @param string[] $hostGroupNames
      * @return HostGroup[]
      * @throws HostGroupException
      */

--- a/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup/Interfaces/HostGroupServiceInterface.php
@@ -46,4 +46,13 @@ interface HostGroupServiceInterface
      * @throws HostGroupException
      */
     public function findHostGroupsByIds(array $hostGroupIds): array;
+
+    /**
+     * Retrieve hostgroups from their names
+     *
+     * @param array $hostGroupNames
+     * @return HostGroup[]
+     * @throws HostGroupException
+     */
+    public function findHostGroupsByNames(array $hostGroupNames): array;
 }

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
@@ -38,7 +38,7 @@ interface ServiceGroupRepositoryInterface
     /**
      * Retrieve servicegroups from their names
      *
-     * @param array<int, string> $serviceGroupNames
+     * @param string[] $serviceGroupNames
      * @return ServiceGroup[]
      */
     public function findServiceGroupsByNames(array $serviceGroupNames): array;

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
@@ -30,15 +30,15 @@ interface ServiceGroupRepositoryInterface
     /**
      * Retrieve servicegroups from their ids
      *
-     * @param array $serviceGroupIds
+     * @param array<int, int> $serviceGroupIds
      * @return ServiceGroup[]
      */
     public function findServiceGroupsByIds(array $serviceGroupIds): array;
 
     /**
-     * Retrieve servicegroups from their ids
+     * Retrieve servicegroups from their names
      *
-     * @param array $serviceGroupIds
+     * @param array<int, string> $serviceGroupNames
      * @return ServiceGroup[]
      */
     public function findServiceGroupsByNames(array $serviceGroupNames): array;

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
@@ -30,7 +30,7 @@ interface ServiceGroupRepositoryInterface
     /**
      * Retrieve servicegroups from their ids
      *
-     * @param array<int, int> $serviceGroupIds
+     * @param int[] $serviceGroupIds
      * @return ServiceGroup[]
      */
     public function findServiceGroupsByIds(array $serviceGroupIds): array;

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupRepositoryInterface.php
@@ -36,6 +36,14 @@ interface ServiceGroupRepositoryInterface
     public function findServiceGroupsByIds(array $serviceGroupIds): array;
 
     /**
+     * Retrieve servicegroups from their ids
+     *
+     * @param array $serviceGroupIds
+     * @return ServiceGroup[]
+     */
+    public function findServiceGroupsByNames(array $serviceGroupNames): array;
+
+    /**
      * @param ContactInterface $contact
      * @return ServiceGroupRepositoryInterface
      */

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
@@ -46,4 +46,13 @@ interface ServiceGroupServiceInterface
      * @throws ServiceGroupException
      */
     public function findServiceGroupsByIds(array $serviceGroupIds): array;
+
+    /**
+     * Retrieve servicegroups from their ids
+     *
+     * @param array $serviceGroupNames
+     * @return ServiceGroup[]
+     * @throws ServiceGroupException
+     */
+    public function findServiceGroupsByNames(array $serviceGroupNames): array;
 }

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
@@ -41,7 +41,7 @@ interface ServiceGroupServiceInterface
     /**
      * Retrieve servicegroups from their ids
      *
-     * @param array $serviceGroupIds
+     * @param array<int, int> $serviceGroupIds
      * @return ServiceGroup[]
      * @throws ServiceGroupException
      */
@@ -50,7 +50,7 @@ interface ServiceGroupServiceInterface
     /**
      * Retrieve servicegroups from their ids
      *
-     * @param array $serviceGroupNames
+     * @param array<int, string> $serviceGroupNames
      * @return ServiceGroup[]
      * @throws ServiceGroupException
      */

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
@@ -41,7 +41,7 @@ interface ServiceGroupServiceInterface
     /**
      * Retrieve servicegroups from their ids
      *
-     * @param array<int, int> $serviceGroupIds
+     * @param int[] $serviceGroupIds
      * @return ServiceGroup[]
      * @throws ServiceGroupException
      */

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/Interfaces/ServiceGroupServiceInterface.php
@@ -50,7 +50,7 @@ interface ServiceGroupServiceInterface
     /**
      * Retrieve servicegroups from their ids
      *
-     * @param array<int, string> $serviceGroupNames
+     * @param string[] $serviceGroupNames
      * @return ServiceGroup[]
      * @throws ServiceGroupException
      */

--- a/src/Centreon/Domain/Monitoring/ServiceGroup/ServiceGroupService.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup/ServiceGroupService.php
@@ -76,4 +76,16 @@ final class ServiceGroupService extends AbstractCentreonService implements Servi
             throw new ServiceGroupException(_('Error when searching servicegroups'), 0, $e);
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function findServiceGroupsByNames(array $serviceGroupNames): array
+    {
+        try {
+            return $this->serviceGroupRepository->findServiceGroupsByNames($serviceGroupNames);
+        } catch (\Throwable $e) {
+            throw new ServiceGroupException(_('Error when searching servicegroups'), 0, $e);
+        }
+    }
 }

--- a/src/Centreon/Infrastructure/Monitoring/HostGroup/HostGroupRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/HostGroup/HostGroupRepositoryRDB.php
@@ -65,6 +65,10 @@ final class HostGroupRepositoryRDB extends AbstractRepositoryDRB implements Host
         $this->accessGroups = $accessGroups;
         return $this;
     }
+
+    /**
+     * @inheritDoc
+     */
     public function findHostGroupsByNames(array $hostGroupNames): array
     {
         $hostGroups = [];

--- a/src/Centreon/Infrastructure/Monitoring/HostGroup/HostGroupRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/HostGroup/HostGroupRepositoryRDB.php
@@ -65,6 +65,76 @@ final class HostGroupRepositoryRDB extends AbstractRepositoryDRB implements Host
         $this->accessGroups = $accessGroups;
         return $this;
     }
+    public function findHostGroupsByNames(array $hostGroupNames): array
+    {
+        $hostGroups = [];
+
+        if ($this->hasNotEnoughRightsToContinue() || empty($hostGroupNames)) {
+            return $hostGroups;
+        }
+
+        $bindValues = [];
+        $subRequest = '';
+        if (!$this->isAdmin()) {
+            $bindValues[':contact_id'] = [\PDO::PARAM_INT => $this->contact->getId()];
+
+            // Not an admin, we must to filter on contact
+            $subRequest .=
+                ' INNER JOIN `:db`.acl_resources_hg_relations hgr
+                    ON hgr.hg_hg_id = hg.hostgroup_id
+                INNER JOIN `:db`.acl_resources res
+                    ON res.acl_res_id = hgr.acl_res_id
+                    AND res.acl_res_activate = \'1\'
+                INNER JOIN `:db`.acl_res_group_relations rgr
+                    ON rgr.acl_res_id = res.acl_res_id
+                INNER JOIN `:db`.acl_groups grp
+                    ON grp.acl_group_id IN ('
+                . $this->accessGroupIdToString($this->accessGroups)
+                . ') AND grp.acl_group_activate = \'1\'
+                    AND grp.acl_group_id = rgr.acl_group_id
+                LEFT JOIN `:db`.acl_group_contacts_relations gcr
+                    ON gcr.acl_group_id = grp.acl_group_id
+                LEFT JOIN `:db`.acl_group_contactgroups_relations gcgr
+                    ON gcgr.acl_group_id = grp.acl_group_id
+                LEFT JOIN `:db`.contactgroup_contact_relation cgcr
+                    ON cgcr.contactgroup_cg_id = gcgr.cg_cg_id
+                    AND cgcr.contact_contact_id = :contact_id
+                    OR gcr.contact_contact_id = :contact_id';
+        }
+
+        $request = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT hg.* FROM `:dbstg`.`hostgroups` hg ' . $subRequest;
+        $request = $this->translateDbName($request);
+
+        $bindHostGroupNames = [];
+        foreach ($hostGroupNames as $index => $hostGroupName) {
+            $bindHostGroupNames[':host_group_name_' . $index] = [\PDO::PARAM_STR => $hostGroupName];
+        }
+        $bindValues = array_merge($bindValues, $bindHostGroupNames);
+        $request .= ' WHERE hg.name IN (' . implode(',', array_keys($bindHostGroupNames)) . ')';
+
+        // Sort
+        $request .= ' ORDER BY hg.name ASC';
+
+        $statement = $this->db->prepare($request);
+
+        // We bind extra parameters according to access rights
+        foreach ($bindValues as $key => $data) {
+            $type = key($data);
+            $value = $data[$type];
+            $statement->bindValue($key, $value, $type);
+        }
+
+        $statement->execute();
+
+        while (false !== ($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $hostGroups[] = EntityCreator::createEntityByArray(
+                HostGroup::class,
+                $result
+            );
+        }
+
+        return $hostGroups;
+    }
 
     /**
      * @inheritDoc

--- a/tests/api/Context/UserFilterContext.php
+++ b/tests/api/Context/UserFilterContext.php
@@ -69,10 +69,33 @@ class UserFilterContext extends ApiContext
      */
     public function iUpdateTheFilterWithTheCreationValues(): void
     {
+        $response = $this->iSendARequestTo(
+            'GET',
+            '/api/v21.10/monitoring/hostgroups'
+        );
+        $decodedResponse = json_decode($response->getBody()->__toString(), true);
+        $hostgroupId = $decodedResponse['result'][0]['id'];
+        $hostgroupName = $decodedResponse['result'][0]['name'];
+
+        $requestBody = '{
+            "name":"my filter1",
+            "criterias":[{
+              "name": "host_groups",
+              "type": "multi_select",
+              "value": [
+                {
+                  "id": ' . $hostgroupId . ',
+                  "name": "' . $hostgroupName . '"
+                }
+              ],
+              "object_type": "host_groups"
+            }]
+        }';
+
         $this->iSendARequestToWithBody(
             'PUT',
             '/api/v21.10/users/filters/events-view/1',
-            $this->requestBody
+            $requestBody
         );
     }
 }

--- a/tests/php/Centreon/Domain/Filter/FilterServiceTest.php
+++ b/tests/php/Centreon/Domain/Filter/FilterServiceTest.php
@@ -117,7 +117,7 @@ class FilterServiceTest extends TestCase
             ->method('filterByContact')
             ->willReturn($this->hostGroupService);
         $this->hostGroupService->expects($this->once())
-            ->method('findHostGroupsByIds')
+            ->method('findHostGroupsByNames')
             ->willReturn([$renamedHostGroup]);
 
         $filterService = new FilterService(
@@ -151,7 +151,7 @@ class FilterServiceTest extends TestCase
             ->method('filterByContact')
             ->willReturn($this->serviceGroupService);
         $this->serviceGroupService->expects($this->once())
-            ->method('findServiceGroupsByIds')
+            ->method('findServiceGroupsByNames')
             ->willReturn([]);
 
         $filterService = new FilterService(


### PR DESCRIPTION
This fixes an issue when editing a filter. Front-end does not send the ids anymore but only the names of servicegroups and hostgroups as criterias. this needs to be reflected on backend when an update action is sent for the filter

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>
See Jira ticket for details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
