### PR TITLE
fix(export): export the contact template that was no longer exported with the contact

### DIFF
--- a/www/class/config-generate/contact.class.php
+++ b/www/class/config-generate/contact.class.php
@@ -98,6 +98,7 @@ class Contact extends AbstractObject
 
     public const ENABLE_NOTIFICATIONS = '1';
     public const DEFAULT_NOTIFICATIONS = '2';
+    public const CONTACT_OBJECT = '1';
 
     private function getContactCache()
     {
@@ -190,8 +191,8 @@ class Contact extends AbstractObject
     {
         if (!isset($this->contacts[$contact_id][$label . '_commands_cache'])) {
             if (is_null($this->stmt_commands[$label])) {
-                $this->stmt_commands[$label] = $this->backend_instance->db->prepare("SELECT
-                        command_command_id
+                $this->stmt_commands[$label] = $this->backend_instance->db->prepare("
+                    SELECT command_command_id
                     FROM contact_" . $label . "commands_relation
                     WHERE contact_contact_id = :contact_id
                 ");
@@ -276,7 +277,10 @@ class Contact extends AbstractObject
         $this->contacts[$contact_id]['use'] = [
             $this->generateFromContactId($this->contacts[$contact_id]['contact_template_id'])
         ];
-        if (!$this->shouldContactBeNotified($contact_id)) {
+        if (
+            $this->contacts[$contact_id]['register'] === self::CONTACT_OBJECT
+            && !$this->shouldContactBeNotified($contact_id)
+        ) {
             return null;
         }
         $this->getContactNotificationCommands($contact_id, 'host');


### PR DESCRIPTION
## Description

The contact template was no longer exported if its **enable_notification** option was set to no.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a contact template and define the notification details (options, periods and order) making sure that the "Enable Notifications" option is set to No.
2. Then create a contact with the "Enable Notifications" option set to Yes and with the previously created contact template.
3. Associate this contact with a host.
4. Export the poller configuration.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
