### PR TITLE
fix(conf) remove option to enable one-click-export button

### DIFF
--- a/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -55,7 +55,7 @@
             <tr class="list_two"><td class="FormRowField">{$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td></tr>
             <tr class="list_two"><td class="FormRowField">{$form.contact_js_effects.label}</td><td class="FormRowValue">{$form.contact_js_effects.html}</td></tr>
-            {if $contactIsAdmin}
+            {if $contactIsAdmin && !$isRemote}
             <tr class="list_one"><td class="FormRowField">{$form.enable_one_click_export.label}</td><td class="FormRowValue">{$form.enable_one_click_export.html}</td></tr>
             {/if}
             <tr class="list_lvl_1">

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -138,13 +138,15 @@ $form->addElement(
 $form->addElement('select', 'contact_lang', _("Language"), $langs);
 $form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
 $form->addElement('checkbox', 'contact_js_effects', _("Animation effects"), null, $attrsText);
-$form->addElement(
-    'checkbox',
-    'enable_one_click_export',
-    _("Enable the one-click export button for poller configuration [BETA]"),
-    null,
-    $attrsText
-);
+if (!$isRemote) {
+    $form->addElement(
+        'checkbox',
+        'enable_one_click_export',
+        _("Enable the one-click export button for poller configuration [BETA]"),
+        null,
+        $attrsText
+    );
+}
 
 
 /* ------------------------ Topoogy ---------------------------- */
@@ -451,6 +453,7 @@ $tpl->assign('cct', $cct);
 $tpl->assign('o', $o);
 $tpl->assign('featuresFlipping', (count($features) > 0));
 $tpl->assign('contactIsAdmin', $centreon->user->get_admin());
+$tpl->assign('isRemote', $isRemote);
 
 /*
  * prepare help texts


### PR DESCRIPTION
## Description

The new poller config export button is available on remote servers

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

When logged as an admin and editing your profile, the option to enable the export button should not be visible.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
