### PR TITLE
Mon 5666 anomaly service not renamed in graph listing

### DIFF
--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -86,7 +86,7 @@ class Generate
     /**
      * Insert services in index_data
      *
-     * @param bool $localhost (default false)
+     * @param bool $localhost (FALSE by default)
      * @return void
      */
     private function generateIndexData($isLocalhost = false): void
@@ -171,7 +171,7 @@ class Generate
     /**
      * Insert services in index_data
      *
-     * @param bool $localhost (default false)
+     * @param bool $localhost (FALSE by default)
      * @return void
      */
     private function generateModulesIndexData($isLocalhost = false): void
@@ -266,7 +266,7 @@ class Generate
         $this->backend_instance->movePath($this->current_poller['id']);
 
         $this->generateIndexData($this->current_poller['localhost'] === '1');
-        $this->generateModulesIndexData($this->current_poller['localhost'] ==='1');
+        $this->generateModulesIndexData($this->current_poller['localhost'] === '1');
     }
 
     public function configPollerFromName($poller_name): void

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
+ * Copyright 2005-2015S Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -189,10 +190,9 @@ class Generate
                 }
             }
         }
-
     }
 
-    private function getPollerFromId($poller_id)
+    private function getPollerFromId($poller_id): void
     {
         $query = "SELECT id, localhost,  centreonconnector_path FROM nagios_server " .
             "WHERE id = :poller_id";
@@ -206,7 +206,7 @@ class Generate
         }
     }
 
-    private function getPollerFromName($poller_name)
+    private function getPollerFromName($poller_name): void
     {
         $query = "SELECT id, localhost, centreonconnector_path FROM nagios_server " .
             "WHERE name = :poller_name";
@@ -220,7 +220,7 @@ class Generate
         }
     }
 
-    public function resetObjectsEngine()
+    public function resetObjectsEngine(): void
     {
         Host::getInstance($this->dependencyInjector)->reset();
         HostTemplate::getInstance($this->dependencyInjector)->reset();
@@ -245,7 +245,7 @@ class Generate
         $this->resetModuleObjects();
     }
 
-    private function configPoller($username = 'unknown')
+    private function configPoller($username = 'unknown'): void
     {
         $this->backend_instance->setUserName($username);
         $this->backend_instance->initPath($this->current_poller['id']);
@@ -269,7 +269,7 @@ class Generate
         $this->generateModulesIndexData($this->current_poller['localhost']);
     }
 
-    public function configPollerFromName($poller_name)
+    public function configPollerFromName($poller_name): void
     {
         try {
             $this->getPollerFromName($poller_name);
@@ -281,7 +281,7 @@ class Generate
         }
     }
 
-    public function configPollerFromId($poller_id, $username = 'unknown')
+    public function configPollerFromId($poller_id, $username = 'unknown'): void
     {
         try {
             if (is_null($this->current_poller)) {
@@ -295,7 +295,7 @@ class Generate
         }
     }
 
-    public function configPollers($username = 'unknown')
+    public function configPollers($username = 'unknown'): void
     {
         $query = "SELECT id, localhost, centreonconnector_path FROM " .
             "nagios_server WHERE ns_activate = '1'";
@@ -337,15 +337,16 @@ class Generate
         }
     }
 
-    public function generateModuleObjects($type = 1)
+    public function generateModuleObjects($type = 1): void
     {
         if (is_null($this->module_objects)) {
             $this->getModuleObjects();
         }
         if (is_array($this->module_objects)) {
             foreach ($this->module_objects as $module_object) {
-                if (($type == 1 && $module_object::getInstance($this->dependencyInjector)->isEngineObject() == true) ||
-                    ($type == 2 && $module_object::getInstance($this->dependencyInjector)->isBrokerObject() == true)
+                if (
+                    ($type == 1 && $module_object::getInstance($this->dependencyInjector)->isEngineObject() == true)
+                    || ($type == 2 && $module_object::getInstance($this->dependencyInjector)->isBrokerObject() == true)
                 ) {
                     $module_object::getInstance($this->dependencyInjector)->generateFromPollerId(
                         $this->current_poller['id'],
@@ -356,7 +357,7 @@ class Generate
         }
     }
 
-    public function resetModuleObjects()
+    public function resetModuleObjects(): void
     {
         if (is_null($this->module_objects)) {
             $this->getModuleObjects();
@@ -371,7 +372,7 @@ class Generate
     /**
      * Reset the cache and the instance
      */
-    public function reset()
+    public function reset(): void
     {
         $this->poller_cache = array();
         $this->current_poller = null;

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -84,7 +84,7 @@ class Generate
     }
 
     /**
-     * Insert services created by modules in index_data
+     * Insert services in index_data
      *
      * @param bool $localhost (FALSE by default)
      * @return void
@@ -169,7 +169,7 @@ class Generate
     }
 
     /**
-     * Insert services in index_data
+     * Insert services created by modules in index_data
      *
      * @param bool $localhost (FALSE by default)
      * @return void

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005-2015S Centreon
+ * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005-2015 Centreon
+ * Copyright 2005-2021 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -86,10 +86,10 @@ class Generate
     /**
      * Insert services in index_data
      *
-     * @param integer $localhost
+     * @param bool $localhost (default false)
      * @return void
      */
-    private function generateIndexData($localhost = 0)
+    private function generateIndexData($isLocalhost = false): void
     {
         $serviceInstance = Service::getInstance($this->dependencyInjector);
         $hostInstance = Host::getInstance($this->dependencyInjector);
@@ -142,7 +142,7 @@ class Generate
         }
 
         # Meta services
-        if ($localhost == 1) {
+        if ($isLocalhost) {
             $metaServices = MetaService::getInstance($this->dependencyInjector)->getMetaServices();
             $hostId = MetaHost::getInstance($this->dependencyInjector)->getHostIdByHostName('_Module_Meta');
             foreach ($metaServices as $metaId => $metaService) {
@@ -171,10 +171,10 @@ class Generate
     /**
      * Insert services in index_data
      *
-     * @param integer $localhost
+     * @param bool $localhost (default false)
      * @return void
      */
-    private function generateModulesIndexData($localhost = 0)
+    private function generateModulesIndexData($isLocalhost = false): void
     {
         if (is_null($this->module_objects)) {
             $this->getModuleObjects();
@@ -186,7 +186,7 @@ class Generate
                     $moduleInstance->isEngineObject() == true
                     && method_exists($moduleInstance, 'generateModuleIndexData')
                 ) {
-                    $moduleInstance->generateModuleIndexData($localhost);
+                    $moduleInstance->generateModuleIndexData($isLocalhost);
                 }
             }
         }
@@ -265,8 +265,8 @@ class Generate
         Broker::getInstance($this->dependencyInjector)->generateFromPoller($this->current_poller);
         $this->backend_instance->movePath($this->current_poller['id']);
 
-        $this->generateIndexData($this->current_poller['localhost']);
-        $this->generateModulesIndexData($this->current_poller['localhost']);
+        $this->generateIndexData($this->current_poller['localhost'] === '1');
+        $this->generateModulesIndexData($this->current_poller['localhost'] ==='1');
     }
 
     public function configPollerFromName($poller_name): void

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -86,7 +86,7 @@ class Generate
     /**
      * Insert services in index_data
      *
-     * @param bool $localhost (FALSE by default)
+     * @param bool $isLocalhost (FALSE by default)
      * @return void
      */
     private function generateIndexData($isLocalhost = false): void
@@ -171,7 +171,7 @@ class Generate
     /**
      * Insert services created by modules in index_data
      *
-     * @param bool $localhost (FALSE by default)
+     * @param bool $isLocalhost (FALSE by default)
      * @return void
      */
     private function generateModulesIndexData($isLocalhost = false): void

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -84,7 +84,7 @@ class Generate
     }
 
     /**
-     * Insert services in index_data
+     * Insert services created by modules in index_data
      *
      * @param bool $localhost (FALSE by default)
      * @return void

--- a/www/class/config-generate/generate.class.php
+++ b/www/class/config-generate/generate.class.php
@@ -167,6 +167,31 @@ class Generate
         }
     }
 
+    /**
+     * Insert services in index_data
+     *
+     * @param integer $localhost
+     * @return void
+     */
+    private function generateModulesIndexData($localhost = 0)
+    {
+        if (is_null($this->module_objects)) {
+            $this->getModuleObjects();
+        }
+        if (is_array($this->module_objects)) {
+            foreach ($this->module_objects as $module_object) {
+                $moduleInstance = $module_object::getInstance($this->dependencyInjector);
+                if (
+                    $moduleInstance->isEngineObject() == true
+                    && method_exists($moduleInstance, 'generateModuleIndexData')
+                ) {
+                    $moduleInstance->generateModuleIndexData($localhost);
+                }
+            }
+        }
+
+    }
+
     private function getPollerFromId($poller_id)
     {
         $query = "SELECT id, localhost,  centreonconnector_path FROM nagios_server " .
@@ -241,6 +266,7 @@ class Generate
         $this->backend_instance->movePath($this->current_poller['id']);
 
         $this->generateIndexData($this->current_poller['localhost']);
+        $this->generateModulesIndexData($this->current_poller['localhost']);
     }
 
     public function configPollerFromName($poller_name)


### PR DESCRIPTION
## Description

Renaming a anomaly detection service in conf does'nt rename it in graph listing

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create an Anomaly Detection service
Export the configuration
Wait up to 10 minutes that some data appears in the graph 
Rename the anomaly detection service
Export the configuration again
Check that the service is renamed correctly in centreon_storage.index_data.service_description and that the graph is still visible

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
