### PR TITLE
fix(conf/broker) bind sql values for inputs/outputs insert requests

### DIFF
--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -910,8 +910,8 @@ class CentreonConfigCentreonBroker
                     $fieldtype = $this->getFieldtypes($typeId);
                     foreach ($infos as $fieldname => $fieldvalue) {
                         $lvl = 0;
-                        $grp_id = NULL;
-                        $parent_id = NULL;
+                        $grp_id = null;
+                        $parent_id = null;
 
                         if ($fieldname == 'multiple_fields' && is_array($fieldvalue)) {
                             foreach ($fieldvalue as $index => $value) {
@@ -981,7 +981,8 @@ class CentreonConfigCentreonBroker
                             $grp_id = $info[1];
                             $query = 'INSERT INTO cfg_centreonbroker_info (config_id, config_key, config_value,'
                                 . 'config_group, config_group_id, grp_level, subgrp_id, parent_grp_id)  VALUES ('
-                                . ':config_id, :config_key, :config_value, :config_group, :config_group_id, :grp_level, :subgrp_id, :parent_grp_id)';
+                                . ':config_id, :config_key, :config_value, :config_group, :config_group_id, '
+                                . ':grp_level, :subgrp_id, :parent_grp_id)';
 
                             $stmt = $this->db->prepare($query);
                             $stmt->bindValue(':config_id', $id, \PDO::PARAM_INT);
@@ -1010,7 +1011,7 @@ class CentreonConfigCentreonBroker
                             $parent_id = $grp_id;
                             $fieldname = $info[2];
                         }
-                        $grp_id = NULL;
+                        $grp_id = null;
                         foreach ($fieldvalue as $value) {
                             $query = 'INSERT INTO cfg_centreonbroker_info (config_id, config_key, config_value, '
                                 . 'config_group, config_group_id, grp_level, subgrp_id, parent_grp_id) VALUES ('

--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -756,15 +756,7 @@ class CentreonConfigCentreonBroker
         } catch (\PDOException $e) {
             return false;
         }
-
-        /*
-         * Inputs and Outputs infos
-         */
-        try {
-            $this->updateCentreonBrokerInfos($id, $values);
-        } catch (\PDOException $e) {
-            return false;
-        }
+        $this->updateCentreonBrokerInfos($id, $values);
     }
 
     /**
@@ -835,15 +827,7 @@ class CentreonConfigCentreonBroker
         } catch (\PDOException $e) {
             return false;
         }
-
-        /*
-         * Inputs and Outputs infos
-         */
-        try {
-            $this->updateCentreonBrokerInfos($id, $values);
-        } catch (\PDOException $e) {
-            return false;
-        }
+        $this->updateCentreonBrokerInfos($id, $values);
     }
 
     /**

--- a/www/class/centreonConfigCentreonBroker.php
+++ b/www/class/centreonConfigCentreonBroker.php
@@ -925,27 +925,11 @@ class CentreonConfigCentreonBroker
                                     $stmt->bindValue(':config_key', $fieldname2, \PDO::PARAM_STR);
                                     $stmt->bindValue(':config_value', $value2, \PDO::PARAM_STR);
                                     $stmt->bindValue(':config_group', $group, \PDO::PARAM_STR);
-                                    $stmt->bindValue(
-                                        ':config_group_id',
-                                        $gid,
-                                        is_null($gid) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                                    );
+                                    $stmt->bindValue(':config_group_id', $gid, \PDO::PARAM_INT);
                                     $stmt->bindValue(':grp_level', $lvl, \PDO::PARAM_INT);
-                                    $stmt->bindValue(
-                                        ':subgrp_id',
-                                        $grp_id,
-                                        is_null($grp_id) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                                    );
-                                    $stmt->bindValue(
-                                        ':parent_grp_id',
-                                        $parent_id,
-                                        is_null($parent_id) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                                    );
-                                    $stmt->bindValue(
-                                        ':fieldIndex',
-                                        $index,
-                                        is_null($index) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                                    );
+                                    $stmt->bindValue(':subgrp_id', $grp_id, \PDO::PARAM_INT);
+                                    $stmt->bindValue(':parent_grp_id', $parent_id, \PDO::PARAM_INT);
+                                    $stmt->bindValue(':fieldIndex', $index, \PDO::PARAM_INT);
                                     $stmt->execute();
                                 }
                             }
@@ -973,22 +957,10 @@ class CentreonConfigCentreonBroker
                             $stmt->bindValue(':config_key', $grp_name, \PDO::PARAM_STR);
                             $stmt->bindValue(':config_value', "", \PDO::PARAM_STR);
                             $stmt->bindValue(':config_group', $group, \PDO::PARAM_STR);
-                            $stmt->bindValue(
-                                ':config_group_id',
-                                $gid,
-                                is_null($gid) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                            );
+                            $stmt->bindValue(':config_group_id', $gid, \PDO::PARAM_INT);
                             $stmt->bindValue(':grp_level', $lvl, \PDO::PARAM_INT);
-                            $stmt->bindValue(
-                                ':subgrp_id',
-                                $grp_id,
-                                is_null($grp_id) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                            );
-                            $stmt->bindValue(
-                                ':parent_grp_id',
-                                $parent_id,
-                                is_null($parent_id) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                            );
+                            $stmt->bindValue(':subgrp_id', $grp_id, \PDO::PARAM_INT);
+                            $stmt->bindValue(':parent_grp_id', $parent_id, \PDO::PARAM_INT);
                             $stmt->execute();
 
                             $lvl++;
@@ -1006,22 +978,10 @@ class CentreonConfigCentreonBroker
                             $stmt->bindValue(':config_key', $fieldname, \PDO::PARAM_STR);
                             $stmt->bindValue(':config_value', $value, \PDO::PARAM_STR);
                             $stmt->bindValue(':config_group', $group, \PDO::PARAM_STR);
-                            $stmt->bindValue(
-                                ':config_group_id',
-                                $gid,
-                                is_null($gid) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                            );
+                            $stmt->bindValue(':config_group_id', $gid, \PDO::PARAM_INT);
                             $stmt->bindValue(':grp_level', $lvl, \PDO::PARAM_INT);
-                            $stmt->bindValue(
-                                ':subgrp_id',
-                                $grp_id,
-                                is_null($grp_id) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                            );
-                            $stmt->bindValue(
-                                ':parent_grp_id',
-                                $parent_id,
-                                is_null($parent_id) ? \PDO::PARAM_NULL : \PDO::PARAM_INT
-                            );
+                            $stmt->bindValue(':subgrp_id', $grp_id, \PDO::PARAM_INT);
+                            $stmt->bindValue(':parent_grp_id', $parent_id, \PDO::PARAM_INT);
                             $stmt->execute();
                         }
                     }


### PR DESCRIPTION
## Description

Using special characters in inputs/outpus broker conf cause SQL error and the deletion of the rest of the conf

MON-11473

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

-In a broker output, use a name with symbols , letters and numbers. In the 20.04 and 20.10 versions I used Failover name field; in the 21.04 and 21.10 versions, I used the tls hostname field
-Save the configuration

Expected result:
Configuration should be saved

Received Result:
Page is unable to save the configuration.
Inception happens on refresh;
Checking back on the broker outputs we find that the modified broker output cannot be opened and all the following outputs are deleted.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
