### PR TITLE
fix(UI): Performane chart are not displayed reliably on Firefox

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -90,6 +90,7 @@ const ExportablePerformanceGraphWithTimeline = ({
   const retrieveTimeline = (): void => {
     if (or(isNil(timelineEndpoint), not(displayEventAnnotations))) {
       setTimeline([]);
+
       return;
     }
 
@@ -126,10 +127,6 @@ const ExportablePerformanceGraphWithTimeline = ({
     retrieveTimeline();
   }, [endpoint, selectedTimePeriod, customTimePeriod, displayEventAnnotations]);
 
-  React.useEffect(() => {
-    setElement(graphContainerRef.current);
-  }, []);
-
   const getEndpoint = (): string | undefined => {
     if (isNil(endpoint)) {
       return undefined;
@@ -151,6 +148,10 @@ const ExportablePerformanceGraphWithTimeline = ({
     ]);
   };
 
+  const enableIntersectionObserver = (): void => {
+    setElement(graphContainerRef.current);
+  };
+
   return (
     <Paper className={classes.graphContainer}>
       <div
@@ -162,6 +163,7 @@ const ExportablePerformanceGraphWithTimeline = ({
           adjustTimePeriod={adjustTimePeriod}
           customTimePeriod={customTimePeriod}
           displayEventAnnotations={displayEventAnnotations}
+          enableIntersectionObserver={enableIntersectionObserver}
           endpoint={getEndpoint()}
           graphHeight={graphHeight}
           isInViewport={isInViewport}

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -84,6 +84,7 @@ interface Props {
   displayCompleteGraph?: () => void;
   displayEventAnnotations?: boolean;
   displayTitle?: boolean;
+  enableIntersectionObserver?: () => void;
   endpoint?: string;
   graphHeight: number;
   isInViewport?: boolean;
@@ -170,6 +171,7 @@ const PerformanceGraph = ({
   limitLegendRows,
   isInViewport = true,
   displayCompleteGraph,
+  enableIntersectionObserver,
 }: Props): JSX.Element | null => {
   const classes = useStyles({
     canAdjustTimePeriod: not(isNil(adjustTimePeriod)),
@@ -267,6 +269,14 @@ const PerformanceGraph = ({
         performanceGraphRef.current.clientHeight;
     }
   }, [isInViewport, lineData]);
+
+  React.useEffect(() => {
+    if (isNil(lineData)) {
+      return;
+    }
+
+    enableIntersectionObserver?.();
+  }, [lineData]);
 
   if (isNil(lineData) || isNil(timeline) || isNil(endpoint)) {
     return (


### PR DESCRIPTION
## Description

This fix graph display issues on Firefox

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add a host with several services
- Open a services details
- Click on the Graph tab
- -> The graph is correctly displayed
- Select another service
- -> The graph is displayed
- Close the panel
- Select another service
- -> The graph is displayed

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
