### PR TITLE
fix(resource): error when filering with ACL on monitoring server name

### DIFF
--- a/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
@@ -112,7 +112,7 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
             $request = $this->translateDbName(
                 'SELECT SQL_CALC_FOUND_ROWS instances.*
                 FROM `:dbstg`.instances
-                INNER JOIN `:db`.acl_resources_poller_relation arpr
+                INNER JOIN `:db`.acl_resources_poller_relations arpr
                     ON instances.instance_id = arpr.poller_id
                 INNER JOIN `:db`.acl_resources res
                     ON arpr.acl_res_id = res.acl_res_id


### PR DESCRIPTION
## Description

Fixing an issue when filering Resource Status view with monitoring_server_name. The criteria listing throws an error. Table does not exists which is true... Table name is missing a 's' char

```
[26-Nov-2021 08:32:50 Europe/Paris] CRITICAL: Error when searching for real time monitoring servers {"context":"[object] (Centreon\\Domain\\MonitoringServer\\Exception\\RealTimeMonitoringServerException(code: 0): Error when searching for real time monitoring servers at /usr/share/centreon/src/Centreon/Domain/MonitoringServer/Exception/RealTimeMonitoringServerException.php:38, PDOException(code: 42S02): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'centreon.acl_resources_poller_relation' doesn't exist at /usr/share/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php:158)"}
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
