### PR TITLE
fix(conf): disable mod security rule 200003

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1412,6 +1412,11 @@ Alias /centreon $INSTALL_DIR_CENTREON/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+  # https://github.com/SpiderLabs/ModSecurity/issues/652
+  SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "$INSTALL_DIR_CENTREON/www">
     DirectoryIndex index.php
     Options Indexes


### PR DESCRIPTION
## Description

disable mod security rule 200003
https://github.com/SpiderLabs/ModSecurity/issues/652

**Fixes** MON-6988

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)