### PR TITLE
fix(downtime): fix error for downtime on hostgroups

### DIFF
--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -49,9 +49,9 @@ class CentreonHostgroups
 
     /**
      *
-     * @var type
+     * @var array
      */
-    private $relationCache;
+    private $relationCache = [];
 
     /**
      *


### PR DESCRIPTION
This issue only occurs on 21.10, this is visible now thanks to the php upgrade.

- 21.04 runs with PHP 7.3, a count on a "null" variable will throw a warning message
- 21.10 runs with PHP 8.0, a count on a "null" variable will throw a fatal error

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
