### PR TITLE
fix(resource): check name existance before updating filter

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15500,6 +15500,9 @@ msgstr "Filtre id %s non trouvé"
 msgid "Filter already exists"
 msgstr "Le filtre existe déjà"
 
+msgid "Filter name already used"
+msgstr "Le nom de filtre est déjà utilisé"
+
 msgid "Error when adding filter %s"
 msgstr "Erreur lors de l'ajout du filtre %s"
 

--- a/src/Centreon/Domain/Filter/FilterService.php
+++ b/src/Centreon/Domain/Filter/FilterService.php
@@ -116,6 +116,7 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
             $filter->getPageName(),
             $filter->getName()
         );
+
         if ($foundFilter !== null && $filter->getId() !== $foundFilter->getId()) {
             throw new FilterException(_('Filter name already used'));
         }

--- a/src/Centreon/Domain/Filter/FilterService.php
+++ b/src/Centreon/Domain/Filter/FilterService.php
@@ -111,6 +111,15 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
      */
     public function updateFilter(Filter $filter): void
     {
+        $foundFilter = $this->filterRepository->findFilterByUserIdAndName(
+            $filter->getUserId(),
+            $filter->getPageName(),
+            $filter->getName()
+        );
+        if ($foundFilter !== null) {
+            throw new FilterException(_('Filter name already in use'));
+        }
+
         try {
             $this->checkCriterias($filter->getCriterias());
 

--- a/src/Centreon/Domain/Filter/FilterService.php
+++ b/src/Centreon/Domain/Filter/FilterService.php
@@ -116,7 +116,7 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
             $filter->getPageName(),
             $filter->getName()
         );
-        if ($foundFilter !== null) {
+        if ($foundFilter !== null && $filter->getId() !== $foundFilter->getId()) {
             throw new FilterException(_('Filter name already used'));
         }
 

--- a/src/Centreon/Domain/Filter/FilterService.php
+++ b/src/Centreon/Domain/Filter/FilterService.php
@@ -117,7 +117,7 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
             $filter->getName()
         );
         if ($foundFilter !== null) {
-            throw new FilterException(_('Filter name already in use'));
+            throw new FilterException(_('Filter name already used'));
         }
 
         try {

--- a/tests/php/Centreon/Domain/Filter/FilterServiceTest.php
+++ b/tests/php/Centreon/Domain/Filter/FilterServiceTest.php
@@ -29,6 +29,7 @@ use Centreon\Domain\Monitoring\HostGroup\Interfaces\HostGroupServiceInterface;
 use Centreon\Domain\Monitoring\HostGroup;
 use Centreon\Domain\Monitoring\ServiceGroup\Interfaces\ServiceGroupServiceInterface;
 use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Filter\FilterException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -166,5 +167,32 @@ class FilterServiceTest extends TestCase
             0,
             $this->filter->getCriterias()[1]->getValue()
         );
+    }
+
+    /**
+     * test update filter with name already in use
+     */
+    public function testUpdateFilterNameExists(): void
+    {
+        $this->filterRepository->expects($this->once())
+            ->method('findFilterByUserIdAndName')
+            ->willReturn($this->filter);
+
+        $filterUpdate = (new Filter())
+            ->setId(2)
+            ->setName($this->filter->getName())
+            ->setUserId($this->filter->getUserId())
+            ->setPageName($this->filter->getPageName());
+
+        $filterService = new FilterService(
+            $this->hostGroupService,
+            $this->serviceGroupService,
+            $this->filterRepository
+        );
+
+        $this->expectException(FilterException::class);
+        $this->expectExceptionMessage('Filter name already used');
+
+        $filterService->updateFilter($filterUpdate);
     }
 }


### PR DESCRIPTION
## Description

This PR intends to check that the name of a filter does not already exists when updating an existing one

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira ticket for details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
