### PR TITLE
fix(myAccount): Fix password input type reset

### DIFF
--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -140,13 +140,13 @@ if ($cct["contact_auth_type"] != 'ldap') {
         'password',
         'contact_passwd',
         _("Password"),
-        array("size" => "30", "autocomplete" => "new-password", "id" => "passwd1", "onFocus" => "resetPwdType(this);")
+        ["size" => "30", "autocomplete" => "new-password", "id" => "passwd1", "onkeypress" => "resetPwdType(this);"]
     );
     $form->addElement(
         'password',
         'contact_passwd2',
         _("Confirm Password"),
-        array("size" => "30", "autocomplete" => "new-password", "id" => "passwd2", "onFocus" => "resetPwdType(this);")
+        ["size" => "30", "autocomplete" => "new-password", "id" => "passwd2", "onkeypress" => "resetPwdType(this);"]
     );
     $form->addElement(
         'button',


### PR DESCRIPTION
## Description

This PR intends to fix My Account password input type reset, where the input type was reset on focus and not on key press (as it does in contact form).

**Fixes** # MON-12051

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Generate an automatic password in the My Account form, it should be an input text. while you select it, it's still an input text, if you type anything, it should reset to input password

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
