### PR TITLE
fix(UI): Titles are cropped in tiles

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
@@ -14,10 +14,10 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
   },
   title: {
-    textOverflow: 'ellipsis',
-    overflow:'hidden',
     display: 'flex',
     gridGap: theme.spacing(1),
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 }));
 

--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
@@ -10,10 +10,12 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.success.main,
   },
   container: {
-    height: 65,
+    height: 70,
     overflow: 'hidden',
   },
   title: {
+    textOverflow: 'ellipsis',
+    overflow:'hidden',
     display: 'flex',
     gridGap: theme.spacing(1),
   },

--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/index.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.success.main,
   },
   container: {
-    height: 70,
+    height: 65,
     overflow: 'hidden',
   },
   title: {


### PR DESCRIPTION
## Description

Titles are cropped in tiles

**Fixes** # (issue)

Add CSS style

## Type of change

- [x] Patch fixing an issue (non-breaking change)


## Target serie

- [x] 21.10.x
- [x] 22.04.x (master)
