### PR TITLE
fix(session): update properly session last reload to avoid disconnect

### DIFF
--- a/www/class/centreonSession.class.php
+++ b/www/class/centreonSession.class.php
@@ -166,6 +166,7 @@ class CentreonSession
                 $sessionStatement->bindValue(':lastReload', time(), \PDO::PARAM_INT);
                 $sessionStatement->bindValue(':ipAddress', $_SERVER["REMOTE_ADDR"], \PDO::PARAM_STR);
                 $sessionStatement->bindValue(':sessionId', $sessionId, \PDO::PARAM_STR);
+                $sessionStatement->execute();
 
                 $sessionExpire = 120;
                 $optionResult = $pearDB->query(
@@ -185,7 +186,7 @@ class CentreonSession
                     SET `expiration_date` = :expirationDate
                     WHERE `token` = :sessionId"
                 );
-                $tokenStatement->bindValue(':expirationDate', $expirationDate, \PDO::PARAM_STR);
+                $tokenStatement->bindValue(':expirationDate', $expirationDate, \PDO::PARAM_INT);
                 $tokenStatement->bindValue(':sessionId', $sessionId, \PDO::PARAM_STR);
                 $tokenStatement->execute();
 


### PR DESCRIPTION
## Description

update properly session last reload to avoid disconnect

**Fixes** MON-11884 #10394 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)