### PR TITLE
enh(autologin): verify that autologin is different than password (21.10,21.04,20.10)

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16317,3 +16317,9 @@ msgstr "Souple"
 
 msgid "User is not allowed to reach web application"
 msgstr "L'utilisateur n'est pas autorisé à joindre l'application web"
+
+msgid "Your autologin key must be different than your current password"
+msgstr "Votre clé d'autologin doit être différente de votre mot de passe actuel"
+
+msgid "Your new password and autologin key must be different"
+msgstr "Votre nouveau mot de passe et votre clé d'autologin doivent être différents"

--- a/lib/Centreon/Object/Contact/Contact.php
+++ b/lib/Centreon/Object/Contact/Contact.php
@@ -54,7 +54,7 @@ class Centreon_Object_Contact extends Centreon_Object
         $sql = "UPDATE $this->table SET ";
         $sqlUpdate = "";
         $sqlParams = [];
-        $not_null_attributes = [];
+        $notNullAttributes = [];
 
         if (isset($params['contact_autologin_key'])) {
             $statement = $this->db->prepare("SELECT contact_passwd FROM contact WHERE contact_id = :contactId ");
@@ -73,20 +73,20 @@ class Centreon_Object_Contact extends Centreon_Object
             $sql_attr = "SHOW FIELDS FROM $this->table";
             $res = $this->getResult($sql_attr, [], "fetchAll");
             foreach ($res as $tab) {
-                if ($tab['Null'] == 'NO') {
-                    $not_null_attributes[$tab['Field']] = true;
+                if ($tab['Null'] === 'NO') {
+                    $notNullAttributes[$tab['Field']] = true;
                 }
             }
         }
         foreach ($params as $key => $value) {
-            if ($key == $this->primaryKey) {
+            if ($key === $this->primaryKey) {
                 continue;
             }
-            if ($sqlUpdate != "") {
+            if ($sqlUpdate !== "") {
                 $sqlUpdate .= ",";
             }
             $sqlUpdate .= $key . " = ? ";
-            if ($value === "" && !isset($not_null_attributes[$key])) {
+            if ($value === "" && !isset($notNullAttributes[$key])) {
                 $value = null;
             }
             if (!is_null($value)) {

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -201,3 +201,38 @@ function updateContact($contact_id = null)
     $centreon->user->email = $ret['contact_email'];
     $centreon->user->setToken(isset($ret['contact_autologin_key']) ? $ret['contact_autologin_key'] : "''");
 }
+
+
+/**
+ * @param array<string,mixed> $fields
+ * @return array<string,string>|bool
+ */
+function checkAutologinValue(array $fields)
+{
+    global $pearDB, $centreon;
+    $errors = [];
+
+    if (!empty($fields['contact_autologin_key'])) {
+        $contactId = $centreon->user->get_id();
+        $statement = $pearDB->prepare('SELECT `contact_passwd` FROM `contact` WHERE contact_id = :contactId');
+        $statement->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        if (
+            ($result = $statement->fetch(\PDO::FETCH_ASSOC))
+            && (md5($fields['contact_autologin_key']) === $result['contact_passwd']
+                || 'md5__' . md5($fields['contact_autologin_key']) === $result['contact_passwd'])
+        ) {
+            $errors['contact_autologin_key'] = _('Your autologin key must be different than your current password');
+        } elseif (
+            !empty($fields['contact_passwd'])
+            && $fields['contact_passwd'] === $fields['contact_autologin_key']
+        ) {
+            $errorMessage = _('Your new password and autologin key must be different');
+            $errors['contact_passwd'] = $errorMessage;
+            $errors['contact_autologin_key'] = $errorMessage;
+        }
+    }
+
+    return count($errors) > 0 ? $errors : true;
+}

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -113,13 +113,13 @@ if ($cct["contact_auth_type"] != 'ldap') {
         'password',
         'contact_passwd',
         _("Password"),
-        array("size" => "30", "autocomplete" => "new-password", "id" => "passwd1", "onFocus" => "resetPwdType(this);")
+        ["size" => "30", "autocomplete" => "new-password", "id" => "passwd1", "onkeypress" => "resetPwdType(this);"]
     );
     $form->addElement(
         'password',
         'contact_passwd2',
         _("Confirm Password"),
-        array("size" => "30", "autocomplete" => "new-password", "id" => "passwd2", "onFocus" => "resetPwdType(this);")
+        ["size" => "30", "autocomplete" => "new-password", "id" => "passwd2", "onkeypress" => "resetPwdType(this);"]
     );
     $form->addElement(
         'button',
@@ -363,6 +363,7 @@ $form->addRule('contact_name', _("Name already in use"), 'exist');
 $form->registerRule('existAlias', 'callback', 'testAliasExistence');
 $form->addRule('contact_alias', _("Name already in use"), 'existAlias');
 $form->setRequiredNote("<font style='color: red;'>*</font>" . _("Required fields"));
+$form->addFormRule('checkAutologinValue');
 
 // Smarty template Init
 $tpl = new Smarty();

--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -714,6 +714,9 @@ if ($o != MASSIVE_CHANGE) {
     }
 
     $form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
+    if ($o === ADD_CONTACT || $o === MODIFY_CONTACT) {
+        $form->addFormRule('validateAutologin');
+    }
     $form->registerRule('exist', 'callback', 'testContactExistence');
     $form->addRule('contact_name', "<font style='color: red;'>*</font>&nbsp;" . _("Contact already exists"), 'exist');
     $form->registerRule('existAlias', 'callback', 'testAliasExistence');


### PR DESCRIPTION
## Description
This PR intends to verify that autologin is different than password

**Fixes** # MON-12159

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
