### PR TITLE
fix(generateImage): set upper_limit only if it is set

### DIFF
--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -312,32 +312,6 @@ class CentreonGraph
     }
 
     /**
-     * Get Maximum Size of metric from index_id
-     *
-     * @param int $metricId
-     * @return float
-     */
-    protected function getMaxLimit($metricId = null)
-    {
-        $query = "SELECT MAX(`max`) as maxlimit
-                  FROM metrics
-                  WHERE index_id = " . $this->DB->escape($this->index);
-        if (isset($metricId)) {
-            $query .= " AND metric_id = " . $this->DB->escape($metricId);
-        }
-        $res = $this->DBC->query($query);
-        if ($res->rowCount()) {
-            $row = $res->fetch();
-            $maxlimit = $row['maxlimit'];
-            if ($maxlimit != 0) {
-                $maxlimit = $maxlimit + ((self::OVER_MAX_LIMIT_PCT / $maxlimit) * 100);
-            }
-            return $maxlimit;
-        }
-        return 0;
-    }
-
-    /**
      *
      * Enter description here ...
      * @param unknown_type $metrics
@@ -388,15 +362,6 @@ class CentreonGraph
         }
         if (isset($this->templateInformations["upper_limit"]) && $this->templateInformations["upper_limit"] != "") {
             $this->setRRDOption("upper-limit", $this->templateInformations["upper_limit"]);
-        } elseif (isset($this->templateInformations["size_to_max"]) && $this->templateInformations["size_to_max"]) {
-            if ($this->onecurve === true) {
-                $upperLimit = $this->getMaxLimit($this->metricsEnabled[0]);
-            } else {
-                $upperLimit = $this->getMaxLimit();
-            }
-            if ($upperLimit != 0) {
-                $this->setRRDOption("upper-limit", $upperLimit);
-            }
         }
         if (
             (isset($this->templateInformations["lower_limit"]) &&


### PR DESCRIPTION
## Description

This PR intends to fix an issue where the displayed graph and the exported png graph were not the same as the export did not handle correctly the "size to max" parameter from the graph template

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira ticket for details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
