### PR TITLE
Fix(Poller): Poller adding issue fixed

### DIFF
--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/ServerConnectionConfigurationService.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/ServerConnectionConfigurationService.php
@@ -3,7 +3,6 @@
 namespace CentreonRemote\Domain\Service\ConfigurationWizard;
 
 use Centreon\Infrastructure\CentreonLegacyDB\CentreonDBAdapter;
-
 use CentreonRemote\Domain\Resources\RemoteConfig\NagiosServer;
 use CentreonRemote\Domain\Resources\RemoteConfig\CfgNagios;
 use CentreonRemote\Domain\Resources\RemoteConfig\CfgNagiosBrokerModule;
@@ -69,6 +68,7 @@ abstract class ServerConnectionConfigurationService
      * Set one peer retention mode
      *
      * @param bool $onePeerRetention if one peer retention mode is enabled
+     * @return void
      */
     public function setOnePeerRetention(bool $onePeerRetention): void
     {
@@ -138,8 +138,10 @@ abstract class ServerConnectionConfigurationService
             throw new \Exception('Resources records from `cfg_resource` could not be fetched.');
         }
 
-        if ($results[0]->resource_name != '$USER1$' ||
-            $results[1]->resource_name != '$CENTREONPLUGINS$'
+        if (
+            !in_array($results[0]->resource_name, ["\$CENTREONPLUGINS$","\$USER1$"])
+            && !in_array($results[1]->resource_name, ["\$CENTREONPLUGINS$,","\$USER1$"])
+            && $results[0]->resource_name !== $results[1]->resource_name
         ) {
             throw new \Exception('Resources records from `cfg_resource` are not as expected.');
         }

--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/ServerConnectionConfigurationService.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/ServerConnectionConfigurationService.php
@@ -3,6 +3,7 @@
 namespace CentreonRemote\Domain\Service\ConfigurationWizard;
 
 use Centreon\Infrastructure\CentreonLegacyDB\CentreonDBAdapter;
+
 use CentreonRemote\Domain\Resources\RemoteConfig\NagiosServer;
 use CentreonRemote\Domain\Resources\RemoteConfig\CfgNagios;
 use CentreonRemote\Domain\Resources\RemoteConfig\CfgNagiosBrokerModule;
@@ -68,7 +69,6 @@ abstract class ServerConnectionConfigurationService
      * Set one peer retention mode
      *
      * @param bool $onePeerRetention if one peer retention mode is enabled
-     * @return void
      */
     public function setOnePeerRetention(bool $onePeerRetention): void
     {
@@ -130,7 +130,7 @@ abstract class ServerConnectionConfigurationService
     protected function insertConfigResources($serverID)
     {
         $sql = 'SELECT `resource_id`, `resource_name` FROM `cfg_resource`';
-        $sql .= "WHERE `resource_name` IN('\$USER1$', '\$CENTREONPLUGINS$') ORDER BY `resource_id` ASC";
+        $sql .= "WHERE `resource_name` IN('\$USER1$', '\$CENTREONPLUGINS$') ORDER BY `resource_name` DESC";
         $this->getDbAdapter()->query($sql);
         $results = $this->getDbAdapter()->results();
 
@@ -138,11 +138,7 @@ abstract class ServerConnectionConfigurationService
             throw new \Exception('Resources records from `cfg_resource` could not be fetched.');
         }
 
-        if (
-            !in_array($results[0]->resource_name, ["\$CENTREONPLUGINS$","\$USER1$"])
-            && !in_array($results[1]->resource_name, ["\$CENTREONPLUGINS$,","\$USER1$"])
-            && $results[0]->resource_name !== $results[1]->resource_name
-        ) {
+        if ($results[0]->resource_name != '$USER1$' || $results[1]->resource_name != '$CENTREONPLUGINS$') {
             throw new \Exception('Resources records from `cfg_resource` are not as expected.');
         }
 

--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/ServerConnectionConfigurationService.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/ServerConnectionConfigurationService.php
@@ -138,7 +138,10 @@ abstract class ServerConnectionConfigurationService
             throw new \Exception('Resources records from `cfg_resource` could not be fetched.');
         }
 
-        if ($results[0]->resource_name != '$USER1$' || $results[1]->resource_name != '$CENTREONPLUGINS$') {
+        if (
+            $results[0]->resource_name !== '$USER1$'
+            || $results[1]->resource_name !== '$CENTREONPLUGINS$'
+        ) {
             throw new \Exception('Resources records from `cfg_resource` are not as expected.');
         }
 


### PR DESCRIPTION
## Description

**Fixes** MON-11558

It is now possible to create a new poller even if someone accidently modified ressources in database

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Update the cfg_resource table by deleting the row with $USER1$
* Recreate the row with $USER1$ and make sure the ressource id is bigger than $CENTREONPLUGINS$
* Try to create a new poller in Configuration > Pollers > Pollers and check if it work well

