### PR TITLE
fix(performances): issue when coming from Resource Status

### DIFF
--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -259,8 +259,8 @@ function loadChart(chart, callback) {
     if (jQuery('select[name="period"]').val() === '') {
         times = {
             period: {
-                startTime: jQuery('input[name="alternativeDateStartDate"]').val() + ' ' + jQuery('#StartTime').val(),
-                endTime: jQuery('input[name="alternativeDateEndDate"]').val() + ' ' + jQuery('#EndTime').val()
+                startTime: jQuery('input[name="StartDate"]').val() + ' ' + jQuery('#StartTime').val(),
+                endTime: jQuery('input[name="EndDate"]').val() + ' ' + jQuery('#EndTime').val()
             }
         };
         end = end;

--- a/www/include/views/graphs/graphs.php
+++ b/www/include/views/graphs/graphs.php
@@ -291,10 +291,10 @@ if ($period_start != 'undefined' && $period_end != 'undefined') {
     $endTime = date('H:i', $period_end);
     $form->setDefaults(
         array(
-            'alternativeDateStartDate' => $startDay,
+            'StartDate' => $startDay,
             'StartTime' => $startTime,
-            'alternativeDateEndDate' => $endDay,
-            'EndTime' => $endTime
+            'EndTime' => $endTime,
+            'EndDate' => $endDay
         )
     );
 } else {


### PR DESCRIPTION
## Description

When coming from Resource Status (shortcut available on graph tab) when reaching the performance page it was not possible to add an other graph to the page (displayed with no data)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
