### PR TITLE
MON-6255-acl-dont-compute-when-services-added-by-clapi

### DIFF
--- a/www/class/centreon-clapi/centreonObject.class.php
+++ b/www/class/centreon-clapi/centreonObject.class.php
@@ -301,6 +301,8 @@ abstract class CentreonObject
         if (method_exists($this, "insertRelations")) {
             $this->insertRelations($id);
         }
+        $aclObj = new CentreonACL($this->dependencyInjector);
+        $aclObj->reload(true);
     }
 
 
@@ -326,6 +328,8 @@ abstract class CentreonObject
         if (count($ids)) {
             $this->object->delete($ids[0]);
             $this->addAuditLog('d', $ids[0], $objectName);
+            $aclObj = new CentreonACL($this->dependencyInjector);
+            $aclObj->reload(true);
         } else {
             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $objectName);
         }

--- a/www/class/centreon-clapi/centreonService.class.php
+++ b/www/class/centreon-clapi/centreonService.class.php
@@ -1260,6 +1260,10 @@ class CentreonService extends CentreonObject
                             }
                         }
                     }
+                    if (in_array($matches[2], ["servicegroup", "host"])) {
+                        $aclObj = new CentreonACL($this->dependencyInjector);
+                        $aclObj->reload(true);
+                    }
                 }
             } else {
                 throw new CentreonClapiException(self::UNKNOWN_METHOD);


### PR DESCRIPTION
## Description

When creating a service or host via clapi, acl are not reloaded properly

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create a new user with ACL
Create new service attach to a host that my user can see via the ACL with CLAPI
export configuration
Service should appear in monitoring list for the user

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
