### PR TITLE
fix(UI): Resource Status is not filtered based on the clicked top counter status

### DIFF
--- a/www/front_src/src/Resources/Filter/filterAtoms.ts
+++ b/www/front_src/src/Resources/Filter/filterAtoms.ts
@@ -43,7 +43,7 @@ export const storedFilterAtom = atomWithStorage<Filter>(
   unhandledProblemsFilter,
 );
 
-export const getDefaultFilterDerivedAtom = atom((): Filter => {
+export const getDefaultFilterDerivedAtom = atom(() => (): Filter => {
   const storedFilter = getStoredOrDefaultFilter(unhandledProblemsFilter);
   const urlQueryParameters = getUrlQueryParameters();
   const filterQueryParameter = urlQueryParameters.filter as Filter | undefined;
@@ -70,10 +70,10 @@ export const getDefaultFilterDerivedAtom = atom((): Filter => {
 
 export const customFiltersAtom = atom<Array<Filter>>([]);
 export const currentFilterAtom = atomWithDefault<Filter>((get) =>
-  get(getDefaultFilterDerivedAtom),
+  get(getDefaultFilterDerivedAtom)(),
 );
 export const appliedFilterAtom = atomWithDefault<Filter>((get) =>
-  get(getDefaultFilterDerivedAtom),
+  get(getDefaultFilterDerivedAtom)(),
 );
 export const editPanelOpenAtom = atom(false);
 export const searchAtom = atom('');

--- a/www/front_src/src/Resources/Filter/useFilter.ts
+++ b/www/front_src/src/Resources/Filter/useFilter.ts
@@ -19,6 +19,7 @@ import {
   currentFilterAtom,
   customFiltersAtom,
   filterWithParsedSearchDerivedAtom,
+  getDefaultFilterDerivedAtom,
   searchAtom,
   sendingFilterAtom,
   storedFilterAtom,
@@ -47,7 +48,7 @@ const useFilter = (): void => {
   const filterWithParsedSearch = useAtomValue(
     filterWithParsedSearchDerivedAtom,
   );
-  const defaultFilter = useAtomValue(storedFilterAtom);
+  const getDefaultFilter = useAtomValue(getDefaultFilterDerivedAtom);
   const setCustomFilters = useUpdateAtom(customFiltersAtom);
   const setSearch = useUpdateAtom(searchAtom);
   const applyFilter = useUpdateAtom(applyFilterDerivedAtom);
@@ -99,7 +100,7 @@ const useFilter = (): void => {
       },
     ]);
 
-    applyFilter(defaultFilter);
+    applyFilter(getDefaultFilter());
   }, [getUrlQueryParameters().fromTopCounter]);
 
   React.useEffect(() => {

--- a/www/front_src/src/Resources/Listing/useLoadResources/index.ts
+++ b/www/front_src/src/Resources/Listing/useLoadResources/index.ts
@@ -14,7 +14,12 @@ import { useAtomValue, useUpdateAtom } from 'jotai/utils';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 
-import { getData, SelectEntry, useRequest } from '@centreon/ui';
+import {
+  getData,
+  SelectEntry,
+  useRequest,
+  getUrlQueryParameters,
+} from '@centreon/ui';
 import { refreshIntervalAtom } from '@centreon/ui-context';
 
 import { ResourceListing, SortOrder } from '../../models';
@@ -158,6 +163,10 @@ const useLoadResources = (): LoadResources => {
 
       return criteriaValue?.map(prop('name')) as Array<string>;
     };
+
+    if (getUrlQueryParameters().fromTopCounter) {
+      return;
+    }
 
     sendRequest({
       hostGroups: getCriteriaNames('host_groups'),


### PR DESCRIPTION
## Description

This fixes the Resources Status filter according to the clicked top counter status.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Click on any top counter's status
- Resource Status is correctly filtered

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
