### PR TITLE
enh(logs) : Display current ressource in admin logs details

### DIFF
--- a/www/include/Administration/configChangelog/viewLogsDetails.ihtml
+++ b/www/include/Administration/configChangelog/viewLogsDetails.ihtml
@@ -7,11 +7,11 @@
     </tr>
 </table>
 <table class="ListTable">
-    <tr class="ListHeader">
-        <td class="ListColHeaderCenter" style="white-space:nowrap;">Changes for ...</td>           
-    </tr>
     {assign var='classStyle' value='list_two'}
     {assign var='firstFlag' value=1}
+     <tr class="ListHeader">
+        <td class="ListColHeaderCenter" style="white-space:nowrap;">Changes for {$action[0].object_name}</td>
+    </tr>
     {foreach item=list from=$action}
         {if $classStyle == 'list_two'}
             {assign var='classStyle' value='list_one'}
@@ -34,7 +34,7 @@
                             <td class="ListColHeaderCenter" style="white-space:nowrap;">{$after}</td>
                         </tr>
                         {/if}
-                        {assign var='cpt' value=0}                      
+                        {assign var='cpt' value=0}
                         {foreach item=modif from=$modification}
                             {if $modif.action_log_id == $list.action_log_id}
                             <tr>

--- a/www/include/Administration/configChangelog/viewLogsDetails.ihtml
+++ b/www/include/Administration/configChangelog/viewLogsDetails.ihtml
@@ -7,11 +7,11 @@
     </tr>
 </table>
 <table class="ListTable">
-    {assign var='classStyle' value='list_two'}
-    {assign var='firstFlag' value=1}
-     <tr class="ListHeader">
+    <tr class="ListHeader">
         <td class="ListColHeaderCenter" style="white-space:nowrap;">Changes for {$action[0].object_name}</td>
     </tr>
+    {assign var='classStyle' value='list_two'}
+    {assign var='firstFlag' value=1}
     {foreach item=list from=$action}
         {if $classStyle == 'list_two'}
             {assign var='classStyle' value='list_one'}


### PR DESCRIPTION
## Description

**Fixes** MON-3789

Display current ressource in admin logs details

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* go to Administration > Logs
* click on a object in the field "object name"
* check in the title if the name is displayed in the next to "changes for" 
