### PR TITLE
fix(api): add constructor to AbstractPresenter

### DIFF
--- a/src/Core/Application/Common/UseCase/AbstractPresenter.php
+++ b/src/Core/Application/Common/UseCase/AbstractPresenter.php
@@ -31,14 +31,16 @@ use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 abstract class AbstractPresenter implements PresenterInterface
 {
     /**
-     * @var PresenterFormatterInterface
-     */
-    protected $presenterFormatter;
-
-    /**
      * @var ResponseStatusInterface|null
      */
     protected $responseStatus;
+
+    /**
+     * @param PresenterFormatterInterface $presenterFormatter
+     */
+    public function __construct(protected PresenterFormatterInterface $presenterFormatter)
+    {
+    }
 
     /**
      * @inheritDoc


### PR DESCRIPTION
## Description

This PR intends to add a Constructor to AbstractPresenter to prevent error due to $presenterFormatter might not defined.

**Fixes** # MON-11964

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
