### PR TITLE
fix(typology) : display submenu subsections for non admin users

### DIFF
--- a/src/Centreon/Domain/Repository/TopologyRepository.php
+++ b/src/Centreon/Domain/Repository/TopologyRepository.php
@@ -44,9 +44,9 @@ use PDO;
 
 class TopologyRepository extends ServiceEntityRepository
 {
-    const ACL_ACCESS_NONE = 0;
-    const ACL_ACCESS_READ_WRITE = 1;
-    const ACL_ACCESS_READ_ONLY = 2;
+    private const ACL_ACCESS_NONE = 0;
+    private const ACL_ACCESS_READ_WRITE = 1;
+    private const ACL_ACCESS_READ_ONLY = 2;
 
     /**
      * Disable Menus for a Master-to-Remote transition

--- a/src/Centreon/Domain/Repository/TopologyRepository.php
+++ b/src/Centreon/Domain/Repository/TopologyRepository.php
@@ -164,7 +164,7 @@ class TopologyRepository extends ServiceEntityRepository
 
         $whereClause = false;
         if (!$user->access->admin) {
-            $query .= ' WHERE topology_page IN (' . $user->access->getTopologyString() . ')';
+            $query .= ' WHERE topology_page IN (' . $user->access->getTopologyString() . ')  OR topology_page IS NULL';
             $whereClause = true;
         }
 


### PR DESCRIPTION
## Description

**Fixes** MON-5414

Display submenu subsections for non admin users

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Connect to centron with an non admin user (or create a user with enought ACL privileges)
* Check if the submenus labels are displayed when moving the cursor to Administration


