### PR TITLE
fix(UI): Fix typo

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16292,7 +16292,7 @@ msgid "This will export and reload the configuration on all of your platform"
 msgstr "Cela va exporter et recharger la configuration sur l'ensemble de votre plateforme"
 
 msgid "Exporting and reloading the configuration. Please wait..."
-msgstr "La configuration est en train d'être exportée et rechargée. Veuillez patientez ..."
+msgstr "La configuration est en train d'être exportée et rechargée. Veuillez patienter ..."
 
 msgid "Configuration exported and reloaded"
 msgstr "Configuration exportée et rechargée"


### PR DESCRIPTION
## Description

This fixes a typo related to the one click export button

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Have a FR UI
- Enable the one click export feature in your admin account
- Press F5
- In the poller's top counter, click on the one click export button
- -> A snackbar appear with the following text "La configuration est en train d'être exportée et rechargée. Veuillez patienter ..."

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
