### PR TITLE
enh(UI): Remove tooltip for action_URL and  displaying label on tooltip for No…

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/Url/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/index.tsx
@@ -61,7 +61,7 @@ const UrlColumn = ({
         <IconButton
           ariaLabel={title}
           size="large"
-          title={title || endpoint}
+          title={title}
           onClick={(): null => {
             return null;
           }}


### PR DESCRIPTION
## Description


For action_url - Remove the tooltip that displays and the URL on hover

For notes_url - If a note as been configured then display the note (label)

If no note configured then no possible hover

**Fixes** # (issue)

https://www.loom.com/share/c4f7cf3c8559445298e4b17e0e40e8b8

## Type of change

- [x] New functionality (non-breaking change)


## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>



