### PR TITLE
fix(resource): return instance information for metaservice

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
@@ -105,8 +105,8 @@ final class MetaServiceProvider extends Provider
             NULL AS `action_url`,
             NULL AS `notes_url`,
             NULL AS `notes_label`,
-            NULL AS `monitoring_server_name`,
-            NULL AS `monitoring_server_id`,
+            i.name AS `monitoring_server_name`,
+            i.instance_id AS `monitoring_server_id`,
             s.command_line AS `command_line`,
             NULL AS `timezone`,
             NULL AS `parent_id`,
@@ -162,6 +162,9 @@ final class MetaServiceProvider extends Provider
             ON sh.host_id = s.host_id
             AND sh.name LIKE '\_Module\_Meta%'
             AND sh.enabled = 1";
+
+            // get monitoring server information
+        $sql .= " INNER JOIN `:dbstg`.`instances` AS i ON i.instance_id = sh.instance_id";
 
         // show active services only
         $sql .= ' WHERE s.enabled = 1 ';

--- a/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/Provider/MetaServiceProvider.php
@@ -163,7 +163,7 @@ final class MetaServiceProvider extends Provider
             AND sh.name LIKE '\_Module\_Meta%'
             AND sh.enabled = 1";
 
-            // get monitoring server information
+        // get monitoring server information
         $sql .= " INNER JOIN `:dbstg`.`instances` AS i ON i.instance_id = sh.instance_id";
 
         // show active services only


### PR DESCRIPTION
## Description

This PR https://github.com/centreon/centreon/pull/10441/files#diff-27e202d58bf78b7300383301943bf165ad974f0634debcca3adb79792b6efa55R510 introduced a constraint when creating the Resource entity on the property “monitoringServerName”.

This property is not returned by the MetaServiceProvider so this breaks the listing with the following error message

![image](https://user-images.githubusercontent.com/31647811/145981132-3fa94dcf-b32e-4e06-ad90-307b8e249ccd.png)


**How to reproduce**

- Create a Metaservice
- Generate and reload the configuration
- Go to Monitoring → Resource Status
- Filter on type:metaservice

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See the How to reproduce

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
