### PR TITLE
feat(api): truly return severity level for Hosts and Services

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Host.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Host.yml
@@ -221,7 +221,7 @@ Centreon\Domain\Monitoring\Host:
                 - 'host_main'
                 - 'host_full'
         criticality:
-            type: string
+            type: int
             groups:
                 - 'host_main'
                 - 'host_full'

--- a/src/Centreon/Domain/Monitoring/Service.php
+++ b/src/Centreon/Domain/Monitoring/Service.php
@@ -207,7 +207,7 @@ class Service implements EntityDescriptorMetadataInterface
     protected $stateType;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $criticality;
 

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -513,12 +513,15 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'SELECT h.*,
             i.name AS poller_name,
               IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS state
+              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS state,
+            host_cvl.value AS `criticality`
             FROM `:dbstg`.`instances` i
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\''
+              AND h.name NOT LIKE \'_Module_BAM%\'
+            LEFT JOIN `:dbstg`.`customvariables` AS host_cvl ON host_cvl.host_id = h.host_id
+              AND host_cvl.service_id = 0 AND host_cvl.name = "CRITICALITY_LEVEL"'
             . $accessGroupFilter .
             ' WHERE h.host_id = :host_id';
 
@@ -776,10 +779,13 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 WHEN srv.state = 2 THEN ' . ResourceStatus::SEVERITY_HIGH . '
                 WHEN srv.state = 3 THEN ' . ResourceStatus::SEVERITY_LOW . '
                 WHEN srv.state = 4 THEN ' . ResourceStatus::SEVERITY_PENDING . '
-              END AS `status_severity_code`
+              END AS `status_severity_code`,
+              service_cvl.value AS `criticality`
             FROM `:dbstg`.services srv
             LEFT JOIN `:dbstg`.hosts h
-              ON h.host_id = srv.host_id'
+              ON h.host_id = srv.host_id
+            LEFT JOIN `:dbstg`.`customvariables` AS service_cvl ON service_cvl.host_id = srv.host_id
+              AND service_cvl.service_id = srv.service_id AND service_cvl.name = "CRITICALITY_LEVEL"'
             . $accessGroupFilter
             . ' WHERE srv.enabled = \'1\'
               AND h.enabled = \'1\'


### PR DESCRIPTION
This PR intends to truly return the "criticality" which corresponds to the severity level on the Hosts and Services using the API.

It was mentionned on the serializer, documentation but not handled on the Repository...

![image](https://user-images.githubusercontent.com/31647811/148925294-3ad92e6a-5a26-46e3-98a6-b749013740f3.png)

![image](https://user-images.githubusercontent.com/31647811/148925354-962e5c50-e94b-409e-847a-1ece3b8eb277.png)
![image](https://user-images.githubusercontent.com/31647811/148925404-f7cd7972-f0b4-472f-93e1-ee16548ed829.png)



**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a Service category of type "Severity", set a level to it and link it to a service template.
- Reload and push configuration
- Check that` /monitoring/hosts/{hostId}/services/{serviceId}` returns the criticality corresponding to the severity level

Same goes for the Host.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
