### PR TITLE
fix(UI): Fix style to display poller details row in sub menu

### DIFF
--- a/www/front_src/src/Header/PollerMenu/index.tsx
+++ b/www/front_src/src/Header/PollerMenu/index.tsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles((theme) => ({
     borderWidth: '1px',
     color: theme.palette.common.white,
     display: 'flex',
-    gap: theme.spacing(1),
+    gap: theme.spacing(9),
   },
   pollerDetailTitle: {
     flexGrow: 1,
@@ -202,7 +202,7 @@ const PollerMenu = (): JSX.Element => {
                 className={clsx(classes.label, classes.pollerDetailRow)}
                 variant="body2"
               >
-                <li {...t(labelAllPollers)} />
+                <li> {t(labelAllPollers)} </li>
                 {pollerCount}
               </Typography>
             )}

--- a/www/front_src/src/Header/PollerMenu/index.tsx
+++ b/www/front_src/src/Header/PollerMenu/index.tsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles((theme) => ({
     borderWidth: '1px',
     color: theme.palette.common.white,
     display: 'flex',
-    gap: theme.spacing(9),
+    justifyContent: 'space-between',
   },
   pollerDetailTitle: {
     flexGrow: 1,


### PR DESCRIPTION
## Description

Fix style to display poller details row in sub menu

**Fixes** # (issue)

Add more space between Label and Poller count in Pollers submenu.

![Sans titre](https://user-images.githubusercontent.com/16045498/147750767-d07aa464-6d57-43b3-955d-294eddf231a2.jpg)

![Sans titre](https://user-images.githubusercontent.com/16045498/147750649-0d6de108-578e-4d79-93e8-e2b7a80037bd.jpg)

## Type of change

- [x] Patch fixing an issue (non-breaking change)


## Target serie


- [x] 22.04.x (master)
