### PR TITLE
fix(UI) : Remove graph unit displayed twice in rs and add metric's unit in Tooltip

### DIFF
--- a/www/class/centreonGraphNg.class.php
+++ b/www/class/centreonGraphNg.class.php
@@ -419,10 +419,6 @@ class CentreonGraphNg
             $legend = str_replace(":", "\:", $legend);
         }
 
-        if ($metric["unit"] != "") {
-            $legend .= " (" . $metric["unit"] . ")";
-        }
-        
         return $legend;
     }
 

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -57,12 +57,6 @@ const useStyles = makeStyles<Theme, MakeStylesProps, string>((theme) => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   }),
-  captionUnit: {
-    justifyContent: 'start',
-    marginRight: theme.spacing(0.5),
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
   highlight: {
     color: theme.typography.body1.color,
   },

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -51,12 +51,18 @@ const maxLinesDisplayed = 11;
 const useStyles = makeStyles<Theme, MakeStylesProps, string>((theme) => ({
   caption: ({ panelWidth }): CreateCSSProperties<MakeStylesProps> => ({
     lineHeight: 1.2,
-    marginRight: theme.spacing(1),
+    marginRight: theme.spacing(0.5),
     maxWidth: 0.85 * panelWidth,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   }),
+  captionUnit: {
+    justifyContent: 'start',
+    marginRight: theme.spacing(0.5),
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
   highlight: {
     color: theme.typography.body1.color,
   },
@@ -83,7 +89,20 @@ const useStyles = makeStyles<Theme, MakeStylesProps, string>((theme) => ({
   legendData: {
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'space-between',
+  },
+  legendName: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'start',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  legendUnit: {
+    justifyContent: 'end',
+    marginLeft: 'auto',
+    marginRight: theme.spacing(0.5),
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   legendValue: {
     fontWeight: theme.typography.body1.fontWeight,
@@ -146,17 +165,18 @@ const LegendContent = ({
     equals(timeSerie.timeTick, timeValue?.timeTick),
   );
 
-  const getLegendName = ({ legend, name }: Line): JSX.Element => {
+  const getLegendName = ({ legend, name, unit }: Line): JSX.Element => {
     const legendName = legend || name;
+    const unitName = ` (${unit})`;
     const metricName = includes('#', legendName)
       ? split('#')(legendName)[1]
       : legendName;
 
     return (
       <div>
-        <Tooltip placement="top" title={legendName}>
+        <Tooltip placement="top" title={legendName + unitName}>
           <Typography
-            className={clsx(classes.caption)}
+            className={classes.legendName}
             component="p"
             variant="caption"
           >
@@ -291,14 +311,14 @@ const LegendContent = ({
               >
                 <LegendMarker color={markerColor} disabled={!display} />
                 <div className={classes.legendData}>
-                  <div>
+                  <div className={classes.legendName}>
                     {getLegendName(line)}
                     <Typography
-                      className={classes.caption}
+                      className={classes.legendUnit}
                       component="p"
                       variant="caption"
                     >
-                      {line.unit && `(${line.unit})`}
+                      {`(${line.unit})`}
                     </Typography>
                   </div>
                   {formattedValue ? (

--- a/www/include/views/graphs/javascript/centreon-graph.js
+++ b/www/include/views/graphs/javascript/centreon-graph.js
@@ -709,6 +709,10 @@
         legendDiv = jQuery('<div>').addClass('chart-legend')
             .data('curveid', curveId)
             .data('legend', i);
+        legendText = legend.legend;
+        if (legend.unit) {
+            legendText += ' (' + legend.unit + ')';
+        }
 
         /* Build legend for a curve */
         legendLabel = jQuery('<div>')
@@ -721,7 +725,7 @@
                 })
             )
             .append(
-              jQuery('<span>').text(legend.legend)
+              jQuery('<span>').text(legendText)
             );
         legendLabel.appendTo(legendDiv);
 


### PR DESCRIPTION
## Description

When displayed, the unit of a metric is displayed twice in RS.First

**Fixes** # (issue)

Remove graph unit displayed twice in RS and add unit in Tooltip

https://www.loom.com/share/b56a3a2994bd4ac89344ea5860238477

Remove

## Type of change

- [x] Patch fixing an issue (non-breaking change)


## Target serie

- [ ]  21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

1- Go to Ressource Status
2- Select a service with graph available. 
3- Expend the graph panel and take a look on the Legend and when hover the Name , the Tooltip display the  unit too.

