### PR TITLE
Mon 11698 update export reload conf for hostdisco

### DIFF
--- a/config/packages/Centreon.yaml
+++ b/config/packages/Centreon.yaml
@@ -111,6 +111,7 @@ services:
 
     Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface:
         class: Centreon\Infrastructure\MonitoringServer\Repository\MonitoringServerConfigurationRepositoryApi
+        public: true
         calls:
         - method: setTimeout
           arguments: ['%curl.timeout%']

--- a/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryFile.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryFile.php
@@ -68,7 +68,7 @@ class MonitoringServerConfigurationRepositoryFile implements MonitoringServerCon
     {
         try {
             ob_start();
-            include(_CENTREON_PATH_ . $filePath);
+            require_once(_CENTREON_PATH_ . $filePath);
             $xml = ob_get_contents();
             ob_end_clean();
             if (!empty($xml)) {

--- a/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryFile.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryFile.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 namespace Centreon\Infrastructure\MonitoringServer\Repository;
 
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
+use Centreon\Domain\Repository\RepositoryException;
+use Centreon\Infrastructure\MonitoringServer\Repository\Exception\MonitoringServerConfigurationRepositoryException;
 
 /**
  * This class is designed to represent the API repository to manage the generation/move/reload of the monitoring
@@ -40,9 +42,7 @@ class MonitoringServerConfigurationRepositoryFile implements MonitoringServerCon
         $_POST['generate'] = true;
         $_POST['debug'] = true;
         $_POST['poller'] = $monitoringServerId;
-        ob_start([$this, 'outputHandler']);
-        include(_CENTREON_PATH_ . 'www/include/configuration/configGenerate/xml/generateFiles.php');
-        ob_end_flush();
+        $this->includeFile('www/include/configuration/configGenerate/xml/generateFiles.php');
     }
 
     /**
@@ -51,9 +51,7 @@ class MonitoringServerConfigurationRepositoryFile implements MonitoringServerCon
     public function moveExportFiles(int $monitoringServerId): void
     {
         $_POST['poller'] = $monitoringServerId;
-        ob_start([$this, 'outputHandler']);
-        include(_CENTREON_PATH_ . 'www/include/configuration/configGenerate/xml/moveFiles.php');
-        ob_end_flush();
+        $this->includeFile('www/include/configuration/configGenerate/xml/moveFiles.php');
     }
 
      /**
@@ -63,24 +61,29 @@ class MonitoringServerConfigurationRepositoryFile implements MonitoringServerCon
     {
         $_POST['poller'] = $monitoringServerId;
         $_POST['mode'] = 1;
-        ob_start([$this, 'outputHandler']);
-        include(_CENTREON_PATH_ . 'www/include/configuration/configGenerate/xml/restartPollers.php');
-        ob_end_flush();
+        $this->includeFile('www/include/configuration/configGenerate/xml/restartPollers.php');
     }
 
-    public function outputHandler(string $buffer): string
+    private function includeFile(string $filePath): void
     {
-        $errors = '';
-        $values = [];
-        $index = [];
-        $parser = xml_parser_create();
-        xml_parse_into_struct($parser, $buffer, $values, $index);
-        if (array_key_exists('ERRORPHP', $index)) {
-            foreach ($index['ERRORPHP'] as $valuesIndex) {
-                $errors .= $values[$valuesIndex]['value'] . "\n";
+        try {
+            ob_start();
+            include(_CENTREON_PATH_ . $filePath);
+            $xml = ob_get_contents();
+            ob_end_clean();
+            if (!empty($xml)) {
+                if (($element = simplexml_load_string($xml)) !== false) {
+                    if ((string) $element->statuscode !== '0') {
+                        throw new RepositoryException((string) $element->error);
+                    }
+                }
+            } else {
+                throw MonitoringServerConfigurationRepositoryException::responseEmpty();
             }
+        } catch (RepositoryException $ex) {
+            throw $ex;
+        } catch (\Throwable $ex) {
+            throw MonitoringServerConfigurationRepositoryException::unexpectedError($ex);
         }
-
-        return $errors;
     }
 }

--- a/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryFile.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryFile.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Infrastructure\MonitoringServer\Repository;
+
+use DateTime;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Repository\RepositoryException;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
+use Centreon\Infrastructure\MonitoringServer\Repository\Exception\MonitoringServerConfigurationRepositoryException;
+
+/**
+ * This class is designed to represent the API repository to manage the generation/move/reload of the monitoring
+ * server configuration.
+ *
+ * @package Centreon\Infrastructure\MonitoringServer\Repository
+ */
+class MonitoringServerConfigurationRepositoryFile implements MonitoringServerConfigurationRepositoryInterface
+{
+    // use LoggerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function generateConfiguration(int $monitoringServerId): void
+    {
+        $_POST['generate'] = true;
+        $_POST['debug'] = true;
+        $_POST['poller'] = $monitoringServerId;
+        include( _CENTREON_PATH_ . 'www/include/configuration/configGenerate/xml/generateFiles.php');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function moveExportFiles(int $monitoringServerId): void
+    {
+        $_POST['poller'] = $monitoringServerId;
+        include( _CENTREON_PATH_ . 'www/include/configuration/configGenerate/xml/moveFiles.php');
+    }
+
+     /**
+     * @inheritDoc
+     */
+    public function reloadConfiguration(int $monitoringServerId): void
+    {
+        $_POST['poller'] = $monitoringServerId;
+        $_POST['mode'] = 1;
+        include( _CENTREON_PATH_ . 'www/include/configuration/configGenerate/xml/restartPollers.php');
+    }
+
+}

--- a/src/Security/Domain/Authentication/Model/LocalProvider.php
+++ b/src/Security/Domain/Authentication/Model/LocalProvider.php
@@ -125,10 +125,10 @@ class LocalProvider implements ProviderInterface
             function () use ($auth) {
                 $userInfos = $auth->userInfos;
                 return [
-                    'contact_id' => $userInfos['contact_id'],
-                    'contact_alias' => $userInfos['contact_alias'],
-                    'contact_auth_type' => $userInfos['contact_auth_type'],
-                    'contact_ldap_dn' => $userInfos['contact_ldap_dn']
+                    'contact_id' => $userInfos['contact_id'] ?? null,
+                    'contact_alias' => $userInfos['contact_alias'] ?? null,
+                    'contact_auth_type' => $userInfos['contact_auth_type'] ?? null,
+                    'contact_ldap_dn' => $userInfos['contact_ldap_dn'] ?? null
                 ];
             }
         );

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -51,6 +51,12 @@ require_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonXML.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 
+if (!isset($dependencyInjector)){
+    $dependencyInjector = \Centreon\LegacyContainer::getInstance();
+}
+if (!isset($GLOBALS['pearDB'])) {
+    global $pearDB;
+}
 $pearDB = $dependencyInjector["configuration_db"];
 
 $xml = new CentreonXML();
@@ -74,10 +80,12 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
         $xml->writeElement("error", 'Contact not found');
         $xml->endElement();
 
-        header('Content-Type: application/xml');
-        header('Cache-Control: no-cache');
-        header('Expires: 0');
-        header('Cache-Control: no-cache, must-revalidate');
+        if (!headers_sent()) {
+            header('Content-Type: application/xml');
+            header('Cache-Control: no-cache');
+            header('Expires: 0');
+            header('Cache-Control: no-cache, must-revalidate');
+        }
 
         $xml->output();
         exit();
@@ -133,8 +141,35 @@ $ret = array();
 $ret['host'] = $pollers;
 $ret['debug'] = $debug;
 
+/**
+ * The error handler for get error from PHP
+ *
+ * @see set_error_handler
+ */
+$log_error = function ($errno, $errstr, $errfile, $errline)
+{
+    global $generatePhpErrors;
+    if (!(error_reporting() && $errno)) {
+        return;
+    }
+
+    switch ($errno) {
+        case E_ERROR:
+        case E_USER_ERROR:
+        case E_CORE_ERROR:
+            $generatePhpErrors[] = array('error', $errstr);
+            break;
+        case E_WARNING:
+        case E_USER_WARNING:
+        case E_CORE_WARNING:
+            $generatePhpErrors[] = array('warning', $errstr);
+            break;
+    }
+    return true;
+};
+
 // Set new error handler
-set_error_handler('log_error');
+set_error_handler($log_error);
 
 $xml->startElement("response");
 try {
@@ -196,40 +231,14 @@ foreach ($generatePhpErrors as $error) {
 }
 $xml->endElement();
 
-header('Content-Type: application/xml');
-header('Cache-Control: no-cache');
-header('Expires: 0');
-header('Cache-Control: no-cache, must-revalidate');
+if (!headers_sent()) {
+    header('Content-Type: application/xml');
+    header('Cache-Control: no-cache');
+    header('Expires: 0');
+    header('Cache-Control: no-cache, must-revalidate');
+}
 
 $xml->output();
-
-
-/**
- * The error handler for get error from PHP
- *
- * @see set_error_handler
- */
-function log_error($errno, $errstr, $errfile, $errline)
-{
-    global $generatePhpErrors;
-    if (!(error_reporting() && $errno)) {
-        return;
-    }
-
-    switch ($errno) {
-        case E_ERROR:
-        case E_USER_ERROR:
-        case E_CORE_ERROR:
-            $generatePhpErrors[] = array('error', $errstr);
-            break;
-        case E_WARNING:
-        case E_USER_WARNING:
-        case E_CORE_WARNING:
-            $generatePhpErrors[] = array('warning', $errstr);
-            break;
-    }
-    return true;
-}
 
 function printDebug($xml, $tabs)
 {

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -52,7 +52,7 @@ require_once _CENTREON_PATH_ . "www/class/centreonXML.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 
 global $dependencyInjector;
-$pearDB = $dependencyInjector["configuration_db"];
+
 $pearDB = $dependencyInjector["configuration_db"];
 
 $xml = new CentreonXML();

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -51,7 +51,7 @@ require_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonXML.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 
-if (!isset($dependencyInjector)){
+if (!isset($dependencyInjector)) {
     $dependencyInjector = \Centreon\LegacyContainer::getInstance();
 }
 if (!isset($GLOBALS['pearDB'])) {
@@ -146,8 +146,7 @@ $ret['debug'] = $debug;
  *
  * @see set_error_handler
  */
-$log_error = function ($errno, $errstr, $errfile, $errline)
-{
+$log_error = function ($errno, $errstr, $errfile, $errline) {
     global $generatePhpErrors;
     if (!(error_reporting() && $errno)) {
         return;

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -51,12 +51,8 @@ require_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonXML.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 
-if (!isset($dependencyInjector)) {
-    $dependencyInjector = \Centreon\LegacyContainer::getInstance();
-}
-if (!isset($GLOBALS['pearDB'])) {
-    global $pearDB;
-}
+global $dependencyInjector;
+$pearDB = $dependencyInjector["configuration_db"];
 $pearDB = $dependencyInjector["configuration_db"];
 
 $xml = new CentreonXML();

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -52,6 +52,7 @@ require_once _CENTREON_PATH_ . "www/class/centreonXML.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 
 global $dependencyInjector;
+global $pearDB;
 
 $pearDB = $dependencyInjector["configuration_db"];
 

--- a/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -202,8 +202,7 @@ if (!empty($remotesResults)) {
  *
  * @see set_error_handler
  */
-$log_error = function($errno, $errstr, $errfile, $errline)
-{
+$log_error = function ($errno, $errstr, $errfile, $errline) {
     global $generatePhpErrors;
     if (!(error_reporting() && $errno)) {
         return;

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -134,8 +134,7 @@ $generatePhpErrors = array();
  *
  * @see set_error_handler
  */
-$log_error = function($errno, $errstr, $errfile, $errline)
-{
+$log_error = function ($errno, $errstr, $errfile, $errline) {
     global $generatePhpErrors;
     if (!(error_reporting() && $errno)) {
         return;

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -51,8 +51,12 @@ require_once _CENTREON_PATH_ . "www/class/centreonBroker.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonACL.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonUser.class.php";
 
-define('STATUS_OK', 0);
-define('STATUS_NOK', 1);
+if (!defined('STATUS_OK')) {
+    define('STATUS_OK', 0);
+}
+if (!defined('STATUS_NOK')) {
+    define('STATUS_NOK', 1);
+}
 
 $pearDB = new CentreonDB();
 $xml = new CentreonXML();
@@ -79,10 +83,12 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
         $xml->writeElement("error", 'Contact not found');
         $xml->endElement();
 
-        header('Content-Type: application/xml');
-        header('Cache-Control: no-cache');
-        header('Expires: 0');
-        header('Cache-Control: no-cache, must-revalidate');
+        if (!headers_sent()) {
+            header('Content-Type: application/xml');
+            header('Cache-Control: no-cache');
+            header('Expires: 0');
+            header('Cache-Control: no-cache, must-revalidate');
+        }
 
         $xml->output();
         exit();
@@ -128,10 +134,10 @@ $generatePhpErrors = array();
  *
  * @see set_error_handler
  */
-function log_error($errno, $errstr, $errfile, $errline)
+$log_error = function($errno, $errstr, $errfile, $errline)
 {
     global $generatePhpErrors;
-    if (!(error_reporting() & $errno)) {
+    if (!(error_reporting() && $errno)) {
         return;
     }
 
@@ -148,7 +154,7 @@ function log_error($errno, $errstr, $errfile, $errline)
             break;
     }
     return true;
-}
+};
 
 try {
     $pollers = explode(',', $_POST['poller']);
@@ -162,7 +168,7 @@ try {
     $centreonBrokerPath = _CENTREON_CACHEDIR_ . "/config/broker/";
 
     /*  Set new error handler */
-    set_error_handler('log_error');
+    set_error_handler($log_error);
 
     if (defined('_CENTREON_VARLIB_')) {
         $centcore_pipe = _CENTREON_VARLIB_ . "/centcore.cmd";
@@ -288,10 +294,12 @@ $xml->endElement();
 $xml->endElement();
 
 // Headers
-header('Content-Type: application/xml');
-header('Cache-Control: no-cache');
-header('Expires: 0');
-header('Cache-Control: no-cache, must-revalidate');
+if (!headers_sent()) {
+    header('Content-Type: application/xml');
+    header('Cache-Control: no-cache');
+    header('Expires: 0');
+    header('Cache-Control: no-cache, must-revalidate');
+}
 
 // Send Data
 $xml->output();


### PR DESCRIPTION
## Description

Modify config generation to allow hostdisco job to export and reload configuration 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

For a job with options "add host" and "export and reload conf" enabled (aka save_mode = 9), running following script should add discovered hosts and rexport and reload configuration of the corresponding monitoring servers

php /usr/share/centreon/www/modules/centreon-autodiscovery-server/script/save_discovered_host.php --all --job-id=[jobId] --username=[login]

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
