### PR TITLE
fix(image) : allow uppercase extension during file upload

### DIFF
--- a/www/include/options/media/images/DB-Func.php
+++ b/www/include/options/media/images/DB-Func.php
@@ -439,7 +439,7 @@ function isCorrectMIMEType(array $file): bool
         "zip" => "application/zip",
         "gzip" => "application/x-gzip"
     ];
-    $fileExtension = end(explode(".", $file["name"]));
+    $fileExtension = strtolower(end(explode(".", $file["name"])));
     if (!array_key_exists($fileExtension, $mimeTypeFileExtensionConcordance)) {
         return false;
     }


### PR DESCRIPTION
## Description

**Fixes** MON-10977

Allow uppercase extension during file upload

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Go to Administration  >  Parameters  >  Images
* Try to upload an image with an extension in UPPERCASE
* Check if the file is uploaded or not