### PR TITLE
enh(sec): get excluded users from password expiration policy

### DIFF
--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -3957,7 +3957,6 @@ components:
             - password_expiration
             - can_reuse_passwords
             - delay_before_new_password
-            - excluded_users
           properties:
             password_min_length:
               description: minimum length of the password

--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -3937,6 +3937,7 @@ components:
             - password_expiration
             - can_reuse_passwords
             - delay_before_new_password
+            - excluded_users
           properties:
             password_min_length:
               description: minimum length of the password
@@ -3974,12 +3975,36 @@ components:
               maximum: 604800
               default: 900
             password_expiration:
-              description: password expiration time in seconds
-              type: integer
-              nullable: true
-              minimum: 604800
-              maximum: 31557600
-              default: 7776000
+              description: password expiration policy
+              type: object
+              required:
+                - duration
+                - excluded_users
+              properties:
+                expiration:
+                  description: password expiration time in seconds
+                  type: integer
+                  nullable: true
+                  minimum: 604800
+                  maximum: 31557600
+                  default: 7776000
+                excluded_users:
+                  description: list of users without password expiration rule
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - name
+                    properties:
+                      id:
+                        type: integer
+                        nullable: false
+                        example: 1
+                      name:
+                        type: string
+                        nullable: false
+                        example: api-user
             can_reuse_passwords:
               description: is allowed or not to reuse a password among 3 last
               type: boolean

--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -705,6 +705,26 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /configuration/users:
+    get:
+      tags:
+      - User
+      summary: get configured users
+      description: get list of configured users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Configuration.User'
+                  meta:
+                    $ref: '#/components/schemas/Meta'
   /configuration/users/current/parameters:
     get:
       tags:
@@ -3978,11 +3998,11 @@ components:
               description: password expiration policy
               type: object
               required:
-                - duration
+                - expiration_delay
                 - excluded_users
               properties:
-                expiration:
-                  description: password expiration time in seconds
+                expiration_delay:
+                  description: password expiration delay in seconds
                   type: integer
                   nullable: true
                   minimum: 604800
@@ -3992,19 +4012,12 @@ components:
                   description: list of users without password expiration rule
                   type: array
                   items:
-                    type: object
-                    required:
-                      - id
-                      - name
-                    properties:
-                      id:
-                        type: integer
-                        nullable: false
-                        example: 1
-                      name:
-                        type: string
-                        nullable: false
-                        example: api-user
+                    type: string
+                    description: user login
+                    nullable: false
+                    example: admin
+                    minLength: 1
+                    maxLength: 255
             can_reuse_passwords:
               description: is allowed or not to reuse a password among 3 last
               type: boolean
@@ -4052,6 +4065,25 @@ components:
                 type: string
                 description: "Comment to add to the monitored resource"
                 example: "Resource is not-OK but it is expected"
+    Configuration.User:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: User id
+          example: 1
+        alias:
+          type: string
+          description: User alias / login
+          example: admin
+        email:
+          type: string
+          description: email address
+          example: root@localhost
+        is_admin:
+          type: boolean
+          description: is admin or not
+          example: true
     Configuration.Host.Category:
       type: object
       properties:

--- a/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -140,6 +140,27 @@ class Assertion
     }
 
     /**
+     * Assert that a string respects email format.
+     *
+     * @param string $value Value to test
+     * @param string|null $propertyPath Property's path (ex: User::email)
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function email(string $value, string $propertyPath = null): void
+    {
+        Assert::email(
+            $value,
+            function (array $parameters) {
+                return AssertionException::email(
+                    $parameters['value'],
+                    $parameters['propertyPath']
+                )->getMessage();
+            },
+            $propertyPath
+        );
+    }
+
+    /**
      * Assert that a date is smaller as a given limit.
      *
      * @param \DateTime $value

--- a/src/Centreon/Domain/Common/Assertion/AssertionException.php
+++ b/src/Centreon/Domain/Common/Assertion/AssertionException.php
@@ -120,6 +120,24 @@ class AssertionException extends \InvalidArgumentException
     }
 
     /**
+     * Exception when the value does not respect email format.
+     *
+     * @param string $value Tested value
+     * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     * @return self
+     */
+    public static function email(string $value, string $propertyPath = null): self
+    {
+        return new self(
+            sprintf(
+                _('[%s] The value "%s" was expected to be a valid e-mail address'),
+                $propertyPath,
+                $value
+            )
+        );
+    }
+
+    /**
      * Exception when the value of the date is higher than the expected date.
      *
      * @param \DateTime $date Tested date

--- a/src/Core/Application/Security/ProviderConfiguration/Local/UseCase/FindConfiguration/FindConfiguration.php
+++ b/src/Core/Application/Security/ProviderConfiguration/Local/UseCase/FindConfiguration/FindConfiguration.php
@@ -87,8 +87,17 @@ class FindConfiguration
         $response->canReusePasswords = $configuration->canReusePasswords();
         $response->attempts = $configuration->getAttempts();
         $response->blockingDuration = $configuration->getBlockingDuration();
-        $response->passwordExpiration = $configuration->getPasswordExpiration();
+        $response->passwordExpirationDelay = $configuration->getPasswordExpirationDelay();
         $response->delayBeforeNewPassword = $configuration->getDelayBeforeNewPassword();
+
+        $response->passwordExpirationExcludedUserAliases = array_reduce(
+            $configuration->getPasswordExpirationExcludedUsers(),
+            function ($acc, $excludedUser) {
+                $acc[] = $excludedUser->getAlias();
+                return $acc;
+            },
+            []
+        );
 
         return $response;
     }

--- a/src/Core/Application/Security/ProviderConfiguration/Local/UseCase/FindConfiguration/FindConfigurationResponse.php
+++ b/src/Core/Application/Security/ProviderConfiguration/Local/UseCase/FindConfiguration/FindConfigurationResponse.php
@@ -68,7 +68,12 @@ class FindConfigurationResponse
     /**
      * @var int|null
      */
-    public ?int $passwordExpiration;
+    public ?int $passwordExpirationDelay;
+
+    /**
+     * @var string[]
+     */
+    public array $passwordExpirationExcludedUserAliases;
 
     /**
      * @var int|null

--- a/src/Core/Application/Security/ProviderConfiguration/Local/UseCase/UpdateConfiguration/UpdateConfigurationRequest.php
+++ b/src/Core/Application/Security/ProviderConfiguration/Local/UseCase/UpdateConfiguration/UpdateConfigurationRequest.php
@@ -68,7 +68,7 @@ class UpdateConfigurationRequest
     /**
      * @var int|null
      */
-    public ?int $passwordExpiration;
+    public ?int $passwordExpirationDelay;
 
     /**
      * @var int|null

--- a/src/Core/Domain/Configuration/User/Model/User.php
+++ b/src/Core/Domain/Configuration/User/Model/User.php
@@ -56,8 +56,7 @@ class User
         Assertion::minLength($name, self::MIN_ALIAS_LENGTH, 'User::name');
         Assertion::maxLength($name, self::MAX_ALIAS_LENGTH, 'User::name');
 
-        Assertion::minLength($email, self::MIN_EMAIL_LENGTH, 'User::email');
-        Assertion::maxLength($email, self::MAX_EMAIL_LENGTH, 'User::email');
+        Assertion::email($email, 'User::email');
     }
 
     /**

--- a/src/Core/Domain/Configuration/User/Model/User.php
+++ b/src/Core/Domain/Configuration/User/Model/User.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Domain\Configuration\User\Model;
+
+use Centreon\Domain\Common\Assertion\Assertion;
+use Centreon\Domain\Common\Assertion\AssertionException;
+
+class User
+{
+    public const MIN_ALIAS_LENGTH = 1,
+                 MAX_ALIAS_LENGTH = 255,
+                 MIN_NAME_LENGTH = 1,
+                 MAX_NAME_LENGTH = 255,
+                 MIN_EMAIL_LENGTH = 1,
+                 MAX_EMAIL_LENGTH = 255;
+
+    /**
+     * @param int $id
+     * @param string $alias
+     * @param string $name
+     * @param string $email
+     * @param bool $isAdmin
+     * @throws AssertionException
+     */
+    public function __construct(
+        private int $id,
+        private string $alias,
+        private string $name,
+        private string $email,
+        private bool $isAdmin,
+    ) {
+        Assertion::minLength($alias, self::MIN_ALIAS_LENGTH, 'User::alias');
+        Assertion::maxLength($alias, self::MAX_ALIAS_LENGTH, 'User::alias');
+
+        Assertion::minLength($name, self::MIN_ALIAS_LENGTH, 'User::name');
+        Assertion::maxLength($name, self::MAX_ALIAS_LENGTH, 'User::name');
+
+        Assertion::minLength($email, self::MIN_EMAIL_LENGTH, 'User::email');
+        Assertion::maxLength($email, self::MAX_EMAIL_LENGTH, 'User::email');
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return self
+     */
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @param string $alias
+     * @return self
+     */
+    public function setAlias(string $alias): self
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     * @return self
+     */
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAdmin(): bool
+    {
+        return $this->isAdmin;
+    }
+
+    /**
+     * @param bool $isAdmin
+     * @return self
+     */
+    public function setAdmin(bool $isAdmin): self
+    {
+        $this->isAdmin = $isAdmin;
+        return $this;
+    }
+}

--- a/src/Core/Domain/Security/ProviderConfiguration/Local/Model/Configuration.php
+++ b/src/Core/Domain/Security/ProviderConfiguration/Local/Model/Configuration.php
@@ -23,22 +23,23 @@ declare(strict_types=1);
 
 namespace Core\Domain\Security\ProviderConfiguration\Local\Model;
 
+use Core\Domain\Configuration\User\Model\User;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Centreon\Domain\Common\Assertion\AssertionException;
 
 class Configuration
 {
     public const SPECIAL_CHARACTERS_LIST = '@$!%*?&',
-         MIN_PASSWORD_LENGTH = 8,
-         MAX_PASSWORD_LENGTH = 128,
-         MIN_ATTEMPTS = 1,
-         MAX_ATTEMPTS = 10,
-         MIN_BLOCKING_DURATION = 1,
-         MAX_BLOCKING_DURATION = 604800, // 7 days in seconds.
-         MIN_PASSWORD_EXPIRATION = 604800, // 7 days in seconds.
-         MAX_PASSWORD_EXPIRATION = 31536000, // 12 months in seconds.
-         MIN_NEW_PASSWORD_DELAY = 3600, // 1 hour in seconds.
-         MAX_NEW_PASSWORD_DELAY = 604800; // 7 days in seconds.
+                 MIN_PASSWORD_LENGTH = 8,
+                 MAX_PASSWORD_LENGTH = 128,
+                 MIN_ATTEMPTS = 1,
+                 MAX_ATTEMPTS = 10,
+                 MIN_BLOCKING_DURATION = 1,
+                 MAX_BLOCKING_DURATION = 604800, // 7 days in seconds.
+                 MIN_PASSWORD_EXPIRATION_DELAY = 604800, // 7 days in seconds.
+                 MAX_PASSWORD_EXPIRATION_DELAY = 31536000, // 12 months in seconds.
+                 MIN_NEW_PASSWORD_DELAY = 3600, // 1 hour in seconds.
+                 MAX_NEW_PASSWORD_DELAY = 604800; // 7 days in seconds.
 
     /**
      * @param int $passwordMinimumLength
@@ -49,7 +50,8 @@ class Configuration
      * @param bool $canReusePasswords
      * @param int|null $attempts
      * @param int|null $blockingDuration
-     * @param int|null $passwordExpiration
+     * @param int|null $passwordExpirationDelay
+     * @param User[] $passwordExpirationExcludedUsers
      * @param int|null $delayBeforeNewPassword
      * @throws AssertionException
      */
@@ -62,7 +64,8 @@ class Configuration
         private bool $canReusePasswords,
         private ?int $attempts,
         private ?int $blockingDuration,
-        private ?int $passwordExpiration,
+        private ?int $passwordExpirationDelay,
+        private array $passwordExpirationExcludedUsers,
         private ?int $delayBeforeNewPassword
     ) {
         Assertion::min($passwordMinimumLength, self::MIN_PASSWORD_LENGTH, 'Configuration::passwordMinimumLength');
@@ -75,9 +78,17 @@ class Configuration
             Assertion::min($blockingDuration, self::MIN_BLOCKING_DURATION, 'Configuration::blockingDuration');
             Assertion::max($blockingDuration, self::MAX_BLOCKING_DURATION, 'Configuration::blockingDuration');
         }
-        if ($passwordExpiration !== null) {
-            Assertion::min($passwordExpiration, self::MIN_PASSWORD_EXPIRATION, 'Configuration::passwordExpiration');
-            Assertion::max($passwordExpiration, self::MAX_PASSWORD_EXPIRATION, 'Configuration::passwordExpiration');
+        if ($passwordExpirationDelay !== null) {
+            Assertion::min(
+                $passwordExpirationDelay,
+                self::MIN_PASSWORD_EXPIRATION_DELAY,
+                'Configuration::passwordExpirationDelay'
+            );
+            Assertion::max(
+                $passwordExpirationDelay,
+                self::MAX_PASSWORD_EXPIRATION_DELAY,
+                'Configuration::passwordExpirationDelay'
+            );
         }
         if ($delayBeforeNewPassword !== null) {
             Assertion::min(
@@ -241,18 +252,36 @@ class Configuration
     /**
      * @return int|null
      */
-    public function getPasswordExpiration(): ?int
+    public function getPasswordExpirationDelay(): ?int
     {
-        return $this->passwordExpiration;
+        return $this->passwordExpirationDelay;
     }
 
     /**
-     * @param int|null $passwordExpiration
+     * @param int|null $passwordExpirationDelay
      * @return self
      */
-    public function setPasswordExpiration(?int $passwordExpiration): self
+    public function setPasswordExpirationDelay(?int $passwordExpirationDelay): self
     {
-        $this->passwordExpiration = $passwordExpiration;
+        $this->passwordExpirationDelay = $passwordExpirationDelay;
+        return $this;
+    }
+
+    /**
+     * @return User[]
+     */
+    public function getPasswordExpirationExcludedUsers(): array
+    {
+        return $this->passwordExpirationExcludedUsers;
+    }
+
+    /**
+     * @param User[] $passwordExpirationExcludedUsers
+     * @return self
+     */
+    public function setPasswordExpirationExcludedUsers(array $passwordExpirationExcludedUsers): self
+    {
+        $this->passwordExpirationExcludedUsers = $passwordExpirationExcludedUsers;
         return $this;
     }
 

--- a/src/Core/Domain/Security/ProviderConfiguration/Local/Model/ConfigurationFactory.php
+++ b/src/Core/Domain/Security/ProviderConfiguration/Local/Model/ConfigurationFactory.php
@@ -46,7 +46,8 @@ class ConfigurationFactory
             $request->canReusePasswords,
             $request->attempts,
             $request->blockingDuration,
-            $request->passwordExpiration,
+            $request->passwordExpirationDelay,
+            [],
             $request->delayBeforeNewPassword
         );
     }

--- a/src/Core/Infrastructure/Configuration/User/Repository/DbUserFactory.php
+++ b/src/Core/Infrastructure/Configuration/User/Repository/DbUserFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Configuration\User\Repository;
+
+use Core\Domain\Configuration\User\Model\User;
+
+class DbUserFactory
+{
+    /**
+     * @param array<string,mixed> $user
+     * @return User
+     */
+    public static function createFromRecord(array $user): User
+    {
+        return new User(
+            (int) $user['contact_id'],
+            $user['contact_alias'],
+            $user['contact_name'],
+            $user['contact_email'],
+            $user['contact_admin'] === '1',
+        );
+    }
+}

--- a/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Api/FindConfiguration/FindConfigurationPresenter.php
+++ b/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Api/FindConfiguration/FindConfigurationPresenter.php
@@ -42,7 +42,10 @@ class FindConfigurationPresenter extends AbstractPresenter implements FindConfig
                 'has_special_character' => $response->hasSpecialCharacter,
                 'attempts' => $response->attempts,
                 'blocking_duration' => $response->blockingDuration,
-                'password_expiration' => $response->passwordExpiration,
+                'password_expiration' => [
+                    'expiration_delay' => $response->passwordExpirationDelay,
+                    'excluded_users' => $response->passwordExpirationExcludedUserAliases,
+                ],
                 'can_reuse_passwords' => $response->canReusePasswords,
                 'delay_before_new_password' => $response->delayBeforeNewPassword,
             ]

--- a/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Api/UpdateConfiguration/UpdateConfigurationController.php
+++ b/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Api/UpdateConfiguration/UpdateConfigurationController.php
@@ -74,7 +74,7 @@ class UpdateConfigurationController extends AbstractController
         $updateRequest->hasSpecialCharacter = $passwordPolicy['has_special_character'];
         $updateRequest->attempts = $passwordPolicy['attempts'];
         $updateRequest->blockingDuration = $passwordPolicy['blocking_duration'];
-        $updateRequest->passwordExpiration = $passwordPolicy['password_expiration'];
+        $updateRequest->passwordExpirationDelay = $passwordPolicy['password_expiration'];
         $updateRequest->canReusePasswords = $passwordPolicy['can_reuse_passwords'];
         $updateRequest->delayBeforeNewPassword = $passwordPolicy['delay_before_new_password'];
 

--- a/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/CustomConfigurationSchema.json
+++ b/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/CustomConfigurationSchema.json
@@ -15,7 +15,7 @@
         "has_special_characters",
         "attempts",
         "blocking_duration",
-        "password_expiration",
+        "password_expiration_delay",
         "can_reuse_passwords",
         "delay_before_new_password"
       ],
@@ -48,7 +48,7 @@
           "minimum": 1,
           "maximum": 604800
         },
-        "password_expiration": {
+        "password_expiration_delay": {
             "type": ["integer", "null"],
             "minimum": 604800,
             "maximum": 31536000

--- a/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbConfigurationFactory.php
+++ b/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbConfigurationFactory.php
@@ -23,26 +23,34 @@ declare(strict_types=1);
 namespace Core\Infrastructure\Security\ProviderConfiguration\Local\Repository;
 
 use Core\Domain\Security\ProviderConfiguration\Local\Model\Configuration;
+use Core\Infrastructure\Configuration\User\Repository\DbUserFactory;
 
 class DbConfigurationFactory
 {
     /**
      * @param array<string,mixed> $configuration
+     * @param array<string,mixed> $excludedUsers
      * @return Configuration
      */
-    public static function createFromRecord(array $configuration): Configuration
+    public static function createFromRecord(array $configuration, array $excludedUsers): Configuration
     {
+        $users = [];
+        foreach ($excludedUsers as $user) {
+            $users[] = DbUserFactory::createFromRecord($user);
+        }
+
         return new Configuration(
-            $configuration['custom_configuration']['password_security_policy']['password_length'],
-            $configuration['custom_configuration']['password_security_policy']['has_uppercase_characters'],
-            $configuration['custom_configuration']['password_security_policy']['has_lowercase_characters'],
-            $configuration['custom_configuration']['password_security_policy']['has_numbers'],
-            $configuration['custom_configuration']['password_security_policy']['has_special_characters'],
-            $configuration['custom_configuration']['password_security_policy']['can_reuse_passwords'],
-            $configuration['custom_configuration']['password_security_policy']['attempts'],
-            $configuration['custom_configuration']['password_security_policy']['blocking_duration'],
-            $configuration['custom_configuration']['password_security_policy']['password_expiration'],
-            $configuration['custom_configuration']['password_security_policy']['delay_before_new_password'],
+            $configuration['password_security_policy']['password_length'],
+            $configuration['password_security_policy']['has_uppercase_characters'],
+            $configuration['password_security_policy']['has_lowercase_characters'],
+            $configuration['password_security_policy']['has_numbers'],
+            $configuration['password_security_policy']['has_special_characters'],
+            $configuration['password_security_policy']['can_reuse_passwords'],
+            $configuration['password_security_policy']['attempts'],
+            $configuration['password_security_policy']['blocking_duration'],
+            $configuration['password_security_policy']['password_expiration_delay'],
+            $users,
+            $configuration['password_security_policy']['delay_before_new_password'],
         );
     }
 }

--- a/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbReadConfigurationRepository.php
+++ b/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbReadConfigurationRepository.php
@@ -100,8 +100,8 @@ class DbReadConfigurationRepository extends AbstractRepositoryDRB implements Rea
         );
 
         $excludedUsers = [];
-        if ($statement !== false && $result = $statement->fetch(\PDO::FETCH_ASSOC)) {
-            $excludedUsers[] = $result;
+        if ($statement !== false) {
+            $excludedUsers = $statement->fetchAll(\PDO::FETCH_ASSOC);
         }
 
         return $excludedUsers;

--- a/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbWriteConfigurationRepository.php
+++ b/src/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbWriteConfigurationRepository.php
@@ -51,7 +51,7 @@ class DbWriteConfigurationRepository extends AbstractRepositoryDRB implements Wr
                 "has_special_characters" => $localConfiguration->hasSpecialCharacter(),
                 "attempts" => $localConfiguration->getAttempts(),
                 "blocking_duration" => $localConfiguration->getBlockingDuration(),
-                "password_expiration" => $localConfiguration->getPasswordExpiration(),
+                "password_expiration_delay" => $localConfiguration->getPasswordExpirationDelay(),
                 "delay_before_new_password" => $localConfiguration->getDelayBeforeNewPassword(),
                 "can_reuse_passwords" => $localConfiguration->canReusePasswords(),
             ],

--- a/tests/php/Core/Application/Security/ProviderConfiguration/Local/UseCase/FindConfiguration/FindConfigurationTest.php
+++ b/tests/php/Core/Application/Security/ProviderConfiguration/Local/UseCase/FindConfiguration/FindConfigurationTest.php
@@ -66,7 +66,8 @@ class FindConfigurationTest extends TestCase
             true,
             Configuration::MIN_ATTEMPTS,
             Configuration::MIN_BLOCKING_DURATION,
-            Configuration::MIN_PASSWORD_EXPIRATION,
+            Configuration::MIN_PASSWORD_EXPIRATION_DELAY,
+            [],
             Configuration::MIN_NEW_PASSWORD_DELAY
         );
 
@@ -89,7 +90,10 @@ class FindConfigurationTest extends TestCase
         $this->assertEquals($presenter->response->canReusePasswords, $configuration->canReusePasswords());
         $this->assertEquals($presenter->response->attempts, $configuration->getAttempts());
         $this->assertEquals($presenter->response->blockingDuration, $configuration->getBlockingDuration());
-        $this->assertEquals($presenter->response->passwordExpiration, $configuration->getPasswordExpiration());
+        $this->assertEquals(
+            $presenter->response->passwordExpirationDelay,
+            $configuration->getPasswordExpirationDelay()
+        );
         $this->assertEquals($presenter->response->delayBeforeNewPassword, $configuration->getDelayBeforeNewPassword());
     }
 

--- a/tests/php/Core/Application/Security/ProviderConfiguration/Local/UseCase/UpdateConfiguration/UpdateConfigurationTest.php
+++ b/tests/php/Core/Application/Security/ProviderConfiguration/Local/UseCase/UpdateConfiguration/UpdateConfigurationTest.php
@@ -64,7 +64,8 @@ class UpdateConfigurationTest extends TestCase
             true,
             Configuration::MIN_ATTEMPTS,
             Configuration::MIN_BLOCKING_DURATION,
-            Configuration::MIN_PASSWORD_EXPIRATION,
+            Configuration::MIN_PASSWORD_EXPIRATION_DELAY,
+            [],
             Configuration::MIN_NEW_PASSWORD_DELAY
         );
 
@@ -77,7 +78,7 @@ class UpdateConfigurationTest extends TestCase
         $request->canReusePasswords = true;
         $request->attempts = Configuration::MIN_ATTEMPTS;
         $request->blockingDuration = Configuration::MIN_BLOCKING_DURATION;
-        $request->passwordExpiration = Configuration::MIN_PASSWORD_EXPIRATION;
+        $request->passwordExpirationDelay = Configuration::MIN_PASSWORD_EXPIRATION_DELAY;
         $request->delayBeforeNewPassword = Configuration::MIN_NEW_PASSWORD_DELAY;
 
         $this->repository

--- a/tests/php/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbConfigurationFactoryTest.php
+++ b/tests/php/Core/Infrastructure/Security/ProviderConfiguration/Local/Repository/DbConfigurationFactoryTest.php
@@ -46,7 +46,7 @@ class DbConfigurationFactoryTest extends TestCase
             'can_reuse_passwords' => true,
             'attempts' => Configuration::MIN_ATTEMPTS,
             'blocking_duration' => Configuration::MIN_BLOCKING_DURATION,
-            'password_expiration' => Configuration::MIN_PASSWORD_EXPIRATION,
+            'password_expiration_delay' => Configuration::MIN_PASSWORD_EXPIRATION_DELAY,
             'delay_before_new_password' => Configuration::MIN_NEW_PASSWORD_DELAY,
         ];
     }
@@ -64,11 +64,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -85,11 +83,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -106,11 +102,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -127,11 +121,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -148,11 +140,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -169,11 +159,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -181,20 +169,18 @@ class DbConfigurationFactoryTest extends TestCase
      */
     public function testPasswordExpirationTooSmallException(): void
     {
-        $this->securityPolicyData['password_expiration'] = Configuration::MIN_PASSWORD_EXPIRATION - 1;
+        $this->securityPolicyData['password_expiration_delay'] = Configuration::MIN_PASSWORD_EXPIRATION_DELAY - 1;
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(AssertionException::min(
-            $this->securityPolicyData['password_expiration'],
-            Configuration::MIN_PASSWORD_EXPIRATION,
-            'Configuration::passwordExpiration'
+            $this->securityPolicyData['password_expiration_delay'],
+            Configuration::MIN_PASSWORD_EXPIRATION_DELAY,
+            'Configuration::passwordExpirationDelay'
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -202,20 +188,18 @@ class DbConfigurationFactoryTest extends TestCase
      */
     public function testPasswordExpirationTooHighException(): void
     {
-        $this->securityPolicyData['password_expiration'] = Configuration::MAX_PASSWORD_EXPIRATION + 1;
+        $this->securityPolicyData['password_expiration_delay'] = Configuration::MAX_PASSWORD_EXPIRATION_DELAY + 1;
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(AssertionException::max(
-            $this->securityPolicyData['password_expiration'],
-            Configuration::MAX_PASSWORD_EXPIRATION,
-            'Configuration::passwordExpiration'
+            $this->securityPolicyData['password_expiration_delay'],
+            Configuration::MAX_PASSWORD_EXPIRATION_DELAY,
+            'Configuration::passwordExpirationDelay'
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -232,11 +216,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -253,11 +235,9 @@ class DbConfigurationFactoryTest extends TestCase
         )->getMessage());
 
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        DbConfigurationFactory::createFromRecord($configuration);
+        DbConfigurationFactory::createFromRecord($configuration, []);
     }
 
     /**
@@ -266,11 +246,9 @@ class DbConfigurationFactoryTest extends TestCase
     public function testConfigurationCorrectlyCreated(): void
     {
         $configuration = [
-            'custom_configuration' => [
-                'password_security_policy' => $this->securityPolicyData,
-            ],
+            'password_security_policy' => $this->securityPolicyData,
         ];
-        $createdSecurityPolicy = DbConfigurationFactory::createFromRecord($configuration);
+        $createdSecurityPolicy = DbConfigurationFactory::createFromRecord($configuration, []);
 
         $this->assertEquals(
             $this->securityPolicyData['password_length'],
@@ -305,8 +283,8 @@ class DbConfigurationFactoryTest extends TestCase
             $createdSecurityPolicy->getBlockingDuration()
         );
         $this->assertEquals(
-            $this->securityPolicyData['password_expiration'],
-            $createdSecurityPolicy->getPasswordExpiration()
+            $this->securityPolicyData['password_expiration_delay'],
+            $createdSecurityPolicy->getPasswordExpirationDelay()
         );
         $this->assertEquals(
             $this->securityPolicyData['delay_before_new_password'],

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2395,7 +2395,7 @@ CREATE TABLE `password_expiration_excluded_users` (
   CONSTRAINT `password_expiration_excluded_users_provider_configuration_id_fk` FOREIGN KEY (`provider_configuration_id`)
   REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
   CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk` FOREIGN KEY (`user_id`)
-  REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
+  REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `security_token` (

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2389,6 +2389,15 @@ CREATE TABLE `provider_configuration` (
   UNIQUE KEY `unique_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `password_expiration_excluded_users` (
+  `provider_configuration_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  CONSTRAINT `password_expiration_excluded_users_provider_configuration_id_fk` FOREIGN KEY (`provider_configuration_id`)
+  REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk` FOREIGN KEY (`user_id`)
+  REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `security_token` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `token` varchar(255) NOT NULL,

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -1394,7 +1394,7 @@ INSERT INTO `provider_configuration` (type, name, custom_configuration, is_activ
 VALUES (
   'local',
   'local',
-  '{"password_security_policy": {"password_length": 12, "has_uppercase_characters": true, "has_lowercase_characters": true, "has_numbers": true, "has_special_characters": true, "attempts": 5, "blocking_duration": 900, "password_expiration": 7776000, "delay_before_new_password": 3600, "can_reuse_passwords": false }}',
+  '{"password_security_policy": {"password_length": 12, "has_uppercase_characters": true, "has_lowercase_characters": true, "has_numbers": true, "has_special_characters": true, "attempts": 5, "blocking_duration": 900, "password_expiration_delay": 7776000, "delay_before_new_password": 3600, "can_reuse_passwords": false }}',
   true,
   true
 );

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -37,10 +37,12 @@ try {
         "CREATE TABLE `password_expiration_excluded_users` (
         `provider_configuration_id` int(11) NOT NULL,
         `user_id` int(11) NOT NULL,
-        CONSTRAINT `password_expiration_excluded_users_provider_configuration_id_fk` FOREIGN KEY (`provider_configuration_id`)
-        REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
-        CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk` FOREIGN KEY (`user_id`)
-        REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
+        CONSTRAINT `password_expiration_excluded_users_provider_configuration_id_fk`
+          FOREIGN KEY (`provider_configuration_id`)
+          REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
+        CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk`
+          FOREIGN KEY (`user_id`)
+          REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8"
     );
 

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -32,6 +32,18 @@ try {
         "ALTER TABLE `provider_configuration` ADD COLUMN `custom_configuration` JSON NOT NULL AFTER `name`"
     );
 
+    $errorMessage = "Unable to create 'password_expiration_excluded_users' table";
+    $pearDB->query(
+        "CREATE TABLE `password_expiration_excluded_users` (
+        `provider_configuration_id` int(11) NOT NULL,
+        `user_id` int(11) NOT NULL,
+        CONSTRAINT `password_expiration_excluded_users_provider_configuration_id_fk` FOREIGN KEY (`provider_configuration_id`)
+        REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
+        CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk` FOREIGN KEY (`user_id`)
+        REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;"
+    );
+
     $errorMessage = "Unable to insert default local security policy configuration";
     $localProviderConfiguration = json_encode([
         "password_security_policy" => [

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -40,8 +40,8 @@ try {
         CONSTRAINT `password_expiration_excluded_users_provider_configuration_id_fk` FOREIGN KEY (`provider_configuration_id`)
         REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
         CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk` FOREIGN KEY (`user_id`)
-        REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;"
+        REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8"
     );
 
     $errorMessage = "Unable to insert default local security policy configuration";
@@ -54,7 +54,7 @@ try {
             "has_special_characters" => true,
             "attempts" => 5,
             "blocking_duration" => 900,
-            "password_expiration" => 7776000,
+            "password_expiration_delay" => 7776000,
             "delay_before_new_password" => 3600,
             "can_reuse_passwords" => false,
         ],


### PR DESCRIPTION
## Description

get excluded users from password expiration policy

**Fixes** MON-12040

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)