### PR TITLE
fix(UI): Graph tooltip does not always dismiss

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { path, isNil } from 'ramda';
+import { path, isNil, not } from 'ramda';
 
 import { makeStyles, Paper } from '@material-ui/core';
 import IconGraph from '@material-ui/icons/BarChart';
@@ -58,6 +58,7 @@ const GraphColumn = ({
 }): ((props: ComponentColumnProps) => JSX.Element | null) => {
   const GraphHoverChip = ({
     row,
+    isHovered,
   }: ComponentColumnProps): JSX.Element | null => {
     const classes = useStyles();
 
@@ -88,10 +89,11 @@ const GraphColumn = ({
               <IconGraph fontSize="small" />
             </IconButton>
           )}
+          isHovered={isHovered}
           label={label}
         >
-          {({ close }): JSX.Element => {
-            if (isHost) {
+          {({ close, isChipHovered }): JSX.Element => {
+            if (isHost || not(isChipHovered) || not(isHovered)) {
               return <div />;
             }
 

--- a/www/front_src/src/Resources/Listing/columns/HoverChip.tsx
+++ b/www/front_src/src/Resources/Listing/columns/HoverChip.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 
+import { not } from 'ramda';
+
 import { Tooltip, makeStyles } from '@material-ui/core';
+
+import { useMemoComponent } from '@centreon/ui';
 
 const useStyles = makeStyles(() => ({
   iconButton: {
@@ -15,11 +19,18 @@ const useStyles = makeStyles(() => ({
 interface Props {
   Chip: () => JSX.Element;
   children: (props?) => JSX.Element;
+  isHovered?: boolean;
   label: string;
   onClick?: () => void;
 }
 
-const HoverChip = ({ children, Chip, label, onClick }: Props): JSX.Element => {
+const HoverChip = ({
+  children,
+  Chip,
+  label,
+  onClick,
+  isHovered = false,
+}: Props): JSX.Element => {
   const classes = useStyles();
 
   const [isChipHovered, setIsChipHovered] = React.useState<boolean>(false);
@@ -28,37 +39,47 @@ const HoverChip = ({ children, Chip, label, onClick }: Props): JSX.Element => {
 
   const closeTooltip = (): void => setIsChipHovered(false);
 
-  return (
-    <Tooltip
-      interactive
-      PopperProps={{
-        onClick: (e): void => {
+  React.useEffect(() => {
+    if (not(isHovered)) {
+      return;
+    }
+    setIsChipHovered(false);
+  }, [isHovered]);
+
+  return useMemoComponent({
+    Component: (
+      <Tooltip
+        interactive
+        PopperProps={{
+          onClick: (e): void => {
+            e.preventDefault();
+            e.stopPropagation();
+          },
+        }}
+        aria-label={label}
+        classes={{ tooltip: classes.tooltip }}
+        enterDelay={200}
+        enterNextDelay={200}
+        leaveDelay={0}
+        open={isChipHovered}
+        placement="left"
+        title={<span>{children({ close: closeTooltip, isChipHovered })}</span>}
+        onClick={(e): void => {
           e.preventDefault();
           e.stopPropagation();
-        },
-      }}
-      aria-label={label}
-      classes={{ tooltip: classes.tooltip }}
-      enterDelay={200}
-      enterNextDelay={200}
-      leaveDelay={0}
-      open={isChipHovered}
-      placement="left"
-      title={children({ close: closeTooltip })}
-      onClick={(e): void => {
-        e.preventDefault();
-        e.stopPropagation();
 
-        onClick?.();
-      }}
-      onClose={closeTooltip}
-      onOpen={openTooltip}
-    >
-      <span>
-        <Chip />
-      </span>
-    </Tooltip>
-  );
+          onClick?.();
+        }}
+        onClose={closeTooltip}
+        onOpen={openTooltip}
+      >
+        <span>
+          <Chip />
+        </span>
+      </Tooltip>
+    ),
+    memoProps: [isHovered, isChipHovered, label],
+  });
 };
 
 export default HoverChip;


### PR DESCRIPTION
## Description

This fixes some graph tooltip that might not dismiss

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Have at least 30 services with a graph
- Move your mouse following the graph column to open and close the graph tooltip on the listing
- -> Each graph tooltip is closed when the line is not hovered

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
