### PR TITLE
enh(resource): display only comments not deleted for ACK and DT

### DIFF
--- a/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
@@ -177,11 +177,26 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
                   AND acg.acl_group_activate = \'1\'
                   AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
-        $request =
-            'SELECT ack.*, contact.contact_id AS author_id
+        $request = 'SELECT
+            ack.acknowledgement_id,
+            ack.entry_time,
+            ack.host_id,
+            ack.service_id,
+            ack.author,
+            `cmts`.data AS `comment_data`,
+            ack.deletion_time,
+            ack.instance_id,
+            ack.notify_contacts,
+            ack.persistent_comment,
+            ack.state,
+            ack.sticky,
+            ack.type,
+            contact.contact_id AS `author_id`
             FROM `:dbstg`.acknowledgements ack
             LEFT JOIN `:db`.contact
-              ON contact.contact_alias = ack.author'
+                ON contact.contact_alias = ack.author
+            LEFT JOIN `:dbstg`.`comments` AS `cmts`
+                ON `cmts`.host_id = ack.host_id AND `cmts`.deletion_time IS NULL'
             . $accessGroupFilter
             . 'WHERE ack.host_id = :host_id
               AND ack.service_id = 0';
@@ -213,11 +228,27 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
                   AND acg.acl_group_activate = \'1\'
                   AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
-        $request =
-            'SELECT ack.*, contact.contact_id AS author_id
+        $request = 'SELECT
+            ack.acknowledgement_id,
+            ack.entry_time,
+            ack.host_id,
+            ack.service_id,
+            ack.author,
+            `cmts`.data AS `comment_data`,
+            ack.deletion_time,
+            ack.instance_id,
+            ack.notify_contacts,
+            ack.persistent_comment,
+            ack.state,
+            ack.sticky,
+            ack.type,
+            contact.contact_id AS `author_id`
             FROM `:dbstg`.acknowledgements ack
             LEFT JOIN `:db`.contact
-              ON contact.contact_alias = ack.author'
+                ON contact.contact_alias = ack.author
+            LEFT JOIN `:dbstg`.`comments` AS `cmts`
+                ON `cmts`.host_id = ack.host_id AND `cmts`.service_id = ack.host_id
+                AND `cmts`.deletion_time IS NULL'
             . $accessGroupFilter
             . 'WHERE ack.host_id = :host_id
             AND ack.service_id = :service_id';

--- a/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
@@ -36,16 +36,6 @@ use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implements AcknowledgementRepositoryInterface
 {
     /**
-     * Define a host acknowledgement (0)
-     */
-    const TYPE_HOST_ACKNOWLEDGEMENT = 0;
-
-    /**
-     * Define a service acknowledgement (1)
-     */
-    const TYPE_SERVICE_ACKNOWLEDGEMENT = 1;
-
-    /**
      * @var SqlRequestParametersTranslator
      */
     private $sqlRequestTranslator;
@@ -145,7 +135,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
      */
     public function findHostsAcknowledgements(): array
     {
-        return $this->findAcknowledgementsOf(self::TYPE_HOST_ACKNOWLEDGEMENT);
+        return $this->findAcknowledgementsOf(Acknowledgement::TYPE_HOST_ACKNOWLEDGEMENT);
     }
 
     /**
@@ -154,7 +144,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
      */
     public function findServicesAcknowledgements(): array
     {
-        return $this->findAcknowledgementsOf(self::TYPE_SERVICE_ACKNOWLEDGEMENT);
+        return $this->findAcknowledgementsOf(Acknowledgement::TYPE_SERVICE_ACKNOWLEDGEMENT);
     }
 
     /**
@@ -364,7 +354,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
      * @throws \PDOException
      * @throws RequestParametersTranslatorException
      */
-    private function findAcknowledgementsOf(int $type = self::TYPE_HOST_ACKNOWLEDGEMENT): array
+    private function findAcknowledgementsOf(int $type = Acknowledgement::TYPE_HOST_ACKNOWLEDGEMENT): array
     {
         $acknowledgements = [];
 
@@ -376,14 +366,17 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
             ? ' '
             : ' INNER JOIN `:dbstg`.`centreon_acl` acl
                   ON acl.host_id = ack.host_id'
-                .  (($type === self::TYPE_SERVICE_ACKNOWLEDGEMENT) ? ' AND acl.service_id = ack.service_id ' : '')
+                .  (($type === Acknowledgement::TYPE_SERVICE_ACKNOWLEDGEMENT)
+                    ? ' AND acl.service_id = ack.service_id '
+                    : ''
+                )
                 . ' INNER JOIN `:db`.`acl_groups` acg
                   ON acg.acl_group_id = acl.group_id
                   AND acg.acl_group_activate = \'1\'
                   AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
         $this->sqlRequestTranslator->setConcordanceArray(
-            $type === self::TYPE_SERVICE_ACKNOWLEDGEMENT
+            $type === Acknowledgement::TYPE_SERVICE_ACKNOWLEDGEMENT
             ? $this->serviceConcordanceArray
             : $this->hostConcordanceArray
         );
@@ -393,7 +386,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
             LEFT JOIN `:db`.contact
                 ON contact.contact_alias = ack.author '
             . $accessGroupFilter
-            . 'WHERE ack.service_id ' . (($type === self::TYPE_HOST_ACKNOWLEDGEMENT) ? ' = 0' : ' != 0');
+            . 'WHERE ack.service_id ' . (($type === Acknowledgement::TYPE_HOST_ACKNOWLEDGEMENT) ? ' = 0' : ' != 0');
 
         return $this->processListingRequest($request);
     }

--- a/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
@@ -66,12 +66,12 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
     private $contact;
 
     /**
-     * @var array
+     * @var array<string, string>
      */
     private $hostConcordanceArray;
 
     /**
-     * @var array
+     * @var array<string, string>
      */
     private $serviceConcordanceArray;
 
@@ -423,7 +423,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
     /**
      * Find one acknowledgement taking into account or not the ACLs.
      *
-     * @param int $downtimeId Acknowledgement id
+     * @param int $acknowledgementId Acknowledgement id
      * @param bool $isAdmin Indicates whether user is an admin
      * @return Acknowledgement|null Return NULL if the acknowledgement has not been found
      * @throws \Exception
@@ -494,7 +494,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
      * Find all acknowledgements.
      *
      * @param bool $isAdmin Indicates whether user is an admin
-     * @return array
+     * @return Acknowledgement[]
      * @throws \Exception
      */
     private function findAcknowledgements(bool $isAdmin): array

--- a/src/Centreon/Infrastructure/Downtime/DowntimeRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Downtime/DowntimeRepositoryRDB.php
@@ -46,7 +46,7 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
      */
     private $accessGroups;
     /**
-     * @var array
+     * @var array<string, string>
      */
     private $downtimeConcordanceArray;
 
@@ -125,7 +125,7 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
 
     /**
      * @param bool $isAdmin Indicates whether user is an admin
-     * @return array
+     * @return Downtime[]
      * @throws \Exception
      */
     private function findHostDowntimes(bool $isAdmin = false): array
@@ -255,7 +255,7 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
      * Find all downtimes.
      *
      * @param bool $isAdmin Indicates whether user is an admin
-     * @return array
+     * @return Downtime[]
      * @throws \Exception
      */
     private function findDowntimes(bool $isAdmin): array
@@ -509,7 +509,7 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
      * @param int $hostId Host id linked to this service
      * @param int $serviceId Service id for which we want to find downtimes
      * @param bool $isAdmin Indicates whether user is an admin
-     * @return array
+     * @return Downtime[]
      * @throws \Exception
      */
     private function findDowntimesByService(int $hostId, int $serviceId, bool $isAdmin): array

--- a/src/Centreon/Infrastructure/Downtime/DowntimeRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Downtime/DowntimeRepositoryRDB.php
@@ -379,11 +379,32 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
                 . $this->accessGroupIdToString($this->accessGroups) . ')';
         }
 
-        $request =
-            'SELECT SQL_CALC_FOUND_ROWS DISTINCT dwt.*, contact.contact_id AS author_id
+        $request = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT
+            dwt.downtime_id,
+            dwt.entry_time,
+            dwt.host_id,
+            dwt.service_id,
+            dwt.author,
+            dwt.cancelled,
+            `cmts`.data AS `comment_data`,
+            dwt.deletion_time,
+            dwt.duration,
+            dwt.end_time,
+            dwt.fixed,
+            dwt.instance_id,
+            dwt.internal_id,
+            dwt.start_time,
+            dwt.actual_start_time,
+            dwt.actual_end_time,
+            dwt.started,
+            dwt.triggered_by,
+            dwt.type,
+            contact.contact_id AS `author_id`
             FROM `:dbstg`.downtimes dwt
             LEFT JOIN `:db`.`contact`
                 ON contact.contact_alias = dwt.author
+            LEFT JOIN `:dbstg`.`comments` AS `cmts`
+                ON `cmts`.host_id = dwt.host_id AND `cmts`.service_id = dwt.service_id
             INNER JOIN `:dbstg`.hosts
               ON hosts.host_id = dwt.host_id
               AND dwt.host_id = :host_id'
@@ -522,8 +543,27 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
                 . $this->accessGroupIdToString($this->accessGroups) . ')';
         }
 
-        $request =
-            'SELECT SQL_CALC_FOUND_ROWS DISTINCT dwt.*, contact.contact_id AS author_id
+        $request = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT
+            dwt.downtime_id,
+            dwt.entry_time,
+            dwt.host_id,
+            dwt.service_id,
+            dwt.author,
+            dwt.cancelled,
+            `cmts`.data AS `comment_data`,
+            dwt.deletion_time,
+            dwt.duration,
+            dwt.end_time,
+            dwt.fixed,
+            dwt.instance_id,
+            dwt.internal_id,
+            dwt.start_time,
+            dwt.actual_start_time,
+            dwt.actual_end_time,
+            dwt.started,
+            dwt.triggered_by,
+            dwt.type,
+            contact.contact_id AS `author_id`
             FROM `:dbstg`.downtimes dwt
             INNER JOIN `:dbstg`.hosts
                 ON hosts.host_id = dwt.host_id
@@ -533,7 +573,10 @@ class DowntimeRepositoryRDB extends AbstractRepositoryDRB implements DowntimeRep
                 AND dwt.host_id = :host_id
                 AND srv.service_id = :service_id
             LEFT JOIN `:db`.`contact`
-                ON contact.contact_alias = dwt.author'
+                ON contact.contact_alias = dwt.author
+            LEFT JOIN `:dbstg`.`comments` AS `cmts`
+                ON `cmts`.host_id = dwt.host_id AND `cmts`.service_id = dwt.service_id
+                AND `cmts`.deletion_time IS NULL'
             . $aclRequest;
 
         $this->sqlRequestTranslator->addSearchValue(':host_id', [\PDO::PARAM_INT => $hostId]);

--- a/src/Centreon/Infrastructure/Downtime/DowntimeRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Downtime/DowntimeRepositoryRDB.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
  *

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1726,13 +1726,37 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $downtimes;
         }
 
-        $sql = 'SELECT d.*, c.contact_id AS `author_id` FROM `:dbstg`.`downtimes`  AS `d` '
-            . 'LEFT JOIN `:db`.contact AS `c` ON c.contact_alias = d.author '
-            . 'WHERE d.host_id = :hostId AND d.service_id = :serviceId '
-            . 'AND d.deletion_time IS NULL AND ((NOW() BETWEEN FROM_UNIXTIME(d.actual_start_time) '
-            . 'AND FROM_UNIXTIME(d.actual_end_time)) OR ((NOW() > FROM_UNIXTIME(d.actual_start_time) '
-            . 'AND d.actual_end_time IS NULL))) '
-            . 'ORDER BY d.entry_time DESC';
+        $sql = 'SELECT
+            d.downtime_id,
+            d.entry_time,
+            d.host_id,
+            d.service_id,
+            d.author,
+            d.cancelled,
+            `cmts`.data AS `comment_data`,
+            d.deletion_time,
+            d.duration,
+            d.end_time,
+            d.fixed,
+            d.instance_id,
+            d.internal_id,
+            d.start_time,
+            d.actual_start_time,
+            d.actual_end_time,
+            d.started,
+            d.triggered_by,
+            d.type,
+            c.contact_id AS `author_id`
+        FROM `:dbstg`.`downtimes`  AS `d`
+        LEFT JOIN `:db`.contact AS `c` ON c.contact_alias = d.author
+        LEFT JOIN `:dbstg`.`comments` AS `cmts`
+            ON `cmts`.host_id = d.host_id AND `cmts`.service_id = d.service_id
+            AND `cmts`.deletion_time IS NULL
+        WHERE d.host_id = :hostId AND d.service_id = :serviceId
+            AND d.deletion_time IS NULL AND ((NOW() BETWEEN FROM_UNIXTIME(d.actual_start_time)
+            AND FROM_UNIXTIME(d.actual_end_time)) OR ((NOW() > FROM_UNIXTIME(d.actual_start_time)
+            AND d.actual_end_time IS NULL)))
+        ORDER BY d.entry_time DESC';
 
         $request = $this->translateDbName($sql);
         $statement = $this->db->prepare($request);
@@ -1761,10 +1785,28 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $acks;
         }
 
-        $sql = 'SELECT a.*, c.contact_id AS `author_id` FROM `:dbstg`.`acknowledgements` AS `a` '
-            . 'LEFT JOIN `:db`.contact AS `c` ON c.contact_alias = a.author '
-            . 'WHERE a.host_id = :hostId AND a.service_id = :serviceId AND a.deletion_time IS NULL '
-            . 'ORDER BY a.entry_time DESC';
+        $sql = 'SELECT
+            a.acknowledgement_id,
+            a.entry_time,
+            a.host_id,
+            a.service_id,
+            a.author,
+            `cmts`.data AS `comment_data`,
+            a.deletion_time,
+            a.instance_id,
+            a.notify_contacts,
+            a.persistent_comment,
+            a.state,
+            a.sticky,
+            a.type,
+            c.contact_id AS `author_id`
+            FROM `:dbstg`.`acknowledgements` AS `a`
+            LEFT JOIN `:db`.contact AS `c` ON c.contact_alias = a.author
+            LEFT JOIN `:dbstg`.`comments` AS `cmts`
+                ON `cmts`.host_id = a.host_id AND `cmts`.service_id = a.service_id
+                AND `cmts`.deletion_time IS NULL
+            WHERE a.host_id = :hostId AND a.service_id = :serviceId AND a.deletion_time IS NULL
+            ORDER BY a.entry_time DESC';
 
         $request = $this->translateDbName($sql);
         $statement = $this->db->prepare($request);


### PR DESCRIPTION
This PR intends to use the comment stored in the table comments instead of the comment attached to the acknowledgements / downtimes tables.

This will ensure that if a comment has been deleted through the page Monitoring -> Downtimes -> Comments then in Resource Status this comment will no longer appear in the Resource Detail of listing state tooltip

/!\ Encountered phpstan et phpcs errors were also fixed on files edited

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira for details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
