### PR TITLE
fix(conf) fails to display php warnings/errors on conf export

### DIFF
--- a/www/include/configuration/configGenerate/formGenerateFiles.php
+++ b/www/include/configuration/configGenerate/formGenerateFiles.php
@@ -502,7 +502,8 @@ $tpl->display("formGenerateFiles.ihtml");
         divErrors.style.visibility = 'hidden';
         tdEl2.appendChild(divErrors);
         for (var i = 0; i < errors.length; i++) {
-            divErrors.innerHTML += errors.item(i).firstChild.data;
+            divErrors.innerHTML += errors.get(i).firstChild.data;
+            divErrors.innerHTML += "<br/>";
         }
     }
 


### PR DESCRIPTION
## Description

If a php error/warning occurs, the export configuration page fails to display them and 'freeze' with an error in the console

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
