### PR TITLE
fix(UI): Include host_id when selecting ServiceGroups on dashboard re…

### DIFF
--- a/www/include/reporting/dashboard/DB-Func.php
+++ b/www/include/reporting/dashboard/DB-Func.php
@@ -461,7 +461,7 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
         . $aclCondition . " "
         . $servicesSubquery . " "
         . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysOfWeek . ") "
-        . "GROUP BY las.service_id";
+        . "GROUP BY las.host_id, las.service_id";
     $statement = $pearDBO->prepare($rq);
 
     foreach ($bindValues as $bindName => $bindParams) {


### PR DESCRIPTION
## Description

**Reporting  >  Dashboard  >  Service Groups** show a wrong output if we have a service linked with more than one host. That is because the SQL are "grouping" all the services_ids ignoring if the host_id is different or not.


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [X] 21.10.x
- [ ] 22.04.x (master)

## How this pull request can be tested ?

1. Create 02 hosts
2. Create a *Service by host*
3. On the field  *"Linked with Hosts"* select the 02 hosts that you have created.
4. Create a *Services Group* and select the 02 services that you have created.
5. Apply the changes
6. Go to *Reporting  >  Dashboard  >  Service Groups* select the *Service Group* that you have created.



### Actual SQL result
```sql
+---------+------------+--------+------+-----------+-----------+-----------+-----------+------------+------------+----------------+---------------+
| host_id | service_id | OK_T   | OK_A | WARNING_T | WARNING_A | UNKNOWN_T | UNKNOWN_A | CRITICAL_T | CRITICAL_A | UNDETERMINED_T | MAINTENANCE_T |
+---------+------------+--------+------+-----------+-----------+-----------+-----------+------------+------------+----------------+---------------+
|      89 |       1302 | 345600 |    0 |         0 |         0 |         0 |         0 |          0 |          0 |              0 |             0 |
+---------+------------+--------+------+-----------+-----------+-----------+-----------+------------+------------+----------------+---------------+
```

### Expected SQL result
```sql
+---------+------------+-------+------+-----------+-----------+-----------+-----------+------------+------------+----------------+---------------+
| host_id | service_id | OK_T  | OK_A | WARNING_T | WARNING_A | UNKNOWN_T | UNKNOWN_A | CRITICAL_T | CRITICAL_A | UNDETERMINED_T | MAINTENANCE_T |
+---------+------------+-------+------+-----------+-----------+-----------+-----------+------------+------------+----------------+---------------+
|      70 |       1302 | 86400 |    0 |         0 |         0 |         0 |         0 |          0 |          0 |              0 |             0 |
|      84 |       1302 | 86400 |    0 |         0 |         0 |         0 |         0 |          0 |          0 |              0 |             0 |
|      88 |       1302 | 86400 |    0 |         0 |         0 |         0 |         0 |          0 |          0 |              0 |             0 |
|      89 |       1302 | 86400 |    0 |         0 |         0 |         0 |         0 |          0 |          0 |              0 |             0 |
+---------+------------+-------+------+-----------+-----------+-----------+-----------+------------+------------+----------------+---------------+
```



## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
