### PR TITLE
enh(API): create NoContent and Created Response

### DIFF
--- a/src/Core/Application/Common/UseCase/CreatedResponse.php
+++ b/src/Core/Application/Common/UseCase/CreatedResponse.php
@@ -28,13 +28,6 @@ use Core\Application\Common\UseCase\ResponseStatusInterface;
 class CreatedResponse implements ResponseStatusInterface
 {
     /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
      * @inheritDoc
      */
     public function getMessage(): string

--- a/src/Core/Application/Common/UseCase/CreatedResponse.php
+++ b/src/Core/Application/Common/UseCase/CreatedResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Common\UseCase;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+class CreatedResponse implements ResponseStatusInterface
+{
+    /**
+     * @param string $message
+     */
+    public function __construct(private string $message)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage(): string
+    {
+        return 'Created';
+    }
+}

--- a/src/Core/Application/Common/UseCase/NoContentResponse.php
+++ b/src/Core/Application/Common/UseCase/NoContentResponse.php
@@ -28,13 +28,6 @@ use Core\Application\Common\UseCase\ResponseStatusInterface;
 class NoContentResponse implements ResponseStatusInterface
 {
     /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
      * @inheritDoc
      */
     public function getMessage(): string

--- a/src/Core/Application/Common/UseCase/NoContentResponse.php
+++ b/src/Core/Application/Common/UseCase/NoContentResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Common\UseCase;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+class NoContentResponse implements ResponseStatusInterface
+{
+    /**
+     * @param string $message
+     */
+    public function __construct(private string $message)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage(): string
+    {
+        return 'No content';
+    }
+}

--- a/src/Core/Infrastructure/Common/Presenter/JsonPresenter.php
+++ b/src/Core/Infrastructure/Common/Presenter/JsonPresenter.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace Core\Infrastructure\Common\Presenter;
 
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\CreatedResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -51,25 +53,37 @@ class JsonPresenter implements PresenterFormatterInterface
      */
     public function show(): JsonResponse
     {
-        if (is_subclass_of($this->data, NotFoundResponse::class, false)) {
-            $this->debug('Data not found. Generating a not found response');
-            return new JsonResponse(
-                [
-                    'code' => JsonResponse::HTTP_NOT_FOUND,
-                    'message' => $this->data->getMessage()
-                ],
-                JsonResponse::HTTP_NOT_FOUND
-            );
-        } elseif (is_subclass_of($this->data, ErrorResponse::class, false)) {
-            $this->debug('Data error. Generating an error response');
-            return new JsonResponse(
-                [
-                    'code' => JsonResponse::HTTP_INTERNAL_SERVER_ERROR,
-                    'message' => $this->data->getMessage()
-                ],
-                JsonResponse::HTTP_INTERNAL_SERVER_ERROR
-            );
+        switch (true) {
+            case is_subclass_of($this->data, NotFoundResponse::class, false):
+                $this->debug('Data not found. Generating a not found response');
+                return new JsonResponse(
+                    [
+                        'code' => JsonResponse::HTTP_NOT_FOUND,
+                        'message' => $this->data->getMessage()
+                    ],
+                    JsonResponse::HTTP_NOT_FOUND
+                );
+            case is_subclass_of($this->data, ErrorResponse::class, false):
+                $this->debug('Data error. Generating an error response');
+                return new JsonResponse(
+                    [
+                        'code' => JsonResponse::HTTP_INTERNAL_SERVER_ERROR,
+                        'message' => $this->data->getMessage()
+                    ],
+                    JsonResponse::HTTP_INTERNAL_SERVER_ERROR
+                );
+            case is_subclass_of($this->data, CreatedResponse::class, false):
+                return new JsonResponse(
+                    null,
+                    JsonResponse::HTTP_CREATED
+                );
+            case is_subclass_of($this->data, NoContentResponse::class, false):
+                return new JsonResponse(
+                    null,
+                    JsonResponse::HTTP_NO_CONTENT
+                );
+            default:
+                return new JsonResponse($this->data, JsonResponse::HTTP_OK);
         }
-        return new JsonResponse($this->data, JsonResponse::HTTP_OK);
     }
 }


### PR DESCRIPTION
## Description

This PR intends to  create NoContent and Created Response

**Fixes** # MON-11975

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
