### PR TITLE
fix(conf/host) fix macro's inheritance on host

### DIFF
--- a/www/class/centreonHost.class.php
+++ b/www/class/centreonHost.class.php
@@ -192,7 +192,7 @@ class CentreonHost
             return $ppList;
         }
         $dbResult = $this->db->query(
-            'SELECT ph.host_id 
+            'SELECT ph.host_id
             FROM mod_ppm_pluginpack_host ph, mod_ppm_pluginpack pp
             WHERE ph.pluginpack_id = pp.pluginpack_id
             AND pp.slug NOT IN ("' . implode('","', $freePp) . '")'
@@ -1094,11 +1094,20 @@ class CentreonHost
                 if (
                     isset($macro['macroInput_#index#'])
                     && isset($macro["macroValue_#index#"])
-                    && isset($macro['macroPassword_#index#'])
                 ) {
-                    if ($input == $macro['macroInput_#index#'] &&
-                        $macroValue[$ind] == $macro["macroValue_#index#"] &&
-                        $macroPassword[$ind] == $macro['macroPassword_#index#']
+                    if (
+                        $input == $macro['macroInput_#index#']
+                        && $macroValue[$ind] == $macro["macroValue_#index#"]
+                        && (
+                            (
+                                isset($macro['macroPassword_#index#'])
+                                && $macroPassword[$ind] == $macro['macroPassword_#index#']
+                            )
+                            || (
+                                isset($macro['macroPassword_#index#']) === false
+                                && isset($macroPassword[$ind]) === false
+                            )
+                        )
                     ) {
                         unset($macroInput[$ind]);
                         unset($macroValue[$ind]);
@@ -1422,8 +1431,8 @@ class CentreonHost
     ) {
         if (!in_array($hostId, $alreadyProcessed)) {
             $alreadyProcessed[$hostId] = $hostId;
-            $query = 'SELECT host_host_id FROM host_template_relation htr 
-                WHERE htr.host_tpl_id = :hostId 
+            $query = 'SELECT host_host_id FROM host_template_relation htr
+                WHERE htr.host_tpl_id = :hostId
                 ORDER BY `order` ASC';
             $stmt = $this->db->prepare($query);
             $stmt->bindParam(':hostId', $hostId, PDO::PARAM_INT);

--- a/www/class/centreonHost.class.php
+++ b/www/class/centreonHost.class.php
@@ -1101,6 +1101,7 @@ class CentreonHost
                         && (
                             (
                                 isset($macro['macroPassword_#index#'])
+                                && isset($macroPassword[$ind])
                                 && $macroPassword[$ind] == $macro['macroPassword_#index#']
                             )
                             || (


### PR DESCRIPTION
## Description

host macro's inheritance is lost after save

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>
- log in to centreon
- open a host configuration page
- add a template with macros => macros inherited are colored
- save
- open the configuration page for the same host again => macro are not flagged (colored) as inherited anymore

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
