### PR TITLE
fix(depedencies) Fix PHP warnings on dependencies

### DIFF
--- a/www/include/configuration/configObject/host_dependency/formHostDependency.php
+++ b/www/include/configuration/configObject/host_dependency/formHostDependency.php
@@ -36,7 +36,7 @@
 $dep = array();
 $childServices = array();
 $initialValues = array();
-if (($o == "c" || $o == "w") && $dep_id) {
+if (($o == MODIFY_DEPENDENCY || $o == WATCH_DEPENDENCY) && $dep_id) {
     $DBRESULT = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $dep_id . "' LIMIT 1");
 
     # Set base value
@@ -83,11 +83,11 @@ $attrServices = array(
  * Form begin
  */
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
-if ($o == "a") {
+if ($o == ADD_DEPENDENCY) {
     $form->addElement('header', 'title', _("Add a Dependency"));
-} elseif ($o == "c") {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $form->addElement('header', 'title', _("Modify a Dependency"));
-} elseif ($o == "w") {
+} elseif ($o == WATCH_DEPENDENCY) {
     $form->addElement('header', 'title', _("View a Dependency"));
 }
 
@@ -110,44 +110,74 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok/Up"),
-    array('id' => 'hUp', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'nUp', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'd',
     '&nbsp;',
     _("Down"),
-    array('id' => 'hDown', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'nDown', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unreachable"),
-    array('id' => 'hUnreachable', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'nUnreachable', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'hPending', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'nPending', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'hNone', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'nNone', 'onClick' => 'applyNotificationRules(this);')
 );
 $form->addGroup($tab, 'notification_failure_criteria', _("Notification Failure Criteria"), '&nbsp;&nbsp;');
 
 $tab = array();
-$tab[] = $form->createElement('checkbox', 'o', '&nbsp;', _("Up"));
-$tab[] = $form->createElement('checkbox', 'd', '&nbsp;', _("Down"));
-$tab[] = $form->createElement('checkbox', 'u', '&nbsp;', _("Unreachable"));
-$tab[] = $form->createElement('checkbox', 'p', '&nbsp;', _("Pending"));
-$tab[] = $form->createElement('checkbox', 'n', '&nbsp;', _("None"));
+$tab[] = $form->createElement(
+    'checkbox',
+    'o',
+    '&nbsp;',
+    _("Up"),
+    ['id' => 'eUp', 'onClick' => 'applyExecutionRules(this);']
+);
+$tab[] = $form->createElement(
+    'checkbox',
+    'd',
+    '&nbsp;',
+    _("Down"),
+    ['id' => 'eDown', 'onClick' => 'applyExecutionRules(this);']
+);
+$tab[] = $form->createElement(
+    'checkbox',
+    'u',
+    '&nbsp;',
+    _("Unreachable"),
+    ['id' => 'eUnreachable', 'onClick' => 'applyExecutionRules(this);']
+);
+$tab[] = $form->createElement(
+    'checkbox',
+    'p',
+    '&nbsp;',
+    _("Pending"),
+    ['id' => 'ePending', 'onClick' => 'applyExecutionRules(this);']
+);
+$tab[] = $form->createElement(
+    'checkbox',
+    'n',
+    '&nbsp;',
+    _("None"),
+    ['id' => 'eNone', 'onClick' => 'applyExecutionRules(this);']
+);
 $form->addGroup($tab, 'execution_failure_criteria', _("Execution Failure Criteria"), '&nbsp;&nbsp;');
 
 $route = './include/common/webServices/rest/internal.php?object=centreon_configuration_host' .
@@ -199,6 +229,8 @@ $form->addRule('dep_hostChilds', _("Circular Definition"), 'cycle');
 $form->registerRule('exist', 'callback', 'testHostDependencyExistence');
 $form->addRule('dep_name', _("Name is already in use"), 'exist');
 $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _("Required fields"));
+$form->addRule('execution_failure_criteria', _("Required Field"), 'required');
+$form->addRule('notification_failure_criteria', _("Required Field"), 'required');
 
 /*
  * Smarty template Init
@@ -221,7 +253,7 @@ foreach ($help as $key => $text) {
 $tpl->assign("helptext", $helptext);
 
 # Just watch a Dependency information
-if ($o == "w") {
+if ($o == WATCH_DEPENDENCY) {
     if ($centreon->user->access->page($p) != 2) {
         $form->addElement(
             "button",
@@ -233,12 +265,12 @@ if ($o == "w") {
     $form->setDefaults($dep);
     $form->freeze();
 } # Modify a Dependency information
-elseif ($o == "c") {
+elseif ($o == MODIFY_DEPENDENCY) {
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($dep);
 } # Add a Dependency information
-elseif ($o == "a") {
+elseif ($o == ADD_DEPENDENCY) {
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults(array('inherits_parent', '0'));
@@ -274,19 +306,26 @@ if ($valid) {
 
 ?>
 <script type="text/javascript">
-    function uncheckAllH(object) {
-        if (object.id == "hNone" && object.checked) {
-            document.getElementById('hUp').checked = false;
-            document.getElementById('hDown').checked = false;
-            document.getElementById('hUnreachable').checked = false;
-            document.getElementById('hPending').checked = false;
-            if (document.getElementById('hFlapping')) {
-                document.getElementById('hFlapping').checked = false;
-            }
+    function applyNotificationRules(object) {
+        if (object.id == "nNone" && object.checked) {
+            document.getElementById('nUp').checked = false;
+            document.getElementById('nDown').checked = false;
+            document.getElementById('nUnreachable').checked = false;
+            document.getElementById('nPending').checked = false;
         }
         else {
-            document.getElementById('hNone').checked = false;
+            document.getElementById('nNone').checked = false;
         }
     }
-
+    function applyExecutionRules(object) {
+        if (object.id === "eNone" && object.checked) {
+            document.getElementById('eUp').checked = false;
+            document.getElementById('eDown').checked = false;
+            document.getElementById('eUnreachable').checked = false;
+            document.getElementById('ePending').checked = false;
+        }
+        else {
+            document.getElementById('eNone').checked = false;
+        }
+    }
 </script>

--- a/www/include/configuration/configObject/host_dependency/formHostDependency.php
+++ b/www/include/configuration/configObject/host_dependency/formHostDependency.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
@@ -264,13 +265,11 @@ if ($o == WATCH_DEPENDENCY) {
     }
     $form->setDefaults($dep);
     $form->freeze();
-} # Modify a Dependency information
-elseif ($o == MODIFY_DEPENDENCY) {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($dep);
-} # Add a Dependency information
-elseif ($o == ADD_DEPENDENCY) {
+} elseif ($o == ADD_DEPENDENCY) {
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults(array('inherits_parent', '0'));
@@ -293,8 +292,8 @@ if ($valid) {
     require_once("listHostDependency.php");
 } else {
     /*
-	 * Apply a template definition
-	 */
+     * Apply a template definition
+     */
     $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl, true);
     $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font>');
     $renderer->setErrorTemplate('<font color="red">{$error}</font><br />{$html}');

--- a/www/include/configuration/configObject/host_dependency/hostDependency.php
+++ b/www/include/configuration/configObject/host_dependency/hostDependency.php
@@ -38,6 +38,12 @@ if (!isset($centreon)) {
     exit();
 }
 
+const ADD_DEPENDENCY = 'a';
+const WATCH_DEPENDENCY = 'w';
+const MODIFY_DEPENDENCY = 'c';
+const DUPLICATE_DEPENDENCY = 'm';
+const DELETE_DEPENDENCY = 'd';
+
 /*
  * Path to the configuration dir
  */
@@ -72,12 +78,12 @@ $acl = $centreon->user->access;
 $dbmon = $acl->getNameDBAcl();
 
 switch ($o) {
-    case "a": # Add a Dependency
-    case "w": # Watch a Dependency
-    case "c": # Modify a Dependency
+    case ADD_DEPENDENCY:
+    case WATCH_DEPENDENCY:
+    case MODIFY_DEPENDENCY:
         require_once($path . "formHostDependency.php");
         break;
-    case "m": # Duplicate n Dependencies
+    case DUPLICATE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
@@ -90,7 +96,7 @@ switch ($o) {
         }
         require_once($path . "listHostDependency.php");
         break;
-    case "d": # Delete n Dependencies
+    case DELETE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();

--- a/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+++ b/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
@@ -246,13 +247,11 @@ if ($o == WATCH_DEPENDENCY) {
     }
     $form->setDefaults($dep);
     $form->freeze();
-} # Modify a Dependency information
-elseif ($o == MODIFY_DEPENDENCY) {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($dep);
-} # Add a Dependency information
-elseif ($o == ADD_DEPENDENCY) {
+} elseif ($o == ADD_DEPENDENCY) {
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults(array('inherits_parent', '0'));
@@ -288,8 +287,8 @@ if ($valid) {
     require_once("listHostGroupDependency.php");
 } else {
     /*
-	 * Apply a template definition
-	 */
+     * Apply a template definition
+     */
     $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl, true);
     $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font>');
     $renderer->setErrorTemplate('<font color="red">{$error}</font><br />{$html}');

--- a/www/include/configuration/configObject/hostgroup_dependency/hostGroupDependency.php
+++ b/www/include/configuration/configObject/hostgroup_dependency/hostGroupDependency.php
@@ -38,6 +38,11 @@ if (!isset($centreon)) {
     exit();
 }
 
+const ADD_DEPENDENCY = 'a';
+const WATCH_DEPENDENCY = 'w';
+const MODIFY_DEPENDENCY = 'c';
+const DUPLICATE_DEPENDENCY = 'm';
+const DELETE_DEPENDENCY = 'd';
 /*
  * Path to the configuration dir
  */
@@ -49,7 +54,7 @@ $path = "./include/configuration/configObject/hostgroup_dependency/";
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
-$dep_id = filter_var(
+$depId = filter_var(
     $_GET['dep_id'] ?? $_POST['dep_id'] ?? null,
     FILTER_VALIDATE_INT
 );
@@ -74,12 +79,12 @@ $hgs = $acl->getHostGroupAclConf(null, 'broker');
 $hgstring = CentreonUtils::toStringWithQuotes($hgs);
 
 switch ($o) {
-    case "a": # Add a Dependency
-    case "w": # Watch a Dependency
-    case "c": # Modify a Dependency
+    case ADD_DEPENDENCY:
+    case WATCH_DEPENDENCY:
+    case MODIFY_DEPENDENCY:
         require_once($path . "formHostGroupDependency.php");
         break;
-    case "m": # Duplicate n Dependencies
+    case DUPLICATE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
@@ -92,7 +97,7 @@ switch ($o) {
         }
         require_once($path . "listHostGroupDependency.php");
         break;
-    case "d": # Delete n Dependency
+    case DELETE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();

--- a/www/include/configuration/configObject/metaservice_dependency/MetaServiceDependency.php
+++ b/www/include/configuration/configObject/metaservice_dependency/MetaServiceDependency.php
@@ -38,6 +38,12 @@ if (!isset($centreon)) {
     exit();
 }
 
+const ADD_DEPENDENCY = 'a';
+const WATCH_DEPENDENCY = 'w';
+const MODIFY_DEPENDENCY = 'c';
+const DUPLICATE_DEPENDENCY = 'm';
+const DELETE_DEPENDENCY = 'd';
+
 #Path to the configuration dir
 $path = "./include/configuration/configObject/metaservice_dependency/";
 
@@ -69,12 +75,12 @@ $acl = $oreon->user->access;
 $metastr = $acl->getMetaServiceString();
 
 switch ($o) {
-    case "a": # Add a Meta Service
-    case "w": # Watch a Meta Service
-    case "c": # Modify a Meta Service
+    case ADD_DEPENDENCY:
+    case WATCH_DEPENDENCY:
+    case MODIFY_DEPENDENCY:
         require_once($path . "formMetaServiceDependency.php");
         break;
-    case "m": # Duplicate n Meta Services
+    case DUPLICATE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
@@ -87,7 +93,7 @@ switch ($o) {
         }
         require_once($path . "listMetaServiceDependency.php");
         break;
-    case "d": # Delete n Meta Service
+    case DELETE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();

--- a/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+++ b/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
@@ -40,7 +40,7 @@
 $dep = array();
 $initialValues = array();
 
-if (($o == "c" || $o == "w") && $dep_id) {
+if (($o == MODIFY_DEPENDENCY || $o == WATCH_DEPENDENCY) && $dep_id) {
     $DBRESULT = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
     $DBRESULT->bindValue(':dep_id', $dep_id, PDO::PARAM_INT);
     $DBRESULT->execute();
@@ -100,11 +100,11 @@ $attrMetas = array(
 ## Form begin
 #
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
-if ($o == "a") {
+if ($o == ADD_DEPENDENCY) {
     $form->addElement('header', 'title', _("Add a Dependency"));
-} elseif ($o == "c") {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $form->addElement('header', 'title', _("Modify a Dependency"));
-} elseif ($o == "w") {
+} elseif ($o == WATCH_DEPENDENCY) {
     $form->addElement('header', 'title', _("View a Dependency"));
 }
 
@@ -127,42 +127,42 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok"),
-    array('id' => 'sOk', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nOk', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nWarning', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nUnknown', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nCritical', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'sPending', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nPending', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nNone', 'onClick' => 'applyNotificationRules(this);')
 );
 $form->addGroup($tab, 'notification_failure_criteria', _("Notification Failure Criteria"), '&nbsp;&nbsp;');
 
@@ -172,42 +172,42 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok"),
-    array('id' => 'sOk2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eOk', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eWarning', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eUnknown', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eCritical', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'sPending2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'ePending', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eNone', 'onClick' => 'applyExecutionRules(this);')
 );
 $form->addGroup($tab, 'execution_failure_criteria', _("Execution Failure Criteria"), '&nbsp;&nbsp;');
 
@@ -249,6 +249,8 @@ $form->addRule('dep_msChilds', _("Circular Definition"), 'cycle');
 $form->registerRule('exist', 'callback', 'testExistence');
 $form->addRule('dep_name', _("Name is already in use"), 'exist');
 $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _("Required fields"));
+$form->addRule('execution_failure_criteria', _("Required Field"), 'required');
+$form->addRule('notification_failure_criteria', _("Required Field"), 'required');
 
 #
 ##End of form definition
@@ -259,7 +261,7 @@ $tpl = new Smarty();
 $tpl = initSmartyTpl($path, $tpl);
 
 # Just watch a Dependency information
-if ($o == "w") {
+if ($o == WATCH_DEPENDENCY) {
     if ($centreon->user->access->page($p) != 2) {
         $form->addElement(
             "button",
@@ -270,11 +272,11 @@ if ($o == "w") {
     }
     $form->setDefaults($dep);
     $form->freeze();
-} elseif ($o == "c") { # Modify a Dependency information
+} elseif ($o == MODIFY_DEPENDENCY) { # Modify a Dependency information
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($dep);
-} elseif ($o == "a") { # Add a Dependency information
+} elseif ($o == ADD_DEPENDENCY) { # Add a Dependency information
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults(array('inherits_parent', '0'));
@@ -320,29 +322,29 @@ if ($valid) {
 }
 ?>
 <script type="text/javascript">
-    function uncheckAllS(object) {
-        if (object.id == "sNone" && object.checked) {
-            document.getElementById('sOk').checked = false;
-            document.getElementById('sWarning').checked = false;
-            document.getElementById('sUnknown').checked = false;
-            document.getElementById('sCritical').checked = false;
-            document.getElementById('sRecovery').checked = false;
+    function applyNotificationRules(object) {
+        if (object.id == "nNone" && object.checked) {
+            document.getElementById('nOk').checked = false;
+            document.getElementById('nWarning').checked = false;
+            document.getElementById('nUnknown').checked = false;
+            document.getElementById('nCritical').checked = false;
+            document.getElementById('nPending').checked = false;
         }
         else {
-            document.getElementById('sNone').checked = false;
+            document.getElementById('nNone').checked = false;
         }
     }
 
-    function uncheckAllS2(object) {
-        if (object.id == "sNone2" && object.checked) {
-            document.getElementById('sOk2').checked = false;
-            document.getElementById('sWarning2').checked = false;
-            document.getElementById('sUnknown2').checked = false;
-            document.getElementById('sCritical2').checked = false;
-            document.getElementById('sRecovery2').checked = false;
+    function applyExecutionRules(object) {
+        if (object.id == "eNone" && object.checked) {
+            document.getElementById('eOk').checked = false;
+            document.getElementById('eWarning').checked = false;
+            document.getElementById('eUnknown').checked = false;
+            document.getElementById('eCritical').checked = false;
+            document.getElementById('ePending').checked = false;
         }
         else {
-            document.getElementById('sNone2').checked = false;
+            document.getElementById('eNone').checked = false;
         }
     }
 </script>

--- a/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+++ b/www/include/configuration/configObject/service_dependency/formServiceDependency.php
@@ -41,7 +41,7 @@ $parentServices = array();
 $childServices = array();
 
 $initialValues = array();
-if (($o == "c" || $o == "w") && $dep_id) {
+if (($o == MODIFY_DEPENDENCY || $o == WATCH_DEPENDENCY) && $dep_id) {
     $DBRESULT = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
     $DBRESULT->bindValue(':dep_id', $dep_id, PDO::PARAM_INT);
     $DBRESULT->execute();
@@ -90,11 +90,11 @@ $attrServices = array(
 
 # Form begin
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
-if ($o == "a") {
+if ($o == ADD_DEPENDENCY) {
     $form->addElement('header', 'title', _("Add a Dependency"));
-} elseif ($o == "c") {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $form->addElement('header', 'title', _("Modify a Dependency"));
-} elseif ($o == "w") {
+} elseif ($o == WATCH_DEPENDENCY) {
     $form->addElement('header', 'title', _("View a Dependency"));
 }
 
@@ -115,42 +115,42 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok"),
-    array('id' => 'sOk', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nOk', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nWarning', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nUnknown', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nCritical', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'sPending', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nPending', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nNone', 'onClick' => 'applyNotificationRules(this);')
 );
 
 $form->addGroup($tab, 'notification_failure_criteria', _("Notification Failure Criteria"), '&nbsp;&nbsp;');
@@ -160,42 +160,42 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok"),
-    array('id' => 'sOk2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eOk', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eWarning', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eUnknown', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eCritical', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'sPending2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'ePending', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eNone', 'onClick' => 'applyExecutionRules(this);')
 );
 $form->addGroup($tab, 'execution_failure_criteria', _("Execution Failure Criteria"), '&nbsp;&nbsp;');
 
@@ -244,7 +244,8 @@ $form->addRule('dep_hSvChi', _("Circular Definition"), 'cycleH');
 $form->registerRule('exist', 'callback', 'testServiceDependencyExistence');
 $form->addRule('dep_name', _("Name is already in use"), 'exist');
 $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _("Required fields"));
-
+$form->addRule('execution_failure_criteria', _("Required Field"), 'required');
+$form->addRule('notification_failure_criteria', _("Required Field"), 'required');
 
 /*
  * Smarty template Init
@@ -271,7 +272,7 @@ foreach ($help as $key => $text) {
 $tpl->assign("helptext", $helptext);
 
 // Just watch a Dependency information
-if ($o == "w") {
+if ($o == WATCH_DEPENDENCY) {
     if ($centreon->user->access->page($p) != 2) {
         $form->addElement(
             "button",
@@ -282,11 +283,11 @@ if ($o == "w") {
     }
     $form->setDefaults($dep);
     $form->freeze();
-} elseif ($o == "c") {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($dep);
-} elseif ($o == "a") {
+} elseif ($o == ADD_DEPENDENCY) {
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults(array('inherits_parent', '0'));
@@ -321,27 +322,27 @@ if ($valid) {
 }
 ?>
 <script type="text/javascript">
-    function uncheckAllS(object) {
-        if (object.id == "sNone" && object.checked) {
-            document.getElementById('sOk').checked = false;
-            document.getElementById('sWarning').checked = false;
-            document.getElementById('sUnknown').checked = false;
-            document.getElementById('sCritical').checked = false;
-            document.getElementById('sPending').checked = false;
+    function applyNotificationRules(object) {
+        if (object.id == "nNone" && object.checked) {
+            document.getElementById('nOk').checked = false;
+            document.getElementById('nWarning').checked = false;
+            document.getElementById('nUnknown').checked = false;
+            document.getElementById('nCritical').checked = false;
+            document.getElementById('nPending').checked = false;
         } else {
-            document.getElementById('sNone').checked = false;
+            document.getElementById('nNone').checked = false;
         }
     }
 
-    function uncheckAllS2(object) {
-        if (object.id == "sNone2" && object.checked) {
-            document.getElementById('sOk2').checked = false;
-            document.getElementById('sWarning2').checked = false;
-            document.getElementById('sUnknown2').checked = false;
-            document.getElementById('sCritical2').checked = false;
-            document.getElementById('sPending2').checked = false;
+    function applyExecutionRules(object) {
+        if (object.id == "eNone" && object.checked) {
+            document.getElementById('eOk').checked = false;
+            document.getElementById('eWarning').checked = false;
+            document.getElementById('eUnknown').checked = false;
+            document.getElementById('eCritical').checked = false;
+            document.getElementById('ePending').checked = false;
         } else {
-            document.getElementById('sNone2').checked = false;
+            document.getElementById('eNone').checked = false;
         }
     }
 

--- a/www/include/configuration/configObject/service_dependency/serviceDependency.php
+++ b/www/include/configuration/configObject/service_dependency/serviceDependency.php
@@ -38,6 +38,12 @@ if (!isset($centreon)) {
     exit();
 }
 
+const ADD_DEPENDENCY = 'a';
+const WATCH_DEPENDENCY = 'w';
+const MODIFY_DEPENDENCY = 'c';
+const DUPLICATE_DEPENDENCY = 'm';
+const DELETE_DEPENDENCY = 'd';
+
 /*
  * Path to the configuration dir
  */
@@ -73,12 +79,12 @@ if (isset($ret) && is_array($ret) && $ret['topology_page'] != "" && $p != $ret['
     $dbmon = $acl->getNameDBAcl();
 
 switch ($o) {
-    case "a": # Add a Dependency
-    case "w": # Watch a Dependency
-    case "c": # Modify a Dependency
+    case ADD_DEPENDENCY:
+    case WATCH_DEPENDENCY:
+    case MODIFY_DEPENDENCY:
         require_once($path . "formServiceDependency.php");
         break;
-    case "m": # Duplicate n Dependencies
+    case DUPLICATE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
@@ -91,7 +97,7 @@ switch ($o) {
         }
         require_once($path . "listServiceDependency.php");
         break;
-    case "d": # Delete n Dependencies
+    case DELETE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();

--- a/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+++ b/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
@@ -40,7 +40,7 @@
 #
 $dep = array();
 $initialValues = array();
-if (($o == "c" || $o == "w") && $dep_id) {
+if (($o == MODIFY_DEPENDENCY || $o == WATCH_DEPENDENCY) && $dep_id) {
     $DBRESULT = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
     $DBRESULT->bindValue(':dep_id', $dep_id, PDO::PARAM_INT);
     $DBRESULT->execute();
@@ -90,11 +90,11 @@ $attrServicegroups = array(
  * Form begin
  */
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
-if ($o == "a") {
+if ($o == ADD_DEPENDENCY) {
     $form->addElement('header', 'title', _("Add a Dependency"));
-} elseif ($o == "c") {
+} elseif ($o == MODIFY_DEPENDENCY) {
     $form->addElement('header', 'title', _("Modify a Dependency"));
-} elseif ($o == "w") {
+} elseif ($o == WATCH_DEPENDENCY) {
     $form->addElement('header', 'title', _("View a Dependency"));
 }
 
@@ -117,42 +117,42 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok"),
-    array('id' => 'sOk', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nOk', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nWarning', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nUnknown', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nCritical', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'sPending', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nPending', 'onClick' => 'applyNotificationRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'nNone', 'onClick' => 'applyNotificationRules(this);')
 );
 $form->addGroup($tab, 'notification_failure_criteria', _("Notification Failure Criteria"), '&nbsp;&nbsp;');
 
@@ -162,42 +162,42 @@ $tab[] = $form->createElement(
     'o',
     '&nbsp;',
     _("Ok"),
-    array('id' => 'sOk2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eOk', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eWarning', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eUnknown', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eCritical', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'p',
     '&nbsp;',
     _("Pending"),
-    array('id' => 'sPending2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'ePending', 'onClick' => 'applyExecutionRules(this);')
 );
 $tab[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone2', 'onClick' => 'uncheckAllS2(this);')
+    array('id' => 'eNone', 'onClick' => 'applyExecutionRules(this);')
 );
 $form->addGroup($tab, 'execution_failure_criteria', _("Execution Failure Criteria"), '&nbsp;&nbsp;');
 
@@ -238,6 +238,7 @@ $form->addRule('dep_description', _("Unauthorized value"), 'sanitize');
 $form->addRule('dep_sgParents', _("Required Field"), 'required');
 $form->addRule('dep_sgChilds', _("Required Field"), 'required');
 
+$form->addRule('execution_failure_criteria', _("Required Field"), 'required');
 $form->addRule('notification_failure_criteria', _("Required Field"), 'required');
 
 $form->registerRule('cycle', 'callback', 'testServiceGroupDependencyCycle');
@@ -255,7 +256,7 @@ $tpl = initSmartyTpl($path, $tpl);
 /*
  * Just watch a Dependency information
  */
-if ($o == "w") {
+if ($o == WATCH_DEPENDENCY) {
     if ($centreon->user->access->page($p) != 2) {
         $form->addElement(
             "button",
@@ -266,12 +267,12 @@ if ($o == "w") {
     }
     $form->setDefaults($dep);
     $form->freeze();
-} elseif ($o == "c") {
+} elseif ($o == MODIFY_DEPENDENCY) {
     # Modify a Dependency information
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($dep);
-} elseif ($o == "a") {
+} elseif ($o == ADD_DEPENDENCY) {
     # Add a Dependency information
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
@@ -319,27 +320,29 @@ if ($valid) {
 }
 ?>
 <script type="text/javascript">
-    function uncheckAllS(object) {
-        if (object.id == "sNone" && object.checked) {
-            document.getElementById('sOk').checked = false;
-            document.getElementById('sWarning').checked = false;
-            document.getElementById('sUnknown').checked = false;
-            document.getElementById('sCritical').checked = false;
-            document.getElementById('sPending').checked = false;
-        } else {
-            document.getElementById('sNone').checked = false;
+    function applyNotificationRules(object) {
+      console.log(object.id);
+        if (object.id === "nNone" && object.checked) {
+            document.getElementById('nOk').checked = false;
+            document.getElementById('nWarning').checked = false;
+            document.getElementById('nUnknown').checked = false;
+            document.getElementById('nCritical').checked = false;
+            document.getElementById('nPending').checked = false;
+        }
+        else {
+            document.getElementById('nNone').checked = false;
         }
     }
-
-    function uncheckAllS2(object) {
-        if (object.id == "sNone2" && object.checked) {
-            document.getElementById('sOk2').checked = false;
-            document.getElementById('sWarning2').checked = false;
-            document.getElementById('sUnknown2').checked = false;
-            document.getElementById('sCritical2').checked = false;
-            document.getElementById('sPending2').checked = false;
-        } else {
-            document.getElementById('sNone2').checked = false;
+    function applyExecutionRules(object) {
+        if (object.id === "eNone" && object.checked) {
+            document.getElementById('eOk').checked = false;
+            document.getElementById('eWarning').checked = false;
+            document.getElementById('eUnknown').checked = false;
+            document.getElementById('eCritical').checked = false;
+            document.getElementById('ePending').checked = false;
+        }
+        else {
+            document.getElementById('eNone').checked = false;
         }
     }
 </script>

--- a/www/include/configuration/configObject/servicegroup_dependency/serviceGroupDependency.php
+++ b/www/include/configuration/configObject/servicegroup_dependency/serviceGroupDependency.php
@@ -38,6 +38,12 @@ if (!isset($centreon)) {
     exit();
 }
 
+const ADD_DEPENDENCY = 'a';
+const WATCH_DEPENDENCY = 'w';
+const MODIFY_DEPENDENCY = 'c';
+const DUPLICATE_DEPENDENCY = 'm';
+const DELETE_DEPENDENCY = 'd';
+
 /*
  * Path to the configuration dir
  */
@@ -74,12 +80,12 @@ $sgs = $acl->getServiceGroupAclConf(null, 'broker');
 $sgstring = CentreonUtils::toStringWithQuotes($sgs);
 
 switch ($o) {
-    case "a": # Add a Dependency
-    case "w": # Watch a Dependency
-    case "c": # Modify a Dependency
+    case ADD_DEPENDENCY:
+    case WATCH_DEPENDENCY:
+    case MODIFY_DEPENDENCY:
         require_once($path . "formServiceGroupDependency.php");
         break;
-    case "m": # Duplicate n Dependencies
+    case DUPLICATE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
@@ -92,7 +98,7 @@ switch ($o) {
         }
         require_once($path . "listServiceGroupDependency.php");
         break;
-    case "d": # Delete n Dependency
+    case DELETE_DEPENDENCY:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();


### PR DESCRIPTION
## Description

Some PHP warnings appears after creating dependencies (host, hostgroup, service, servicegroup or meta-service dependency).
We make the 'Execution Failure Criteria' and 'Notification Failure Criteria' fields mandatory.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
