### PR TITLE
fix(command/ack) Fix of the acknowledgment concerning the "sticky" option

### DIFF
--- a/src/Centreon/Domain/Engine/EngineService.php
+++ b/src/Centreon/Domain/Engine/EngineService.php
@@ -66,6 +66,9 @@ class EngineService extends AbstractCentreonService implements
      */
     private $engineConfigurationRepository;
 
+    private const ACKNOWLEDGEMENT_WITH_STICKY_OPTION = 2;
+    private const ACKNOWLEDGEMENT_WITH_NO_STICKY_OPTION = 0;
+
     /**
      * CentCoreService constructor.
      *
@@ -98,7 +101,9 @@ class EngineService extends AbstractCentreonService implements
         $preCommand = sprintf(
             'ACKNOWLEDGE_HOST_PROBLEM;%s;%d;%d;%d;%s;%s',
             $host->getName(),
-            (int) $acknowledgement->isSticky(),
+            $acknowledgement->isSticky()
+                ? self::ACKNOWLEDGEMENT_WITH_STICKY_OPTION
+                : self::ACKNOWLEDGEMENT_WITH_NO_STICKY_OPTION,
             (int) $acknowledgement->isNotifyContacts(),
             (int) $acknowledgement->isPersistentComment(),
             $this->contact->getAlias(),
@@ -125,7 +130,9 @@ class EngineService extends AbstractCentreonService implements
             'ACKNOWLEDGE_SVC_PROBLEM;%s;%s;%d;%d;%d;%s;%s',
             $service->getHost()->getName(),
             $service->getDescription(),
-            (int) $acknowledgement->isSticky(),
+            $acknowledgement->isSticky()
+                ? self::ACKNOWLEDGEMENT_WITH_STICKY_OPTION
+                : self::ACKNOWLEDGEMENT_WITH_NO_STICKY_OPTION,
             (int) $acknowledgement->isNotifyContacts(),
             (int) $acknowledgement->isPersistentComment(),
             $this->contact->getAlias(),


### PR DESCRIPTION
## Description

The "sticky" option is not properly taken into account when creating a host or service acknowledgment from APIv2.
The fix has already been made on version 21.10.x but has never been deployed on earlier versions.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
