### PR TITLE
enh(autologin): verify that autologin is different than password

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16452,3 +16452,9 @@ msgstr "Votre mot de passe expirera dans %s jours."
 
 msgid "Security policy not found. Please verify that your installation is valid"
 msgstr "Politique de sécurité non trouvée. Veuillez vérifier que votre installation est valide"
+
+msgid "Your autologin key should be different than your current password"
+msgstr "Votre clé d'autologin doit être différente de votre mot de passe actuel"
+
+msgid "Your new password and autologin key should be different"
+msgstr "Votre nouveau mot de passe et votre clé d'autologin doivent être différents"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16453,8 +16453,8 @@ msgstr "Votre mot de passe expirera dans %s jours."
 msgid "Security policy not found. Please verify that your installation is valid"
 msgstr "Politique de sécurité non trouvée. Veuillez vérifier que votre installation est valide"
 
-msgid "Your autologin key should be different than your current password"
+msgid "Your autologin key must be different than your current password"
 msgstr "Votre clé d'autologin doit être différente de votre mot de passe actuel"
 
-msgid "Your new password and autologin key should be different"
+msgid "Your new password and autologin key must be different"
 msgstr "Votre nouveau mot de passe et votre clé d'autologin doivent être différents"

--- a/lib/Centreon/Object/Contact/Contact.php
+++ b/lib/Centreon/Object/Contact/Contact.php
@@ -116,8 +116,7 @@ class Centreon_Object_Contact extends \Centreon_Object
         } else {
             $params = $parameterNames;
         }
-        $sql = "SELECT $params, cp.password AS contact_passwd FROM $this->table " .
-        "LEFT JOIN contact_password cp ON cp.contact_id = contact.contact_id";
+        $sql = "SELECT $params FROM $this->table";
         $filterTab = array();
         if (count($filters)) {
             foreach ($filters as $key => $rawvalue) {
@@ -145,7 +144,23 @@ class Centreon_Object_Contact extends \Centreon_Object
         if (isset($count) && $count != -1) {
             $sql = $this->db->limit($sql, $count, $offset);
         }
-        return $this->getResult($sql, $filterTab, "fetchAll");
+
+        $contacts = $this->getResult($sql, $filterTab, "fetchAll");
+        foreach ($contacts as &$contact) {
+            $statement = $this->db->prepare(
+                "SELECT password FROM contact_password WHERE contact_id = :contactId " .
+                "ORDER BY creation_date DESC LIMIT 1"
+            );
+            $statement->bindValue(':contactId', $contact['contact_id'], \PDO::PARAM_INT);
+            $statement->execute();
+            if ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                $contact['contact_passwd'] = $result['password'];
+            } else {
+                $contact['contact_passwd'] = null;
+            }
+        }
+
+        return $contacts;
     }
 
     /**
@@ -162,6 +177,20 @@ class Centreon_Object_Contact extends \Centreon_Object
         if (isset($params['contact_passwd'])) {
             $password = $params['contact_passwd'];
             unset($params['contact_passwd']);
+        }
+        if (isset($params['contact_autologin_key'])) {
+            $statement = $this->db->prepare(
+                "SELECT password FROM contact_password WHERE contact_id = :contactId " .
+                "ORDER BY creation_date DESC LIMIT 1"
+            );
+            $statement->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
+            $statement->execute();
+            if (
+                ($result = $statement->fetch(\PDO::FETCH_ASSOC))
+                && password_verify($params['contact_autologin_key'], $result['password'])
+            ) {
+                throw new \Exception('Your autologin key should be different than your current password');
+            }
         }
 
         if (array_search("", $params)) {

--- a/lib/Centreon/Object/Contact/Contact.php
+++ b/lib/Centreon/Object/Contact/Contact.php
@@ -189,7 +189,7 @@ class Centreon_Object_Contact extends \Centreon_Object
                 ($result = $statement->fetch(\PDO::FETCH_ASSOC))
                 && password_verify($params['contact_autologin_key'], $result['password'])
             ) {
-                throw new \Exception('Your autologin key should be different than your current password');
+                throw new \Exception(_('Your autologin key should be different than your current password'));
             }
         }
 

--- a/lib/Centreon/Object/Contact/Contact.php
+++ b/lib/Centreon/Object/Contact/Contact.php
@@ -189,7 +189,7 @@ class Centreon_Object_Contact extends \Centreon_Object
                 ($result = $statement->fetch(\PDO::FETCH_ASSOC))
                 && password_verify($params['contact_autologin_key'], $result['password'])
             ) {
-                throw new \Exception(_('Your autologin key should be different than your current password'));
+                throw new \Exception(_('Your autologin key must be different than your current password'));
             }
         }
 

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -244,6 +244,7 @@ class CentreonContact extends CentreonObject
             "AND"
         );
         foreach ($elements as $tab) {
+            unset($tab['contact_passwd']);
             echo implode($this->delim, $tab) . "\n";
         }
     }

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -221,7 +221,7 @@ function validatePasswordModification(array $fields)
 }
 
 /**
- * @param array $fields
+ * @param array<string,mixed> $fields
  * @return array<string,string>|bool
  */
 function checkAutologinValue(array $fields)
@@ -242,12 +242,12 @@ function checkAutologinValue(array $fields)
             && !empty($fields['contact_passwd'])
             && password_verify($fields['contact_autologin_key'], $result['password'])
         ) {
-            $errors['contact_autologin_key'] = _('Your autologin key should be different than your current password');
+            $errors['contact_autologin_key'] = _('Your autologin key must be different than your current password');
         } elseif (
             !empty($fields['contact_passwd'])
             && $fields['contact_passwd'] === $fields['contact_autologin_key']
         ) {
-            $errorMessage = _('Your new password and autologin key should be different');
+            $errorMessage = _('Your new password and autologin key must be different');
             $errors['contact_passwd'] = $errorMessage;
             $errors['contact_autologin_key'] = $errorMessage;
         }

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -222,6 +222,7 @@ function validatePasswordModification(array $fields)
 
 /**
  * @param array $fields
+ * @return array<string,string>|bool
  */
 function checkAutologinValue(array $fields)
 {
@@ -238,17 +239,17 @@ function checkAutologinValue(array $fields)
 
         if (
             ($result = $statement->fetch(\PDO::FETCH_ASSOC))
-            && password_verify($fields['contact_autologin_key'], $result['password'])
             && !empty($fields['contact_passwd'])
+            && password_verify($fields['contact_autologin_key'], $result['password'])
         ) {
             $errors['contact_autologin_key'] = _('Your autologin key should be different than your current password');
         } elseif (
-            empty($fields['contact_passwd'])
+            !empty($fields['contact_passwd'])
             && $fields['contact_passwd'] === $fields['contact_autologin_key']
         ) {
-            $errorMessage = 'Your new password and autologin key should be different';
-            $errors['contact_passwd'] = _($errorMessage);
-            $errors['contact_autologin_key'] = _($errorMessage);
+            $errorMessage = _('Your new password and autologin key should be different');
+            $errors['contact_passwd'] = $errorMessage;
+            $errors['contact_autologin_key'] = $errorMessage;
         }
     }
 

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -219,3 +219,37 @@ function validatePasswordModification(array $fields)
 
     return count($errors) > 0 ? $errors : true;
 }
+
+/**
+ * @param array $fields
+ */
+function checkAutologinValue(array $fields)
+{
+    global $pearDB, $centreon;
+    $errors = [];
+
+    if (isset($fields['contact_autologin_key'])) {
+        $contactId = $centreon->user->get_id();
+        $statement = $pearDB->prepare(
+            'SELECT * FROM `contact_password` WHERE contact_id = :contactId ORDER BY creation_date DESC LIMIT 1'
+        );
+        $statement->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        if (
+            ($result = $statement->fetch(\PDO::FETCH_ASSOC))
+            && password_verify($fields['contact_autologin_key'], $result['password'])
+        ) {
+            $errors['contact_autologin_key'] = _('Your autologin key should be different than your current password');
+        } elseif (
+            isset($fields['contact_passwd'])
+            && $fields['contact_passwd'] === $fields['contact_autologin_key']
+        ) {
+            $errorMessage = 'Your new password and autologin key should be different';
+            $errors['contact_passwd'] = _($errorMessage);
+            $errors['contact_autologin_key'] = _($errorMessage);
+        }
+    }
+
+    return count($errors) > 0 ? $errors : true;
+}

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -228,7 +228,7 @@ function checkAutologinValue(array $fields)
     global $pearDB, $centreon;
     $errors = [];
 
-    if (isset($fields['contact_autologin_key'])) {
+    if (!empty($fields['contact_autologin_key'])) {
         $contactId = $centreon->user->get_id();
         $statement = $pearDB->prepare(
             'SELECT * FROM `contact_password` WHERE contact_id = :contactId ORDER BY creation_date DESC LIMIT 1'
@@ -239,10 +239,11 @@ function checkAutologinValue(array $fields)
         if (
             ($result = $statement->fetch(\PDO::FETCH_ASSOC))
             && password_verify($fields['contact_autologin_key'], $result['password'])
+            && !empty($fields['contact_passwd'])
         ) {
             $errors['contact_autologin_key'] = _('Your autologin key should be different than your current password');
         } elseif (
-            isset($fields['contact_passwd'])
+            empty($fields['contact_passwd'])
             && $fields['contact_passwd'] === $fields['contact_autologin_key']
         ) {
             $errorMessage = 'Your new password and autologin key should be different';

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -390,6 +390,7 @@ $form->addRule('contact_name', _("Name already in use"), 'exist');
 $form->registerRule('existAlias', 'callback', 'testAliasExistence');
 $form->addRule('contact_alias', _("Name already in use"), 'existAlias');
 $form->setRequiredNote("<font style='color: red;'>*</font>" . _("Required fields"));
+$form->addFormRule('checkAutologinValue');
 
 // Smarty template Init
 $tpl = new Smarty();

--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -1327,7 +1327,7 @@ function validatePasswordModification(array $fields)
  * Validate autologin key is not equal to a password
  *
  * @param array $fields
- * @return mixed
+ * @return array<string,string>|bool
  */
 function validateAutologin(array $fields)
 {

--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -1300,7 +1300,7 @@ function validatePasswordCreation(array $fields)
 /**
  * Validate password creation using defined security policy.
  *
- * @param array $fields
+ * @param array<string,mixed> $fields
  * @return mixed
  */
 function validatePasswordModification(array $fields)
@@ -1326,7 +1326,7 @@ function validatePasswordModification(array $fields)
 /**
  * Validate autologin key is not equal to a password
  *
- * @param array $fields
+ * @param array<string,mixed> $fields
  * @return array<string,string>|bool
  */
 function validateAutologin(array $fields)
@@ -1351,7 +1351,7 @@ function validateAutologin(array $fields)
                 && password_verify($fields['contact_autologin_key'], $result['password'])
             ) {
                 $errors['contact_autologin_key'] = _(
-                    'Your autologin key should be different than your current password'
+                    'Your autologin key must be different than your current password'
                 );
             }
         }

--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -749,6 +749,7 @@ if ($o != MASSIVE_CHANGE) {
     $form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
     if ($o === ADD_CONTACT || $o === MODIFY_CONTACT) {
         $form->addFormRule('validatePasswordCreation');
+        $form->addFormRule('validateAutologin');
     }
     if ($o === MODIFY_CONTACT) {
         $form->addFormRule('validatePasswordModification');


### PR DESCRIPTION
## Description

This PR intends to verify that autologin is different than password
**Fixes** # MON-12050

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
