### PR TITLE
fix(authentication): correct PHP error

### DIFF
--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -436,7 +436,7 @@ class CentreonAuthSSO extends CentreonAuth
             $this->CentreonLog->insertLog(
                 1,
                 sprintf(
-                    "[%s] [Error] Unable to get Token Access Information: %S, message: %s",
+                    "[%s] [Error] Unable to get Token Access Information: %s, message: %s",
                     $this->source,
                     get_class($e),
                     $e->getMessage()


### PR DESCRIPTION
## Description

When enable debug for authentication and use OpenId a PHP issue appears:

```
[02-Nov-2021 14:47:27 Europe/Paris] PHP Fatal error:  Uncaught ValueError: Unknown format specifier "S" in /usr/share/centreon/www/class/centreonAuth.SSO.class.php:442
Stack trace:
#0 /usr/share/centreon/www/class/centreonAuth.SSO.class.php(442): sprintf()
#1 /usr/share/centreon/www/class/centreonAuth.SSO.class.php(189): CentreonAuthSSO->getOpenIdConnectToken()
#2 /usr/share/centreon/www/include/core/login/processLogin.php(92): CentreonAuthSSO->__construct()
#3 /usr/share/centreon/www/include/core/login/login.php(77): require_once('...')
#4 /usr/share/centreon/www/index.php(154): include_once('...')
#5 {main}
  thrown in /usr/share/centreon/www/class/centreonAuth.SSO.class.php on line 442
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use OIDC authentication
Enable debug for authentication

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
