### PR TITLE
enh(API): add default_page to current user parameters

### DIFF
--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -748,10 +748,15 @@ paths:
                     type: boolean
                     description: If the current user is an administrator
                     example: true
-                  useDeprecatedPages:
+                  use_deprecated_pages:
                     type: boolean
                     description: Indicates if user wants to use deprecated monitoring pages
                     example: false
+                  default_page:
+                    type: string
+                    nullable: true
+                    description: Default page for the current user
+                    example: '/main.php?p=60901'
         '403':
           $ref: '#/components/responses/Forbidden'
         '500':

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -93,7 +93,8 @@ class UserController extends AbstractController
             'locale' => $user->getLocale(),
             'is_admin' => $user->isAdmin(),
             'use_deprecated_pages' => $user->isUsingDeprecatedPages(),
-            'is_export_button_enabled' => $user->isOneClickExportEnabled()
+            'is_export_button_enabled' => $user->isOneClickExportEnabled(),
+            'default_page' => $user->getDefaultPage() !== null ? $user->getDefaultPage()->getRedirectionUri() : null
         ]);
     }
 

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -94,7 +94,7 @@ class UserController extends AbstractController
             'is_admin' => $user->isAdmin(),
             'use_deprecated_pages' => $user->isUsingDeprecatedPages(),
             'is_export_button_enabled' => $user->isOneClickExportEnabled(),
-            'default_page' => $user->getDefaultPage() !== null ? $user->getDefaultPage()->getRedirectionUri() : null
+            'default_page' => $user->getDefaultPage()?->getRedirectionUri()
         ]);
     }
 

--- a/src/Centreon/Domain/Menu/Model/Page.php
+++ b/src/Centreon/Domain/Menu/Model/Page.php
@@ -25,6 +25,8 @@ namespace Centreon\Domain\Menu\Model;
 
 class Page
 {
+    public const LEGACY_PAGE_BASE_URI = '/main.php?p=';
+
     /**
      * @var int
      */
@@ -106,5 +108,24 @@ class Page
     public function isReact(): bool
     {
         return $this->isReact;
+    }
+
+    /**
+     * Return the redirection uri of the page.
+     *
+     * @return string
+     */
+    public function getRedirectionUri(): string
+    {
+        if ($this->isReact === true) {
+            return $this->url;
+        }
+
+        $redirectionUri = self::LEGACY_PAGE_BASE_URI . (string) $this->pageNumber;
+        if ($this->urlOptions !== null) {
+            $redirectionUri .= $this->urlOptions;
+        }
+
+        return $redirectionUri;
     }
 }

--- a/src/Centreon/Domain/Menu/Model/Page.php
+++ b/src/Centreon/Domain/Menu/Model/Page.php
@@ -117,7 +117,7 @@ class Page
      */
     public function getRedirectionUri(): string
     {
-        if ($this->isReact === true) {
+        if ($this->isReact) {
             return $this->url;
         }
 

--- a/src/Centreon/Domain/Menu/Model/Page.php
+++ b/src/Centreon/Domain/Menu/Model/Page.php
@@ -121,7 +121,7 @@ class Page
             return $this->url;
         }
 
-        $redirectionUri = self::LEGACY_PAGE_BASE_URI . (string) $this->pageNumber;
+        $redirectionUri = self::LEGACY_PAGE_BASE_URI . $this->pageNumber;
         if ($this->urlOptions !== null) {
             $redirectionUri .= $this->urlOptions;
         }


### PR DESCRIPTION
## Description

This PR add a property default_page to the endpoint /configuration/users/current/parameters

**Fixes** # MON-11945

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Login to apiV2, call the endpoint /configuration/users/current/parameters, you should have a new property default_page, with the uri of your default_page.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
