### PR TITLE
enh(debug) : hide token in login debug file

### DIFF
--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -448,7 +448,6 @@ class CentreonAuthSSO extends CentreonAuth
         }
 
         if ($this->debug && isset($result)) {
-
             $resultForDebug = $result;
 
             if (isset($resultForDebug["access_token"])) {
@@ -519,7 +518,6 @@ class CentreonAuthSSO extends CentreonAuth
         }
 
         if ($this->debug && isset($result)) {
-
             $resultForDebug = $result;
 
             if (isset($resultForDebug['jti'])) {

--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -449,20 +449,22 @@ class CentreonAuthSSO extends CentreonAuth
 
         if ($this->debug && isset($result)) {
 
-            if (isset($result["access_token"])) {
-                $result["access_token"] = substr($result["access_token"], 0, 8);
+            $resultForDebug = $result;
+
+            if (isset($resultForDebug["access_token"])) {
+                $resultForDebug["access_token"] = substr($resultForDebug["access_token"], 0, 8);
             }
 
-            if (isset($result["id_token"])) {
-                $result["id_token"] = substr($result["id_token"], 0, 8);
+            if (isset($resultForDebug["id_token"])) {
+                $resultForDebug["id_token"] = substr($resultForDebug["id_token"], 0, 8);
             }
 
-            if (isset($result["refresh_token"])) {
-                $result["refresh_token"] = substr($result["refresh_token"], 0, 8);
+            if (isset($resultForDebug["refresh_token"])) {
+                $resultForDebug["refresh_token"] = substr($resultForDebug["refresh_token"], 0, 8);
             }
             $this->CentreonLog->insertLog(
                 1,
-                "[" . $this->source . "] [Debug] Token Access Information: " . json_encode($result)
+                "[" . $this->source . "] [Debug] Token Access Information: " . json_encode($resultForDebug)
             );
         }
 
@@ -518,13 +520,15 @@ class CentreonAuthSSO extends CentreonAuth
 
         if ($this->debug && isset($result)) {
 
-            if (isset($result['jti'])) {
-                $result['jti'] = substr($result['jti'], 0, 8);
+            $resultForDebug = $result;
+
+            if (isset($resultForDebug['jti'])) {
+                $resultForDebug['jti'] = substr($resultForDebug['jti'], 0, 8);
             }
 
             $this->CentreonLog->insertLog(
                 1,
-                "[" . $this->source . "] [Debug] Token Introspection Information: " . json_encode($result)
+                "[" . $this->source . "] [Debug] Token Introspection Information: " . json_encode($resultForDebug)
             );
         }
 

--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -448,6 +448,18 @@ class CentreonAuthSSO extends CentreonAuth
         }
 
         if ($this->debug && isset($result)) {
+
+            if (isset($result["access_token"])) {
+                $result["access_token"] = substr($result["access_token"], 0, 8);
+            }
+
+            if (isset($result["id_token"])) {
+                $result["id_token"] = substr($result["id_token"], 0, 8);
+            }
+
+            if (isset($result["refresh_token"])) {
+                $result["refresh_token"] = substr($result["refresh_token"], 0, 8);
+            }
             $this->CentreonLog->insertLog(
                 1,
                 "[" . $this->source . "] [Debug] Token Access Information: " . json_encode($result)
@@ -505,6 +517,11 @@ class CentreonAuthSSO extends CentreonAuth
         }
 
         if ($this->debug && isset($result)) {
+
+            if (isset($result['jti'])) {
+                $result['jti'] = substr($result['jti'], 0, 8);
+            }
+
             $this->CentreonLog->insertLog(
                 1,
                 "[" . $this->source . "] [Debug] Token Introspection Information: " . json_encode($result)

--- a/www/class/centreonAuth.SSO.class.php
+++ b/www/class/centreonAuth.SSO.class.php
@@ -44,6 +44,8 @@ class CentreonAuthSSO extends CentreonAuth
 
     private const SOURCE_SSO = 'sso';
     private const SOURCE_OPENID_CONNECT = 'OpenId';
+    private const START = 0;
+    private const LENGTH = 8;
 
     /**
      * @var string
@@ -451,15 +453,15 @@ class CentreonAuthSSO extends CentreonAuth
             $resultForDebug = $result;
 
             if (isset($resultForDebug["access_token"])) {
-                $resultForDebug["access_token"] = substr($resultForDebug["access_token"], 0, 8);
+                $resultForDebug["access_token"] = substr($resultForDebug["access_token"], self::START, self::LENGTH);
             }
 
             if (isset($resultForDebug["id_token"])) {
-                $resultForDebug["id_token"] = substr($resultForDebug["id_token"], 0, 8);
+                $resultForDebug["id_token"] = substr($resultForDebug["id_token"], self::START, self::LENGTH);
             }
 
             if (isset($resultForDebug["refresh_token"])) {
-                $resultForDebug["refresh_token"] = substr($resultForDebug["refresh_token"], 0, 8);
+                $resultForDebug["refresh_token"] = substr($resultForDebug["refresh_token"], self::START, self::LENGTH);
             }
             $this->CentreonLog->insertLog(
                 1,
@@ -521,9 +523,8 @@ class CentreonAuthSSO extends CentreonAuth
             $resultForDebug = $result;
 
             if (isset($resultForDebug['jti'])) {
-                $resultForDebug['jti'] = substr($resultForDebug['jti'], 0, 8);
+                $resultForDebug['jti'] = substr($resultForDebug['jti'], self::START, self::LENGTH);
             }
-
             $this->CentreonLog->insertLog(
                 1,
                 "[" . $this->source . "] [Debug] Token Introspection Information: " . json_encode($resultForDebug)


### PR DESCRIPTION
## Description

**Fixes** MON-10851

Partially hide token values in debug log file for opendid connection

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Configure your centreon platform to enable openid
* Enable "Authentication debug" in “Administration > Parameters > Debug”
* When all is set, connect to centreon home page with openid
* check in /var/log/centreon/login.log if you see for the values "access_token", "id_token" (if exist), "refresh_token" and jti (if exist)  8 characters
