### PR TITLE
fix(admin) remove extra spaces in filter inputs

### DIFF
--- a/www/include/Administration/performance/viewData.ihtml
+++ b/www/include/Administration/performance/viewData.ihtml
@@ -12,16 +12,8 @@
             <td><h4>{$Pollers}</h4></td>
         </tr>
         <tr>
-            <td><input type='text' name='searchH' value="
-                {if isset($searchH)}
-                    {$searchH}
-                {/if}
-            "/></td>
-            <td><input type='text' name='searchS' value="
-                {if isset($searchS)}
-                    {$searchS}
-                {/if}
-            "/></td>
+            <td><input type='text' name='searchH' value="{if isset($searchH)}{$searchH}{/if}"/></td>
+            <td><input type='text' name='searchS' value="{if isset($searchS)}{$searchS}{/if}"/></td>
             <td>{$form.searchP.html}</td>
             <td>{$form.Search.html}</td>
         </tr>


### PR DESCRIPTION
## Description

When validating a search, spaces are added at the start and end of filters inputs

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to Administration > Parameters > Data
Add some text in host and/or services filters input and click on search button
Search inputs have extra spaces

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
