### PR TITLE
fix(sql): manage compatibility with mysql 8 on login

### DIFF
--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -308,7 +308,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
                 ON rules.acl_action_rule_id = actions.acl_action_id
             WHERE contact.contact_id = :contact_id
                 AND rules.acl_action_name IS NOT NULL
-            ORDER BY contact.contact_id, rules.acl_action_name';
+            ORDER BY rules.acl_action_name';
 
         $request = $this->translateDbName($request);
         $statement = $this->db->prepare($request);


### PR DESCRIPTION
## Description

manage compatibility with mysql 8 on login

**Fixes** MON-10739

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)