### PR TITLE
fix(php): remove php warnings in performance data management

### DIFF
--- a/www/include/Administration/performance/viewData.ihtml
+++ b/www/include/Administration/performance/viewData.ihtml
@@ -12,16 +12,8 @@
             <td><h4>{$Pollers}</h4></td>
         </tr>
         <tr>
-            <td><input type='text' name='searchH' value="
-                {if isset($searchH)}
-                    {$searchH}
-                {/if}
-            "/></td>
-            <td><input type='text' name='searchS' value="
-                {if isset($searchS)}
-                    {$searchS}
-                {/if}
-            "/></td>
+            <td><input type='text' name='searchH' value="{if isset($searchH)}{$searchH}{/if}"/></td>
+            <td><input type='text' name='searchS' value="{if isset($searchS)}{$searchS}{/if}"/></td>
             <td>{$form.searchP.html}</td>
             <td>{$form.Search.html}</td>
         </tr>

--- a/www/include/Administration/performance/viewMetrics.ihtml
+++ b/www/include/Administration/performance/viewMetrics.ihtml
@@ -6,7 +6,6 @@
 			<td>
 				{$form.o1.html}
 				&nbsp;&nbsp;&nbsp;
-				<!-- <a href="{$msg.addL}" class="btc bt_success">{$msg.addT}</a> -->
 			</td>
 			{php}
 			   include('./include/common/pagination.php');
@@ -53,14 +52,13 @@
 			<td>
 				{$form.o2.html}
 				&nbsp;&nbsp;&nbsp;
-				<!-- <a href="{$msg.addL}" class="btc bt_success">{$msg.addT}</a> -->
 			</td>
-			<input name="o" value="{$o}" type="hidden">		
+			<input name="o" value="{$o}" type="hidden">
 			{php}
 			   include('./include/common/pagination.php');
 			{/php}
 		</tr>
 	</table>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value='{$limit}'>
 {$form.hidden}
 </form>


### PR DESCRIPTION
## Description

remove php warnings during performance data management
**Fixes** MON-11432

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)