### PR TITLE
fix(UI): Fix fullname and alias layout

### DIFF
--- a/www/front_src/src/Header/userMenu/index.js
+++ b/www/front_src/src/Header/userMenu/index.js
@@ -13,7 +13,7 @@ import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import { Typography } from '@material-ui/core';
+import { Typography, withStyles, createStyles } from '@material-ui/core';
 import UserIcon from '@material-ui/icons/AccountCircle';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import CheckIcon from '@material-ui/icons/Check';
@@ -25,6 +25,19 @@ import axios from '../../axios';
 import MenuLoader from '../../components/MenuLoader';
 
 const EDIT_PROFILE_TOPOLOGY_PAGE = '50104';
+
+const MuiStyles = createStyles({
+  fullname: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    width: '115px',
+  },
+  nameAliasContainer: {
+    display: 'grid',
+    gridTemplateColumns: '2fr 1fr',
+  },
+});
 
 class UserMenu extends Component {
   userService = axios('internal.php?object=centreon_topcounter&action=user');
@@ -110,7 +123,7 @@ class UserMenu extends Component {
     }
 
     // check if edit profile page (My Account) is allowed
-    const { allowedPages, t } = this.props;
+    const { allowedPages, t, classes } = this.props;
     const allowEditProfile = allowedPages?.includes(EDIT_PROFILE_TOPOLOGY_PAGE);
 
     const { fullname, username, autologinkey } = data;
@@ -142,16 +155,19 @@ class UserMenu extends Component {
                 )}
               >
                 <li className={styles['submenu-item']}>
-                  <span className={styles['submenu-item-link']}>
-                    <span className={styles['submenu-user-name']}>
-                      <Typography variant="body2">{fullname}</Typography>
-                    </span>
-                    <span className={styles['submenu-user-type']}>
-                      <Typography variant="body2">
+                  <div className={classnames(styles['submenu-item-link'])}>
+                    <div>
+                      <Typography className={classes.fullname} variant="body2">
+                        {fullname}
+                      </Typography>
+                      <Typography
+                        style={{ wordWrap: 'break-word' }}
+                        variant="body2"
+                      >
                         {t('as')}
                         {` ${username}`}
                       </Typography>
-                    </span>
+                    </div>
                     {allowEditProfile && (
                       <Link
                         className={styles['submenu-user-edit']}
@@ -163,7 +179,7 @@ class UserMenu extends Component {
                         </Typography>
                       </Link>
                     )}
-                  </span>
+                  </div>
                 </li>
                 {autologinkey && (
                   <div className={styles['submenu-content']}>
@@ -211,6 +227,6 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = {};
 
-export default withTranslation()(
-  connect(mapStateToProps, mapDispatchToProps)(UserMenu),
+export default withStyles(MuiStyles)(
+  withTranslation()(connect(mapStateToProps, mapDispatchToProps)(UserMenu)),
 );

--- a/www/front_src/src/Header/userMenu/index.js
+++ b/www/front_src/src/Header/userMenu/index.js
@@ -155,7 +155,12 @@ class UserMenu extends Component {
                 )}
               >
                 <li className={styles['submenu-item']}>
-                  <div className={classnames(styles['submenu-item-link'])}>
+                  <div
+                    className={classnames(
+                      styles['submenu-item-link'],
+                      classes.nameAliasContainer,
+                    )}
+                  >
                     <div>
                       <Typography className={classes.fullname} variant="body2">
                         {fullname}


### PR DESCRIPTION
## Description

This fixes the fullname and alias displayed layout in the user top counter
![Screenshot 2021-10-25 at 10 23 38](https://user-images.githubusercontent.com/12515407/138661005-048430a8-dc8a-4f68-b6ef-21e0d5378203.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Expand the user top counter
- -> The fullname is displayed in one line (and truncated when the fullname is very long)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
