### PR TITLE
Revert "enh(UI): Remove tooltip for action_URL and  displaying label on tooltip for No…"

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/Url/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url/index.tsx
@@ -61,7 +61,7 @@ const UrlColumn = ({
         <IconButton
           ariaLabel={title}
           size="large"
-          title={title}
+          title={title || endpoint}
           onClick={(): null => {
             return null;
           }}


### PR DESCRIPTION
Reverts centreon/centreon#10602, applicable only into 21.10 and 21.04