### PR TITLE
enh(resource): replace custom macros in external urls

### DIFF
--- a/config/routes/Centreon/monitoring_resource.yaml
+++ b/config/routes/Centreon/monitoring_resource.yaml
@@ -29,12 +29,6 @@ centreon_application_monitoring_resource_details_meta_service:
         metaId: '\d+'
     condition: "request.attributes.get('version') >= 21.10"
 
-centreon_application_monitoring_resource_redirect_external_link:
-    methods: POST
-    path: /monitoring/resources/external-link/redirect
-    controller: 'Centreon\Application\Controller\MonitoringResourceController::redirectFromResourceExternalLink'
-    condition: "request.attributes.get('version') >= 21.10"
-
 centreon_application_monitoring_resource_redirect_url_service:
     methods: GET
     path: /monitoring/resources/hosts/{hostId}/services/{serviceId}/{urlType}/redirect

--- a/config/routes/Centreon/monitoring_resource.yaml
+++ b/config/routes/Centreon/monitoring_resource.yaml
@@ -28,3 +28,29 @@ centreon_application_monitoring_resource_details_meta_service:
     requirements:
         metaId: '\d+'
     condition: "request.attributes.get('version') >= 21.10"
+
+centreon_application_monitoring_resource_redirect_external_link:
+    methods: POST
+    path: /monitoring/resources/external-link/redirect
+    controller: 'Centreon\Application\Controller\MonitoringResourceController::redirectFromResourceExternalLink'
+    condition: "request.attributes.get('version') >= 21.10"
+
+centreon_application_monitoring_resource_redirect_url_service:
+    methods: GET
+    path: /monitoring/resources/hosts/{hostId}/services/{serviceId}/{urlType}/redirect
+    controller: 'Centreon\Application\Controller\MonitoringResourceController::redirectResourceExternalLink'
+    requirements:
+        hostId: '\d+'
+        serviceId: '\d+'
+        urlType: '(action-url|notes-url)'
+    condition: "request.attributes.get('version') >= 21.10"
+
+centreon_application_monitoring_resource_redirect_url_host:
+    methods: GET
+    path: /monitoring/resources/hosts/{hostId}/{urlType}/redirect
+    controller: 'Centreon\Application\Controller\MonitoringResourceController::redirectResourceExternalLink'
+    requirements:
+        hostId: '\d+'
+        urlType: '(action-url|notes-url)'
+    condition: "request.attributes.get('version') >= 21.10"
+

--- a/doc/API/centreon-api-v21.10.yaml
+++ b/doc/API/centreon-api-v21.10.yaml
@@ -3134,6 +3134,43 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /monitoring/resources/hosts/{host_id}/services/{service_id}/{url_type}/redirect:
+    get:
+      tags:
+        - Redirect URL
+      summary: "Redirect to the provided URL for the resource type service"
+      description: |
+        This endpoint will redirect to the URL type provided (action_url / notes_url)
+        with standard and custom macros used in the URL replaced by their actual values
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/UrlType'
+      responses:
+        '302':
+          $ref: '#/components/responses/Redirect'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /monitoring/resources/hosts/{host_id}/{url_type}/redirect:
+    get:
+      tags:
+        - Redirect URL
+      summary: "Redirect to the provided URL for the resource type host"
+      description: |
+        This endpoint will redirect to the URL type provided (action_url / notes_url)
+        with standard and custom macros used in the URL replaced by their actual values
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/UrlType'
+      responses:
+        '302':
+          $ref: '#/components/responses/Redirect'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /monitoring/resources/acknowledge:
     post:
       tags:
@@ -3658,6 +3695,15 @@ components:
         type: integer
         format: int64
         example: 5
+    UrlType:
+      in: path
+      name: url_type
+      description: "Type of URL provided"
+      required: true
+      schema:
+        type: string
+        enum: [ action-url, notes-url ]
+        example: action-url
     MetaId:
       in: path
       name: meta_id
@@ -3785,6 +3831,17 @@ components:
               message:
                 type: string
                 example: "You are not authorized to access this resource"
+    Redirect:
+      description: "Redirect"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int64
+                example: 302
     NotFound:
       description: "Not Found"
     NotFoundHostOrService:

--- a/src/Centreon/Domain/HostConfiguration/HostMacro.php
+++ b/src/Centreon/Domain/HostConfiguration/HostMacro.php
@@ -28,12 +28,12 @@ use Centreon\Domain\Annotation\EntityDescriptor;
 class HostMacro implements MacroInterface
 {
     /**
-     * @var int|null
+     * @var int
      */
     private $id;
 
     /**
-     * @var string|null Macro name
+     * @var string Macro name
      */
     private $name;
 
@@ -64,48 +64,44 @@ class HostMacro implements MacroInterface
     private $hostId;
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }
 
     /**
-     * @param int|null $id
+     * @param int $id
      * @return self
      */
-    public function setId(?int $id): self
+    public function setId(int $id): self
     {
         $this->id = $id;
         return $this;
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * @param string|null $name
+     * @param string $name
      * @return self
      */
-    public function setName(?string $name): self
+    public function setName(string $name): self
     {
-        if ($name !== null) {
-            if (strpos($name, '$_HOST') !== 0) {
-                $name = '$_HOST' . $name;
-                if ($name[-1] !== '$') {
-                    $name .= '$';
-                }
+        if (strpos($name, '$_HOST') !== 0) {
+            $name = '$_HOST' . $name;
+            if ($name[-1] !== '$') {
+                $name .= '$';
             }
-            $this->name = strtoupper($name);
-        } else {
-            $this->name = null;
         }
+        $this->name = strtoupper($name);
         return $this;
     }
 

--- a/src/Centreon/Domain/HostConfiguration/Interfaces/HostMacro/HostMacroReadRepositoryInterface.php
+++ b/src/Centreon/Domain/HostConfiguration/Interfaces/HostMacro/HostMacroReadRepositoryInterface.php
@@ -35,7 +35,7 @@ interface HostMacroReadRepositoryInterface
      * Find all service macros for the service.
      *
      * @param int $hostId Id of the Host
-     * @param bool $useInheritance Indicates whether to use inheritance to find service macros (FALSE by default)
+     * @param bool $useInheritance Indicates whether to use inheritance to find service macros
      * @return HostMacro[] List of host macros found
      * @throws \Throwable
      */

--- a/src/Centreon/Domain/HostConfiguration/Interfaces/HostMacro/HostMacroReadRepositoryInterface.php
+++ b/src/Centreon/Domain/HostConfiguration/Interfaces/HostMacro/HostMacroReadRepositoryInterface.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\HostConfiguration\Interfaces\HostMacro;
 
+use Centreon\Domain\HostConfiguration\HostMacro;
+
 /**
  * This interface gathers all the reading operations on the repository.
  *
@@ -29,4 +31,13 @@ namespace Centreon\Domain\HostConfiguration\Interfaces\HostMacro;
  */
 interface HostMacroReadRepositoryInterface
 {
+    /**
+     * Find all service macros for the service.
+     *
+     * @param int $hostId Id of the Host
+     * @param bool $useInheritance Indicates whether to use inheritance to find service macros (FALSE by default)
+     * @return HostMacro[] List of host macros found
+     * @throws \Throwable
+     */
+    public function findOnDemandHostMacros(int $hostId, bool $useInheritance): array;
 }

--- a/src/Centreon/Domain/Log/LoggerTrait.php
+++ b/src/Centreon/Domain/Log/LoggerTrait.php
@@ -35,7 +35,7 @@ trait LoggerTrait
     /**
      * @var ContactInterface
      */
-    private $contact;
+    private $loggerContact;
 
     /**
      * @var LoggerInterface
@@ -45,24 +45,24 @@ trait LoggerTrait
     /**
      * @var ContactForDebug
      */
-    private $contactForDebug;
+    private $loggerContactForDebug;
 
     /**
-     * @param ContactInterface $contact
+     * @param ContactInterface $loggerContact
      * @required
      */
-    public function setContact(ContactInterface $contact): void
+    public function setLoggerContact(ContactInterface $loggerContact): void
     {
-        $this->contact = $contact;
+        $this->contaloggerContactct = $loggerContact;
     }
 
     /**
-     * @param ContactForDebug $contactForDebug
+     * @param ContactForDebug $loggerContactForDebug
      * @required
      */
-    public function setContactForDebug(ContactForDebug $contactForDebug): void
+    public function setLoggerContactForDebug(ContactForDebug $loggerContactForDebug): void
     {
-        $this->contactForDebug = $contactForDebug;
+        $this->loggerContactForDebug = $loggerContactForDebug;
     }
 
     /**
@@ -239,7 +239,7 @@ trait LoggerTrait
     private function canBeLogged(): bool
     {
         return $this->logger !== null
-            && $this->contactForDebug !== null
-            && $this->contactForDebug->isValidForContact($this->contact);
+            && $this->loggerContactForDebug !== null
+            && $this->loggerContactForDebug->isValidForContact($this->loggerContact);
     }
 }

--- a/src/Centreon/Domain/Log/LoggerTrait.php
+++ b/src/Centreon/Domain/Log/LoggerTrait.php
@@ -53,7 +53,7 @@ trait LoggerTrait
      */
     public function setLoggerContact(ContactInterface $loggerContact): void
     {
-        $this->contaloggerContactct = $loggerContact;
+        $this->loggerContact = $loggerContact;
     }
 
     /**

--- a/src/Centreon/Domain/Macro/Interfaces/MacroInterface.php
+++ b/src/Centreon/Domain/Macro/Interfaces/MacroInterface.php
@@ -25,26 +25,26 @@ namespace Centreon\Domain\Macro\Interfaces;
 interface MacroInterface
 {
     /**
-     * @return int|null
+     * @return int
      */
-    public function getId(): ?int;
+    public function getId(): int;
 
     /**
-     * @param int|null $id
+     * @param int $id
      * @return self
      */
-    public function setId(?int $id);
+    public function setId(int $id);
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getName(): ?string;
+    public function getName(): string;
 
     /**
-     * @param string|null $name
+     * @param string $name
      * @return self
      */
-    public function setName(?string $name);
+    public function setName(string $name);
 
     /**
      * @return string|null

--- a/src/Centreon/Domain/Monitoring/Host.php
+++ b/src/Centreon/Domain/Monitoring/Host.php
@@ -22,8 +22,9 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Monitoring;
 
-use Centreon\Domain\Acknowledgement\Acknowledgement;
 use Centreon\Domain\Downtime\Downtime;
+use Centreon\Domain\Monitoring\ResourceStatus;
+use Centreon\Domain\Acknowledgement\Acknowledgement;
 use Centreon\Domain\Service\EntityDescriptorMetadataInterface;
 
 /**
@@ -40,9 +41,13 @@ class Host implements EntityDescriptorMetadataInterface
     public const SERIALIZER_GROUP_WITH_SERVICES = 'host_with_services';
 
     // Status options
-    public const STATUS_UP          = 0;
-    public const STATUS_DOWN        = 1;
-    public const STATUS_UNREACHABLE = 2;
+    public const STATUS_UP = 0,
+                 STATUS_DOWN = 1,
+                 STATUS_UNREACHABLE = 2;
+
+    public const STATUS_NAME_UP = 'UP',
+                 STATUS_NAME_DOWN = 'DOWN',
+                 STATUS_NALE_UNREACHABLE = 'UNREACHABLE';
 
     /**
      * @var int|null Id of host
@@ -308,6 +313,21 @@ class Host implements EntityDescriptorMetadataInterface
      * @var string|null
      */
     protected $pollerName;
+
+    /**
+     * @var string|null
+     */
+    private $actionUrl;
+
+    /**
+     * @var string|null
+     */
+    private $notesUrl;
+
+    /**
+     * @var ResourceStatus|null
+     */
+    private $status;
 
     /**
      * {@inheritdoc}
@@ -1292,6 +1312,60 @@ class Host implements EntityDescriptorMetadataInterface
     {
         $this->pollerName = $pollerName;
 
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getActionUrl(): ?string
+    {
+        return $this->actionUrl;
+    }
+
+    /**
+     * @param string|null $actionUrl
+     * @return self
+     */
+    public function setActionUrl(?string $actionUrl): self
+    {
+        $this->actionUrl = $actionUrl;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNotesUrl(): ?string
+    {
+        return $this->notesUrl;
+    }
+
+    /**
+     * @param string|null $notesUrl
+     * @return self
+     */
+    public function setNotesUrl(?string $notesUrl): self
+    {
+        $this->notesUrl = $notesUrl;
+        return $this;
+    }
+
+    /**
+     * @return ResourceStatus|null
+     */
+    public function getStatus(): ?ResourceStatus
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param ResourceStatus|null $status
+     * @return self
+     */
+    public function setStatus(?ResourceStatus $status): self
+    {
+        $this->status = $status;
         return $this;
     }
 }

--- a/src/Centreon/Domain/Monitoring/Host.php
+++ b/src/Centreon/Domain/Monitoring/Host.php
@@ -325,7 +325,7 @@ class Host implements EntityDescriptorMetadataInterface
     private $notesUrl;
 
     /**
-     * @var ResourceStatus|null
+     * @var ResourceStatus
      */
     private $status;
 
@@ -1118,10 +1118,12 @@ class Host implements EntityDescriptorMetadataInterface
 
     /**
      * @param Service $service
+     * @return self
      */
-    public function addService(Service $service)
+    public function addService(Service $service): self
     {
         $this->services[] = $service;
+        return $this;
     }
 
     /**
@@ -1352,18 +1354,18 @@ class Host implements EntityDescriptorMetadataInterface
     }
 
     /**
-     * @return ResourceStatus|null
+     * @return ResourceStatus
      */
-    public function getStatus(): ?ResourceStatus
+    public function getStatus(): ResourceStatus
     {
         return $this->status;
     }
 
     /**
-     * @param ResourceStatus|null $status
+     * @param ResourceStatus $status
      * @return self
      */
-    public function setStatus(?ResourceStatus $status): self
+    public function setStatus(ResourceStatus $status): self
     {
         $this->status = $status;
         return $this;

--- a/src/Centreon/Domain/Monitoring/HostGroup.php
+++ b/src/Centreon/Domain/Monitoring/HostGroup.php
@@ -46,7 +46,7 @@ class HostGroup implements EntityDescriptorMetadataInterface
     private $hosts = [];
 
     /**
-     * @var string|null
+     * @var string
      */
     private $name;
 
@@ -79,18 +79,18 @@ class HostGroup implements EntityDescriptorMetadataInterface
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * @param string|null $name
+     * @param string $name
      * @return HostGroup
      */
-    public function setName(?string $name): HostGroup
+    public function setName(string $name): HostGroup
     {
         $this->name = $name;
         return $this;

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -224,4 +224,13 @@ interface MonitoringRepositoryInterface
      * @return Acknowledgement[]
      */
     public function findAcknowledgements(int $hostId, int $serviceId): array;
+
+    /**
+     * Find all custom macros linked to a service or a host
+     *
+     * @param int $hostId
+     * @param int $serviceIds
+     * @return array<string, mixed>
+     */
+    public function findCustomMacrosValues(int $hostId, int $serviceId): array;
 }

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -229,8 +229,8 @@ interface MonitoringRepositoryInterface
      * Find all custom macros linked to a service or a host
      *
      * @param int $hostId
-     * @param int $serviceIds
-     * @return array<string, mixed>
+     * @param int $serviceId
+     * @return array<string|int, mixed>
      */
     public function findCustomMacrosValues(int $hostId, int $serviceId): array;
 }

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -230,7 +230,7 @@ interface MonitoringRepositoryInterface
      *
      * @param int $hostId
      * @param int $serviceId
-     * @return array<string|int, mixed>
+     * @return array<string, string>
      */
     public function findCustomMacrosValues(int $hostId, int $serviceId): array;
 }

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace Centreon\Domain\Monitoring\Interfaces;
 
 use Centreon\Domain\Monitoring\ResourceFilter;
+use Centreon\Domain\Exception\EntityNotFoundException;
 use Centreon\Domain\Monitoring\Resource as ResourceEntity;
 use Centreon\Domain\Monitoring\Exception\ResourceException;
 

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -139,12 +139,27 @@ interface ResourceServiceInterface
     public function enrichMetaServiceWithDetails(ResourceEntity $resource): void;
 
     /**
-     * Replace macros set in the external links by their actual values
+     * Replace macros in the URL provided by their actual values for a Service Resource
      *
-     * @param ResourceEntity $resource
-     * @return void
+     * @param int $hostId
+     * @param int $serviceId
+     * @param string $urlType
+     * @return string
+     * @throws \Exception
+     * @throws EntityNotFoundException
      */
-    public function replaceMacrosInExternalLinks(ResourceEntity $resource): void;
+    public function replaceMacrosInServiceUrl(int $hostId, int $serviceId, string $urlType): string;
+
+    /**
+     * Replace macros in the URL provided by their actual values for a Host Resource
+     *
+     * @param int $hostId
+     * @param string $urlType
+     * @return string
+     * @throws \Exception
+     * @throws EntityNotFoundException
+     */
+    public function replaceMacrosInHostUrl(int $hostId, string $urlType): string;
 
     /**
      * Used to filter requests according to a contact.

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -58,7 +58,7 @@ class Resource
     public const TYPE_META = 'metaservice';
 
     /**
-     * @var int|null
+     * @var int
      */
     private $id;
 
@@ -256,7 +256,7 @@ class Resource
      */
     private $calculationType;
 
-    /*
+    /**
      * Indicates if notifications are enabled for the Resource
      *
      * @var bool
@@ -326,18 +326,18 @@ class Resource
     }
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }
 
     /**
-     * @param int|null $id
+     * @param int $id
      * @return \Centreon\Domain\Monitoring\Resource
      */
-    public function setId(?int $id): self
+    public function setId(int $id): self
     {
         $this->id = $id;
 

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -37,6 +37,7 @@ use Centreon\Domain\Security\Interfaces\AccessGroupRepositoryInterface;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringRepositoryInterface;
 use Centreon\Domain\MetaServiceConfiguration\Exception\MetaServiceConfigurationException;
 use Centreon\Domain\HostConfiguration\Interfaces\HostMacro\HostMacroReadRepositoryInterface;
+use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\ServiceConfiguration\Interfaces\ServiceConfigurationRepositoryInterface;
 use Centreon\Domain\MetaServiceConfiguration\Interfaces\MetaServiceConfigurationReadRepositoryInterface;
 
@@ -47,6 +48,7 @@ use Centreon\Domain\MetaServiceConfiguration\Interfaces\MetaServiceConfiguration
  */
 class ResourceService extends AbstractCentreonService implements ResourceServiceInterface
 {
+    use LoggerTrait;
     /**
      * @var ResourceRepositoryInterface
      */
@@ -353,7 +355,16 @@ class ResourceService extends AbstractCentreonService implements ResourceService
 
         $standardMacros = $this->getStandardMacrosForHost($host);
         $customMacros = $this->getCustomMacrosOutOfUrl($hostId, 0, $url);
-        return $this->replaceMacrosByValues($url, array_merge($standardMacros, $customMacros));
+        $macros = array_merge($standardMacros, $customMacros);
+        $this->info(
+            'Replacing macros found in URL',
+            [
+                'url_type' => $urlType,
+                'url' => $url,
+                'macros' => $macros
+            ]
+        );
+        return $this->replaceMacrosByValues($url, $macros);
     }
 
     /**

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -49,6 +49,7 @@ use Centreon\Domain\MetaServiceConfiguration\Interfaces\MetaServiceConfiguration
 class ResourceService extends AbstractCentreonService implements ResourceServiceInterface
 {
     use LoggerTrait;
+
     /**
      * @var ResourceRepositoryInterface
      */

--- a/src/Centreon/Domain/Monitoring/Service.php
+++ b/src/Centreon/Domain/Monitoring/Service.php
@@ -232,6 +232,16 @@ class Service implements EntityDescriptorMetadataInterface
     private $status;
 
     /**
+     * @var string|null
+     */
+    protected $actionUrl;
+
+    /**
+     * @var string|null
+     */
+    protected $notesUrl;
+
+    /**
      * {@inheritdoc}
      */
     public static function loadEntityDescriptorMetadata(): array
@@ -928,7 +938,7 @@ class Service implements EntityDescriptorMetadataInterface
 
     /**
      * @param \Centreon\Domain\Monitoring\ResourceStatus|null $status
-     * @return \Centreon\Domain\Monitoring\Resource
+     * @return self
      */
     public function setStatus(?ResourceStatus $status): self
     {
@@ -949,5 +959,41 @@ class Service implements EntityDescriptorMetadataInterface
         }
 
         return $duration;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getActionUrl(): ?string
+    {
+        return $this->actionUrl;
+    }
+
+    /**
+     * @param string|null $actionUrl
+     * @return self
+     */
+    public function setActionUrl(?string $actionUrl): self
+    {
+        $this->actionUrl = $actionUrl;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNotesUrl(): ?string
+    {
+        return $this->notesUrl;
+    }
+
+    /**
+     * @param string|null $notesUrl
+     * @return self
+     */
+    public function setNotesUrl(?string $notesUrl): self
+    {
+        $this->notesUrl = $notesUrl;
+        return $this;
     }
 }

--- a/src/Centreon/Domain/Monitoring/Service.php
+++ b/src/Centreon/Domain/Monitoring/Service.php
@@ -182,7 +182,7 @@ class Service implements EntityDescriptorMetadataInterface
     protected $maxCheckAttempts;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $nextCheck;
 
@@ -227,7 +227,7 @@ class Service implements EntityDescriptorMetadataInterface
     protected $flapping;
 
     /**
-     * @var \Centreon\Domain\Monitoring\ResourceStatus|null
+     * @var \Centreon\Domain\Monitoring\ResourceStatus
      */
     private $status;
 
@@ -650,7 +650,7 @@ class Service implements EntityDescriptorMetadataInterface
 
     /**
      * @param \DateTime|null $nextCheck
-     * @return Service|null
+     * @return Service
      */
     public function setNextCheck(?\DateTime $nextCheck): Service
     {
@@ -929,18 +929,18 @@ class Service implements EntityDescriptorMetadataInterface
     }
 
     /**
-     * @return \Centreon\Domain\Monitoring\ResourceStatus|null
+     * @return \Centreon\Domain\Monitoring\ResourceStatus
      */
-    public function getStatus(): ?ResourceStatus
+    public function getStatus(): ResourceStatus
     {
         return $this->status;
     }
 
     /**
-     * @param \Centreon\Domain\Monitoring\ResourceStatus|null $status
+     * @param \Centreon\Domain\Monitoring\ResourceStatus $status
      * @return self
      */
-    public function setStatus(?ResourceStatus $status): self
+    public function setStatus(ResourceStatus $status): self
     {
         $this->status = $status;
 
@@ -954,7 +954,7 @@ class Service implements EntityDescriptorMetadataInterface
     {
         $duration = null;
 
-        if ($this->getLastStateChange()) {
+        if ($this->getLastStateChange() !== null) {
             $duration = CentreonDuration::toString(time() - $this->getLastStateChange()->getTimestamp());
         }
 

--- a/src/Centreon/Domain/Monitoring/ServiceGroup.php
+++ b/src/Centreon/Domain/Monitoring/ServiceGroup.php
@@ -46,7 +46,7 @@ class ServiceGroup implements EntityDescriptorMetadataInterface
     private $hosts = [];
 
     /**
-     * @var string|null
+     * @var string
      */
     private $name;
 
@@ -124,18 +124,18 @@ class ServiceGroup implements EntityDescriptorMetadataInterface
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * @param string|null $name
+     * @param string $name
      * @return ServiceGroup
      */
-    public function setName(?string $name): ServiceGroup
+    public function setName(string $name): ServiceGroup
     {
         $this->name = $name;
         return $this;

--- a/src/Centreon/Domain/ServiceConfiguration/Interfaces/ServiceConfigurationRepositoryInterface.php
+++ b/src/Centreon/Domain/ServiceConfiguration/Interfaces/ServiceConfigurationRepositoryInterface.php
@@ -43,11 +43,11 @@ interface ServiceConfigurationRepositoryInterface extends AccessControlListRepos
      * Find all service macros for the service.
      *
      * @param int $serviceId Id of the service
-     * @param bool $isUsingInheritance Indicates whether to use inheritance to find service macros (FALSE by default)
-     * @return array<ServiceMacro> List of service macros found
+     * @param bool $useInheritance Indicates whether to use inheritance to find service macros (FALSE by default)
+     * @return ServiceMacro[] List of service macros found
      * @throws \Throwable
      */
-    public function findOnDemandServiceMacros(int $serviceId, bool $isUsingInheritance = false): array;
+    public function findOnDemandServiceMacros(int $serviceId, bool $useInheritance = false): array;
 
     /**
      * Find the command of a service.

--- a/src/Centreon/Domain/ServiceConfiguration/ServiceMacro.php
+++ b/src/Centreon/Domain/ServiceConfiguration/ServiceMacro.php
@@ -28,12 +28,12 @@ use Centreon\Domain\Annotation\EntityDescriptor;
 class ServiceMacro implements MacroInterface
 {
     /**
-     * @var int|null
+     * @var int
      */
     private $id;
 
     /**
-     * @var string|null Macro name
+     * @var string Macro name
      */
     private $name;
 
@@ -64,49 +64,45 @@ class ServiceMacro implements MacroInterface
     private $serviceId;
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }
 
     /**
-     * @param int|null $id
+     * @param int $id
      * @return self
      */
-    public function setId(?int $id): self
+    public function setId(int $id): self
     {
         $this->id = $id;
         return $this;
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * @param string|null $name
+     * @param string $name
      * @return self
      */
-    public function setName(?string $name): self
+    public function setName(string $name): self
     {
         $patternToBeFound = '$_SERVICE';
-        if ($name !== null) {
-            if (strpos($name, $patternToBeFound) !== 0) {
-                $name = $patternToBeFound . $name;
-                if ($name[-1] !== '$') {
-                    $name .= '$';
-                }
+        if (strpos($name, $patternToBeFound) !== 0) {
+            $name = $patternToBeFound . $name;
+            if ($name[-1] !== '$') {
+                $name .= '$';
             }
-            $this->name = strtoupper($name);
-        } else {
-            $this->name = null;
         }
+        $this->name = strtoupper($name);
         return $this;
     }
 

--- a/src/Centreon/Infrastructure/HostConfiguration/Repository/HostMacroRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/HostConfiguration/Repository/HostMacroRepositoryRDB.php
@@ -2,15 +2,17 @@
 
 namespace Centreon\Infrastructure\HostConfiguration\Repository;
 
-use Centreon\Domain\Common\Assertion\Assertion;
+use Centreon\Domain\Entity\EntityCreator;
 use Centreon\Domain\HostConfiguration\Host;
+use Centreon\Domain\Common\Assertion\Assertion;
+use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Domain\HostConfiguration\HostMacro;
+use Centreon\Domain\RequestParameters\RequestParameters;
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Centreon\Infrastructure\CentreonLegacyDB\StatementCollector;
+use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Centreon\Domain\HostConfiguration\Interfaces\HostMacro\HostMacroReadRepositoryInterface;
 use Centreon\Domain\HostConfiguration\Interfaces\HostMacro\HostMacroWriteRepositoryInterface;
-use Centreon\Domain\RequestParameters\RequestParameters;
-use Centreon\Infrastructure\DatabaseConnection;
-use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
-use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 
 /**
  * This class is designed to represent the MariaDb repository to manage host macro,
@@ -62,5 +64,51 @@ class HostMacroRepositoryRDB extends AbstractRepositoryDRB implements
 
         $hostMacroId = (int)$this->db->lastInsertId();
         $hostMacro->setId($hostMacroId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findOnDemandHostMacros(int $hostId, bool $useInheritance): array
+    {
+        $request = $this->translateDbName(
+            'SELECT
+                host.host_id AS host_id, demand.host_macro_id AS id,
+                host_macro_name AS name, host_macro_value AS `value`,
+                macro_order AS `order`, is_password, description, host_template_model_htm_id
+             FROM `:db`.host
+                LEFT JOIN `:db`.on_demand_macro_host demand ON host.host_id = demand.host_host_id
+             WHERE host.host_id = :host_id'
+        );
+        $statement = $this->db->prepare($request);
+
+        $hostMacros = [];
+        $loop = [];
+        $macrosAdded = [];
+        while (!is_null($hostId)) {
+            if (isset($loop[$hostId])) {
+                break;
+            }
+            $loop[$hostId] = 1;
+            $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+            $statement->execute();
+            while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+                $hostId = $record['host_template_model_htm_id'];
+                if (is_null($record['name']) || isset($macrosAdded[$record['name']])) {
+                    continue;
+                }
+                $macrosAdded[$record['name']] = 1;
+                $record['is_password'] = is_null($record['is_password']) ? 0 : $record['is_password'];
+                $hostMacros[] = EntityCreator::createEntityByArray(
+                    HostMacro::class,
+                    $record
+                );
+            }
+            if (!$useInheritance) {
+                break;
+            }
+        }
+
+        return $hostMacros;
     }
 }

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -154,8 +154,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               h.*,
               cv.value AS criticality,
               i.name AS poller_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS `status_code`,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state) AS `status_code`,
             CASE
                 WHEN h.state = 0 THEN \'UP\'
                 WHEN h.state = 1 THEN \'DOWN\'
@@ -172,7 +172,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\''
+              AND h.name NOT LIKE \'\_Module\_BAM%\''
             . $accessGroupFilter
             . ' LEFT JOIN `:dbstg`.`services` srv
               ON srv.host_id = h.host_id
@@ -267,8 +267,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT
               hg.hostgroup_id, h.*, i.name AS poller_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS `status_code`,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state) AS `status_code`,
             CASE
                 WHEN h.state = 0 THEN \'UP\'
                 WHEN h.state = 1 THEN \'DOWN\'
@@ -285,7 +285,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\''
+              AND h.name NOT LIKE \'\_Module\_BAM%\''
             . $accessGroupFilter
             . ' LEFT JOIN `:dbstg`.`services` srv
               ON srv.host_id = h.host_id
@@ -346,8 +346,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT SQL_CALC_FOUND_ROWS DISTINCT
               ssg.servicegroup_id, h.*, i.name AS poller_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS `status_code`,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state) AS `status_code`,
             CASE
                 WHEN h.state = 0 THEN \'UP\'
                 WHEN h.state = 1 THEN \'DOWN\'
@@ -364,7 +364,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\'
+              AND h.name NOT LIKE \'\_Module\_BAM%\'
             INNER JOIN `:dbstg`.`services` srv
               ON srv.host_id = h.host_id
               AND srv.enabled = \'1\''
@@ -477,7 +477,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 INNER JOIN `:dbstg`.hosts h
                     ON h.host_id = hhg.host_id
                     AND h.enabled = \'1\'
-                    AND h.name NOT LIKE \'_Module_BAM%\'';
+                    AND h.name NOT LIKE \'\_Module\_BAM%\'';
 
             if (!$this->isAdmin()) {
                 $subRequest .=
@@ -579,8 +579,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT h.*,
             i.name AS poller_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state)AS `status_code`,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state)AS `status_code`,
             CASE
                 WHEN h.state = 0 THEN \'UP\'
                 WHEN h.state = 1 THEN \'DOWN\'
@@ -598,7 +598,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\'
+              AND h.name NOT LIKE \'\_Module\_BAM%\'
             LEFT JOIN `:dbstg`.`customvariables` AS host_cvl ON host_cvl.host_id = h.host_id
               AND host_cvl.service_id = 0 AND host_cvl.name = "CRITICALITY_LEVEL"'
             . $accessGroupFilter .
@@ -732,8 +732,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT DISTINCT h.*,
             i.name AS poller_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS `status_code`,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state) AS `status_code`,
             CASE
                 WHEN h.state = 0 THEN \'UP\'
                 WHEN h.state = 1 THEN \'DOWN\'
@@ -750,7 +750,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\'';
+              AND h.name NOT LIKE \'\_Module\_BAM%\'';
 
         $idsListKey = [];
         foreach ($hostIds as $index => $id) {
@@ -807,8 +807,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT DISTINCT h.*,
             i.name AS poller_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS `status_code`,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state) AS `status_code`,
             CASE
                 WHEN h.state = 0 THEN \'UP\'
                 WHEN h.state = 1 THEN \'DOWN\'
@@ -825,7 +825,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN `:dbstg`.`hosts` h
               ON h.instance_id = i.instance_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\''
+              AND h.name NOT LIKE \'\_Module\_BAM%\''
             . $accessGroupFilter;
 
         $idsListKey = [];
@@ -1182,8 +1182,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               srv.*,
               h.host_id, h.alias AS host_alias, h.name AS host_name,
               cv.value as criticality,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS host_display_name,
-              IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS host_state,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'Meta\', h.display_name) AS host_display_name,
+              IF (h.display_name LIKE \'\_Module\_Meta%\', \'0\', h.state) AS host_state,
               srv.state AS `status_code`,
               CASE
                 WHEN srv.state = 0 THEN "' . ResourceStatus::STATUS_NAME_OK . '"
@@ -1203,7 +1203,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             . $accessGroupFilter
             . ' INNER JOIN `:dbstg`.hosts h
               ON h.host_id = srv.host_id
-              AND h.name NOT LIKE \'_Module_BAM%\'
+              AND h.name NOT LIKE \'\_Module\_BAM%\'
               AND h.enabled = \'1\'
               AND srv.enabled = \'1\'
             INNER JOIN `:dbstg`.instances i
@@ -1375,7 +1375,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             . ' INNER JOIN `:dbstg`.hosts h
               ON h.host_id = srv.host_id
               AND h.host_id = :host_id
-              AND h.name NOT LIKE \'_Module_BAM%\'
+              AND h.name NOT LIKE \'\_Module\_BAM%\'
               AND h.enabled = \'1\'
               AND srv.enabled = \'1\'
             INNER JOIN `:dbstg`.instances i
@@ -1571,13 +1571,13 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $request =
-            'SELECT DISTINCT 
+            'SELECT DISTINCT
               srv.service_id, srv.display_name, srv.description, srv.host_id, srv.state
             FROM :dbstg.services srv
             INNER JOIN :dbstg.hosts h
               ON h.host_id = srv.host_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\''
+              AND h.name NOT LIKE \'\_Module\_BAM%\''
             . $accessGroupFilter
             . ' WHERE srv.host_id = ?
               AND srv.enabled = 1
@@ -1640,7 +1640,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN :dbstg.hosts h
               ON h.host_id = srv.host_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\''
+              AND h.name NOT LIKE \'\_Module\_BAM%\''
             . $accessGroupFilter
             . ' WHERE srv.host_id IN (' . str_repeat('?,', count($hostIds) - 1) . '?)
               AND srv.enabled = 1
@@ -1696,7 +1696,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             INNER JOIN :dbstg.`hosts` h
               ON h.host_id = srv.host_id
               AND h.enabled = \'1\'
-              AND h.name NOT LIKE \'_Module_BAM%\'
+              AND h.name NOT LIKE \'\_Module\_BAM%\'
             INNER JOIN `:dbstg`.`services_servicegroups` ssg
               ON ssg.service_id = srv.service_id
               AND ssg.host_id = srv.host_id'

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -472,7 +472,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         // This join will only be added if a search parameter corresponding to one of the host parameter
         if ($shouldJoinHost) {
             $subRequest .=
-                ' INNER JOIN `:dbstg`.hosts_hostgroups hhg 
+                ' INNER JOIN `:dbstg`.hosts_hostgroups hhg
                     ON hhg.hostgroup_id = hg.hostgroup_id
                 INNER JOIN `:dbstg`.hosts h
                     ON h.host_id = hhg.host_id
@@ -1687,9 +1687,9 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT DISTINCT
 		        ssg.servicegroup_id,
-                srv.service_id, 
-                srv.display_name, 
-                srv.description, 
+                srv.service_id,
+                srv.display_name,
+                srv.description,
                 srv.host_id,
                 srv.state
             FROM `:dbstg`.`services` srv

--- a/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/ResourceRepositoryRDB.php
@@ -334,14 +334,14 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             $resource->setIcon($icon);
         }
 
-        // parse parent Resource object
-        $parent = EntityCreator::createEntityByArray(
-            ResourceEntity::class,
-            $data,
-            'parent_'
-        );
+        if ($data['parent_id'] !== null) {
+            // parse parent Resource object
+            $parent = EntityCreator::createEntityByArray(
+                ResourceEntity::class,
+                $data,
+                'parent_'
+            );
 
-        if ($parent->getId()) {
             $parentIcon = EntityCreator::createEntityByArray(
                 Icon::class,
                 $data,

--- a/src/Centreon/Infrastructure/ServiceConfiguration/ServiceConfigurationRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/ServiceConfiguration/ServiceConfigurationRepositoryRDB.php
@@ -30,6 +30,7 @@ use Centreon\Domain\ServiceConfiguration\Interfaces\ServiceConfigurationReposito
 use Centreon\Domain\ServiceConfiguration\Service;
 use Centreon\Domain\ServiceConfiguration\ServiceMacro;
 use Centreon\Infrastructure\AccessControlList\AccessControlListRepositoryTrait;
+use Centreon\Infrastructure\CentreonLegacyDB\StatementCollector;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
@@ -176,7 +177,7 @@ class ServiceConfigurationRepositoryRDB extends AbstractRepositoryDRB implements
     /**
      * @inheritDoc
      */
-    public function findOnDemandServiceMacros(int $serviceId, bool $isUsingInheritance = false): array
+    public function findOnDemandServiceMacros(int $serviceId, bool $useInheritance = false): array
     {
         /* CTE recurse request next release:
          *       WITH RECURSIVE inherite AS (
@@ -209,7 +210,7 @@ class ServiceConfigurationRepositoryRDB extends AbstractRepositoryDRB implements
          */
         $request = $this->translateDbName(
             'SELECT
-                srv.service_id AS service_id, demand.svc_macro_id AS id, 
+                srv.service_id AS service_id, demand.svc_macro_id AS id,
                 svc_macro_name AS name, svc_macro_value AS `value`,
                 macro_order AS `order`, is_password, description, service_template_model_stm_id
              FROM `:db`.service srv
@@ -240,7 +241,7 @@ class ServiceConfigurationRepositoryRDB extends AbstractRepositoryDRB implements
                     $record
                 );
             }
-            if (!$isUsingInheritance) {
+            if (!$useInheritance) {
                 break;
             }
         }

--- a/tests/php/Centreon/Domain/Monitoring/ResourceServiceTest.php
+++ b/tests/php/Centreon/Domain/Monitoring/ResourceServiceTest.php
@@ -23,9 +23,12 @@ namespace Tests\Centreon\Domain\Monitoring;
 
 use PHPUnit\Framework\TestCase;
 use Centreon\Domain\Monitoring\Host;
+use Centreon\Domain\Monitoring\Service;
 use Centreon\Domain\Monitoring\Resource;
 use Centreon\Domain\Monitoring\ResourceFilter;
+use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Domain\Monitoring\ResourceService;
+use Centreon\Domain\HostConfiguration\HostMacro;
 use Centreon\Domain\Monitoring\Interfaces\ResourceRepositoryInterface;
 use Centreon\Domain\Security\Interfaces\AccessGroupRepositoryInterface;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringRepositoryInterface;
@@ -33,6 +36,7 @@ use Centreon\Domain\HostConfiguration\Interfaces\HostMacro\HostMacroReadReposito
 use Centreon\Domain\ServiceConfiguration\Interfaces\ServiceConfigurationRepositoryInterface;
 use Centreon\Infrastructure\MetaServiceConfiguration\Repository\MetaServiceConfigurationRepositoryRDB;
 use Centreon\Domain\MetaServiceConfiguration\Interfaces\MetaServiceConfigurationReadRepositoryInterface;
+use Centreon\Domain\ServiceConfiguration\ServiceMacro;
 
 class ResourceServiceTest extends TestCase
 {
@@ -110,13 +114,28 @@ class ResourceServiceTest extends TestCase
         $this->assertEquals('h1-s1', $resourcesFound[1]->getUuid());
     }
 
+    /**
+     * test host macros replacement
+     */
     public function testReplaceMacrosInHost(): void
     {
         $host = (new Host())
             ->setId(10)
             ->setName('Centreon-Central')
             ->setPollerName('central')
-            ->setActionUrl('http://$HOSTADDRESS$/$HOSTNAME$/$_HOSTCUSTOMVAL$');
+            ->setAddressIp('127.0.0.1')
+            ->setActionUrl('http://$INSTANCENAME$/$HOSTADDRESS$/$HOSTNAME$/$_HOSTCUSTOMVAL$/$HOSTSTATE$')
+            ->setStatus((new ResourceStatus())->setName('UP')->setCode(0));
+
+        $customMacrosValues = [
+            '$_HOSTCUSTOMVAL$' => 'helloworld'
+        ];
+
+        $hostMacro = (new HostMacro())
+            ->setName('$_HOSTCUSTOMVAL$')
+            ->setValue('helloworld')
+            ->setPassword(false);
+
         $resourceService = new ResourceService(
             $this->resourceRepository,
             $this->monitoringRepository,
@@ -125,5 +144,115 @@ class ResourceServiceTest extends TestCase
             $this->hostMacroConfigurationRepository,
             $this->serviceConfigurationRepository
         );
+
+        $this->monitoringRepository->expects($this->once())
+            ->method('findOneHost')
+            ->willReturn($host);
+
+        $this->monitoringRepository->expects($this->once())
+            ->method('findCustomMacrosValues')
+            ->willReturn(['CUSTOMVAL' => 'helloworld']);
+
+        $this->hostMacroConfigurationRepository->expects($this->once())
+            ->method('findOnDemandHostMacros')
+            ->willReturn([$hostMacro]);
+
+        $actionUrl = $host->getActionUrl() !== null ? $host->getActionUrl() : '';
+        $expected = str_replace('$HOSTADDRESS$', (string) $host->getAddressIp(), $actionUrl);
+        $expected = str_replace('$HOSTNAME$', (string) $host->getName(), $expected);
+        $expected = str_replace('$INSTANCENAME$', (string) $host->getPollerName(), $expected);
+        $expected = str_replace('$HOSTSTATE$', (string) $host->getStatus()->getName(), $expected);
+        $expected = str_replace('$_HOSTCUSTOMVAL$', $customMacrosValues['$_HOSTCUSTOMVAL$'], $expected);
+        $this->assertEquals($resourceService->replaceMacrosInHostUrl(10, 'action-url'), $expected);
+    }
+
+
+    /**
+     * test host macros replacement
+     */
+    public function testReplaceMacroInService(): void
+    {
+        $host = (new Host())
+            ->setId(10)
+            ->setName('Centreon-Central')
+            ->setPollerName('central')
+            ->setAddressIp('127.0.0.1')
+            ->setActionUrl('http://$INSTANCENAME$/$HOSTADDRESS$/$HOSTNAME$/$_HOSTCUSTOMVAL$/$HOSTSTATE$')
+            ->setStatus((new ResourceStatus())->setName('UP')->setCode(0));
+
+        $service = (new Service())
+            ->setId(25)
+            ->setDescription('Ping')
+            ->setStatus((new ResourceStatus())->setName('OK')->setCode(0))
+            ->setActionUrl(
+                'http://$INSTANCENAME$/$_SERVICECUSTOMPASSWORD$/$_HOSTCUSTOMVAL$/$_SERVICECUSTOMARG1$/$SERVICEDESC$'
+            )
+            ->setHost($host);
+
+        $customMacrosValues = [
+            '$_HOSTCUSTOMVAL$' => 'helloworld',
+            '$_SERVICECUSTOMARG1$' => 'service-hello',
+            '$_SERVICECUSTOMPASSWORD$' => 'password'
+        ];
+
+        $hostMacro = (new HostMacro())
+            ->setName('$_HOSTCUSTOMVAL$')
+            ->setValue('helloworld')
+            ->setPassword(false);
+
+        $serviceMacroNotPassword = (new ServiceMacro())
+            ->setName('$_SERVICECUSTOMARG1$')
+            ->setValue('service-hello')
+            ->setPassword(false);
+
+        $serviceMacroPassword = (new ServiceMacro())
+            ->setName('$_SERVICECUSTOMPASSWORD$')
+            ->setValue('password')
+            ->setPassword(true);
+
+        $resourceService = new ResourceService(
+            $this->resourceRepository,
+            $this->monitoringRepository,
+            $this->accessGroupRepository,
+            $this->metaServiceConfigurationRepository,
+            $this->hostMacroConfigurationRepository,
+            $this->serviceConfigurationRepository
+        );
+
+        $this->monitoringRepository->expects($this->once())
+            ->method('findOneHost')
+            ->willReturn($host);
+
+        $this->monitoringRepository->expects($this->once())
+            ->method('findOneService')
+            ->willReturn($service);
+
+        $this->monitoringRepository->expects($this->any())
+            ->method('findCustomMacrosValues')
+            ->willReturn([
+                'CUSTOMVAL' => 'helloworld',
+                'CUSTOMARG1' => 'service-hello',
+                'CUSTOMPASSWORD' => 'password'
+            ]);
+
+        $this->hostMacroConfigurationRepository->expects($this->once())
+            ->method('findOnDemandHostMacros')
+            ->willReturn([$hostMacro]);
+
+        $this->serviceConfigurationRepository->expects($this->once())
+            ->method('findOnDemandServiceMacros')
+            ->willReturn([$serviceMacroNotPassword, $serviceMacroPassword]);
+
+        $actionUrl = $service->getActionUrl() !== null ? $service->getActionUrl() : '';
+        $expected = str_replace('$HOSTADDRESS$', (string) $host->getAddressIp(), $actionUrl);
+        $expected = str_replace('$HOSTNAME$', (string) $host->getName(), $expected);
+        $expected = str_replace('$INSTANCENAME$', (string) $host->getPollerName(), $expected);
+        $expected = str_replace('$HOSTSTATE$', (string) $host->getStatus()->getName(), $expected);
+        $expected = str_replace('$_HOSTCUSTOMVAL$', $customMacrosValues['$_HOSTCUSTOMVAL$'], $expected);
+        $expected = str_replace('$SERVICEDESC$', (string) $service->getDescription(), $expected);
+        $expected = str_replace('$_SERVICECUSTOMARG1$', $customMacrosValues['$_SERVICECUSTOMARG1$'], $expected);
+        $expected = str_replace('$_SERVICECUSTOMPASSWORD$', '', $expected);
+
+        $this->assertEquals($resourceService->replaceMacrosInServiceUrl(10, 25, 'action-url'), $expected);
     }
 }

--- a/tests/php/Centreon/Domain/Monitoring/ResourceServiceTest.php
+++ b/tests/php/Centreon/Domain/Monitoring/ResourceServiceTest.php
@@ -22,20 +22,63 @@
 namespace Tests\Centreon\Domain\Monitoring;
 
 use PHPUnit\Framework\TestCase;
+use Centreon\Domain\Monitoring\Host;
 use Centreon\Domain\Monitoring\Resource;
 use Centreon\Domain\Monitoring\ResourceFilter;
 use Centreon\Domain\Monitoring\ResourceService;
 use Centreon\Domain\Monitoring\Interfaces\ResourceRepositoryInterface;
 use Centreon\Domain\Security\Interfaces\AccessGroupRepositoryInterface;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringRepositoryInterface;
+use Centreon\Domain\HostConfiguration\Interfaces\HostMacro\HostMacroReadRepositoryInterface;
+use Centreon\Domain\ServiceConfiguration\Interfaces\ServiceConfigurationRepositoryInterface;
+use Centreon\Infrastructure\MetaServiceConfiguration\Repository\MetaServiceConfigurationRepositoryRDB;
 use Centreon\Domain\MetaServiceConfiguration\Interfaces\MetaServiceConfigurationReadRepositoryInterface;
 
 class ResourceServiceTest extends TestCase
 {
     /**
+     * @var MonitoringRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $monitoringRepository;
+
+    /**
+     * @var ResourceRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $resourceRepository;
+
+    /**
+     * @var AccessGroupRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $accessGroupRepository;
+
+    /**
+     * @var MetaServiceConfigurationReadRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $metaServiceConfigurationRepository;
+
+    /**
+     * @var HostMacroReadRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $hostMacroConfigurationRepository;
+
+    /**
+     * @var ServiceConfigurationRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $serviceConfigurationRepository;
+
+    protected function setUp(): void
+    {
+        $this->resourceRepository = $this->createMock(ResourceRepositoryInterface::class);
+        $this->monitoringRepository = $this->createMock(MonitoringRepositoryInterface::class);
+        $this->accessGroupRepository = $this->createMock(AccessGroupRepositoryInterface::class);
+        $this->metaServiceConfigurationRepository = $this->createMock(MetaServiceConfigurationReadRepositoryInterface::class);
+        $this->hostMacroConfigurationRepository = $this->createMock(HostMacroReadRepositoryInterface::class);
+        $this->serviceConfigurationRepository = $this->createMock(ServiceConfigurationRepositoryInterface::class);
+    }
+    /**
      * @throws \Exception
      */
-    public function testFindResources()
+    public function testFindResources(): void
     {
         $hostResource = (new Resource())
             ->setType('host')
@@ -47,22 +90,17 @@ class ResourceServiceTest extends TestCase
             ->setName('service1')
             ->setParent($hostResource);
 
-        $resourceRepository = $this->createMock(ResourceRepositoryInterface::class);
-        $resourceRepository->expects(self::any())
+        $this->resourceRepository->expects(self::any())
             ->method('findResources')
-            ->willReturn([$hostResource, $serviceResource]); // values returned for the all next tests
-
-        $monitoringRepository = $this->createMock(MonitoringRepositoryInterface::class);
-
-        $accessGroup = $this->createMock(AccessGroupRepositoryInterface::class);
-
-        $metaServiceConfigurationRepository = $this->createMock(MetaServiceConfigurationReadRepositoryInterface::class);
+            ->willReturn([$hostResource, $serviceResource]);
 
         $resourceService = new ResourceService(
-            $resourceRepository,
-            $monitoringRepository,
-            $accessGroup,
-            $metaServiceConfigurationRepository
+            $this->resourceRepository,
+            $this->monitoringRepository,
+            $this->accessGroupRepository,
+            $this->metaServiceConfigurationRepository,
+            $this->hostMacroConfigurationRepository,
+            $this->serviceConfigurationRepository
         );
 
         $resourcesFound = $resourceService->findResources(new ResourceFilter());
@@ -70,5 +108,22 @@ class ResourceServiceTest extends TestCase
         $this->assertCount(2, $resourcesFound);
         $this->assertEquals('h1', $resourcesFound[0]->getUuid());
         $this->assertEquals('h1-s1', $resourcesFound[1]->getUuid());
+    }
+
+    public function testReplaceMacrosInHost(): void
+    {
+        $host = (new Host())
+            ->setId(10)
+            ->setName('Centreon-Central')
+            ->setPollerName('central')
+            ->setActionUrl('http://$HOSTADDRESS$/$HOSTNAME$/$_HOSTCUSTOMVAL$');
+        $resourceService = new ResourceService(
+            $this->resourceRepository,
+            $this->monitoringRepository,
+            $this->accessGroupRepository,
+            $this->metaServiceConfigurationRepository,
+            $this->hostMacroConfigurationRepository,
+            $this->serviceConfigurationRepository
+        );
     }
 }

--- a/tests/php/Centreon/Domain/Monitoring/ResourceServiceTest.php
+++ b/tests/php/Centreon/Domain/Monitoring/ResourceServiceTest.php
@@ -75,7 +75,9 @@ class ResourceServiceTest extends TestCase
         $this->resourceRepository = $this->createMock(ResourceRepositoryInterface::class);
         $this->monitoringRepository = $this->createMock(MonitoringRepositoryInterface::class);
         $this->accessGroupRepository = $this->createMock(AccessGroupRepositoryInterface::class);
-        $this->metaServiceConfigurationRepository = $this->createMock(MetaServiceConfigurationReadRepositoryInterface::class);
+        $this->metaServiceConfigurationRepository = $this->createMock(
+            MetaServiceConfigurationReadRepositoryInterface::class
+        );
         $this->hostMacroConfigurationRepository = $this->createMock(HostMacroReadRepositoryInterface::class);
         $this->serviceConfigurationRepository = $this->createMock(ServiceConfigurationRepositoryInterface::class);
     }


### PR DESCRIPTION
This PR intends to replace the custom macros used in the external urls (action + notes) by their actual values.
Password type macros will be replaced by an empty string.

How does it work ?
- The listing returns the resources
- Action URL and Notes URL if set are replaced by the URL endpoint prepared to be called.
- Once the icon clicked then the endpoint is called, replaces the macros and then redirect to the URL with macros replaced. (this should invisible for the user)

/!\ This PR includes also PHPStan errors patched

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
