### PR TITLE
fix(resource): correctly filter by hostgroup and servicegroup

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/ServiceProvider.php
@@ -216,9 +216,8 @@ final class ServiceProvider extends Provider
             }
 
             $sql .= ' AND EXISTS (SELECT 1 FROM `:dbstg`.`services_servicegroups` AS ssg
-                  WHERE ssg.host_id = s.host_id AND ssg.service_id = s.service_id
-                    AND EXISTS (SELECT 1 FROM `:dbstg`.`servicegroups` AS sg
-                  WHERE sg.servicegroup_id IN (' . implode(', ', $groupList) . ') LIMIT 1) LIMIT 1)';
+                WHERE ssg.host_id = s.host_id AND ssg.service_id = s.service_id
+                AND ssg.servicegroup_id IN (' . implode(', ', $groupList) . ') LIMIT 1)';
         }
 
         // apply the state filter to SQL query

--- a/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
@@ -247,11 +247,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             $request .= ' EXISTS (
                 SELECT 1 FROM `:dbstg`.`hosts_hostgroups` AS hhg
                 WHERE hhg.host_id = resource.host_id
-                    AND EXISTS (
-                        SELECT 1 FROM `:dbstg`.`hostgroups` AS hg
-                        WHERE hg.hostgroup_id IN (' . implode(', ', $groupList) . ')
-                        LIMIT 1)
-                LIMIT 1) ';
+                AND hhg.hostgroup_id IN (' . implode(', ', $groupList) . ') LIMIT 1)';
         }
 
         /**


### PR DESCRIPTION
## Description

This PR intends to patch an issue regarding filtering capacities on servicegroups and hostgroups for the Resource Status page. (see video bellow)


https://user-images.githubusercontent.com/31647811/143250784-59011da0-9909-4ae7-bf79-d4adc8d35a5e.mov

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
