### PR TITLE
fix(remote): incorrect sync when configuration becomes empty

### DIFF
--- a/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
@@ -21,7 +21,6 @@
 namespace CentreonRemote\Domain\Exporter;
 
 use Pimple\Container;
-use PDO;
 use CentreonRemote\Infrastructure\Export\ExportManifest;
 use CentreonRemote\Infrastructure\Service\ExporterServiceAbstract;
 

--- a/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
@@ -72,8 +72,7 @@ class ConfigurationExporter extends ExporterServiceAbstract
         $db = $this->db->getAdapter('configuration_db');
 
         // get tables
-        $stmt = $db->getCentreonDBInstance()->prepare('SHOW TABLES');
-        $stmt->execute();
+        $stmt = $db->getCentreonDBInstance()->query('SHOW TABLES');
         $tables = [];
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             foreach ($row as $key => $name) {

--- a/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
@@ -75,7 +75,7 @@ class ConfigurationExporter extends ExporterServiceAbstract
         $stmt = $db->getCentreonDBInstance()->query('SHOW TABLES');
         $tables = [];
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-            foreach ($row as $key => $name) {
+            foreach ($row as $name) {
                 $tables[$name] = 1;
             }
         }

--- a/www/class/config-generate-remote/Generate.php
+++ b/www/class/config-generate-remote/Generate.php
@@ -213,6 +213,7 @@ class Generate
             $this->backendInstance->initPath($remoteServerId);
             $this->backendInstance->setPollerId($remoteServerId);
             Manifest::getInstance($this->dependencyInjector)->clean();
+            $this->createFiles();
             Manifest::getInstance($this->dependencyInjector)->addRemoteServer($remoteServerId);
 
             $this->getPollerFromId($remoteServerId);
@@ -322,6 +323,66 @@ class Generate
                 $module_object::getInstance($this->dependencyInjector)->reset();
             }
         }
+    }
+
+    /**
+     * Force to create a manifest and empty file
+     *
+     * @return void
+     */
+    private function createFiles()
+    {
+        Host::getInstance($this->dependencyInjector)->reset(true, true);
+        Service::getInstance($this->dependencyInjector)->reset(true, true);
+        HostTemplate::getInstance($this->dependencyInjector)->reset(true);
+        ServiceGroup::getInstance($this->dependencyInjector)->reset(true);
+        HostTemplate::getInstance($this->dependencyInjector)->reset(true);
+        if ($this->backendInstance->isExportContact()) {
+            Contact::getInstance($this->dependencyInjector)->reset(true);
+        }
+        Command::getInstance($this->dependencyInjector)->reset(true);
+        Curves::getInstance($this->dependencyInjector)->reset(true);
+        Engine::getInstance($this->dependencyInjector)->reset(true);
+        Broker::getInstance($this->dependencyInjector)->reset(true);
+        Graph::getInstance($this->dependencyInjector)->reset(true);
+        HostCategory::getInstance($this->dependencyInjector)->reset(true);
+        HostGroup::getInstance($this->dependencyInjector)->reset(true);
+        MacroService::getInstance($this->dependencyInjector)->reset(true);
+        Media::getInstance($this->dependencyInjector)->reset(true);
+        Resource::getInstance($this->dependencyInjector)->reset(true);
+        ServiceCategory::getInstance($this->dependencyInjector)->reset(true);
+        ServiceTemplate::getInstance($this->dependencyInjector)->reset(true);
+        TimePeriod::getInstance($this->dependencyInjector)->reset(true);
+        Trap::getInstance($this->dependencyInjector)->reset(true);
+        PlatformTopology::getInstance($this->dependencyInjector)->reset(true);
+        Relations\BrokerInfo::getInstance($this->dependencyInjector)->reset(true);
+        Relations\CfgResourceInstanceRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ContactGroupHostRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ContactGroupServiceRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ContactHostcommandsRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ContactHostRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ContactServicecommandsRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ContactServiceRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ExtendedHostInformation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ExtendedServiceInformation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\HostCategoriesRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\HostGroupRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\HostServiceRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\HostTemplateRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\HostPollerRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\MacroHost::getInstance($this->dependencyInjector)->reset(true);
+        Relations\NagiosServer::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ServiceCategoriesRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ServiceGroupRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TimePeriodExceptions::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TrapsGroup::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TrapsGroupRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TrapsMatching::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TrapsPreexec::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TrapsServiceRelation::getInstance($this->dependencyInjector)->reset(true);
+        Relations\TrapsVendor::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ViewImageDir::getInstance($this->dependencyInjector)->reset(true);
+        Relations\ViewImgDirRelation::getInstance($this->dependencyInjector)->reset(true);
     }
 
     /**


### PR DESCRIPTION
## Description

-

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- link an uniq host to a remote server
- export configuration for the remote server
- unlink the uniq host of the remote server
- export configuration for the remote server
- you should get nothing if you do: ```SELECT * from host```

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
