### PR TITLE
fix(UI): Expand "Configure pollers" button to full width

### DIFF
--- a/www/front_src/src/Header/PollerMenu/ExportConfiguration/index.test.tsx
+++ b/www/front_src/src/Header/PollerMenu/ExportConfiguration/index.test.tsx
@@ -33,9 +33,13 @@ const mockUser = {
   timezone: 'Europe/Paris',
 };
 const mockRefreshInterval = 60;
+const toggleDetailedView = jest.fn();
 
 const ExportConfigurationButton = (): JSX.Element => (
-  <ExportConfiguration setIsExportingConfiguration={jest.fn} />
+  <ExportConfiguration
+    setIsExportingConfiguration={jest.fn}
+    toggleDetailedView={toggleDetailedView}
+  />
 );
 
 const renderExportConfiguration = (): RenderResult =>
@@ -73,6 +77,8 @@ describe(ExportConfiguration, () => {
         cancelTokenRequestParam,
       );
     });
+
+    expect(toggleDetailedView).toHaveBeenCalled();
 
     expect(
       screen.getByText(labelExportingAndReloadingTheConfiguration),

--- a/www/front_src/src/Header/PollerMenu/ExportConfiguration/index.tsx
+++ b/www/front_src/src/Header/PollerMenu/ExportConfiguration/index.tsx
@@ -25,6 +25,7 @@ import { exportAndReloadConfigurationEndpoint } from './api/endpoints';
 
 interface Props {
   setIsExportingConfiguration: (isExporting: boolean) => void;
+  toggleDetailedView: () => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -43,6 +44,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ExportConfiguration = ({
   setIsExportingConfiguration,
+  toggleDetailedView,
 }: Props): JSX.Element | null => {
   const classes = useStyles();
   const { t } = useTranslation();
@@ -64,6 +66,7 @@ const ExportConfiguration = ({
     setAskingBeforeExportConfiguration(false);
 
   const confirmExportAndReload = (): void => {
+    toggleDetailedView();
     showInfoMessage(t(labelExportingAndReloadingTheConfiguration));
     sendRequest({
       endpoint: exportAndReloadConfigurationEndpoint,

--- a/www/front_src/src/Header/PollerMenu/index.tsx
+++ b/www/front_src/src/Header/PollerMenu/index.tsx
@@ -203,7 +203,11 @@ const PollerMenu = (): JSX.Element => {
             )}
             {allowPollerConfiguration && (
               <Paper className={classes.confButton}>
-                <Button size="small" onClick={redirectToPollerConfiguration}>
+                <Button
+                  fullWidth
+                  size="small"
+                  onClick={redirectToPollerConfiguration}
+                >
                   {t(labelConfigurePollers)}
                 </Button>
               </Paper>

--- a/www/front_src/src/Header/PollerMenu/index.tsx
+++ b/www/front_src/src/Header/PollerMenu/index.tsx
@@ -212,7 +212,10 @@ const PollerMenu = (): JSX.Element => {
                 </Button>
               </Paper>
             )}
-            <ExportConfiguration setIsExportingConfiguration={newExporting} />
+            <ExportConfiguration
+              setIsExportingConfiguration={newExporting}
+              toggleDetailedView={toggleDetailedView}
+            />
           </div>
         </SubmenuHeader>
       </div>

--- a/www/front_src/src/Provider/decoder.ts
+++ b/www/front_src/src/Provider/decoder.ts
@@ -5,7 +5,9 @@ import { User } from '@centreon/ui-context';
 export const userDecoder = JsonDecoder.object<User>(
   {
     alias: JsonDecoder.string,
-    default_page: JsonDecoder.nullable(JsonDecoder.string),
+    default_page: JsonDecoder.optional(
+      JsonDecoder.nullable(JsonDecoder.string),
+    ),
     isExportButtonEnabled: JsonDecoder.boolean,
     locale: JsonDecoder.string,
     name: JsonDecoder.string,

--- a/www/front_src/src/Provider/index.test.tsx
+++ b/www/front_src/src/Provider/index.test.tsx
@@ -25,7 +25,8 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const retrievedUser = {
   alias: 'Admin alias',
-  is_export_button_enabled: undefined,
+  default_page: '/monitoring/resources',
+  is_export_button_enabled: true,
   locale: 'fr_FR.UTF8',
   name: 'Admin',
   timezone: 'Europe/Paris',
@@ -34,7 +35,8 @@ const retrievedUser = {
 
 const contextUser = {
   alias: 'Admin alias',
-  isExportButtonEnabled: undefined,
+  default_page: '/monitoring/resources',
+  isExportButtonEnabled: true,
   locale: 'fr_FR.UTF8',
   name: 'Admin',
   timezone: 'Europe/Paris',

--- a/www/front_src/src/Provider/index.tsx
+++ b/www/front_src/src/Provider/index.tsx
@@ -41,8 +41,7 @@ import {
   userEndpoint,
 } from './endpoint';
 import { DefaultParameters } from './models';
-// TODO uncomment after https://github.com/centreon/centreon/pull/10507
-// import { userDecoder } from './decoder';
+import { userDecoder } from './decoder';
 
 dayjs.extend(localizedFormat);
 dayjs.extend(utcPlugin);
@@ -64,8 +63,7 @@ const Provider = ({ children }: Props): JSX.Element => {
   const [dataLoaded, setDataLoaded] = React.useState(false);
 
   const { sendRequest: getUser } = useRequest<User>({
-    // TODO uncomment after https://github.com/centreon/centreon/pull/10507
-    // decoder: userDecoder,
+    decoder: userDecoder,
     request: getData,
   });
   const { sendRequest: getParameters } = useRequest<DefaultParameters>({

--- a/www/front_src/src/Resources/Details/tabs/Details/storedDetailsCards.ts
+++ b/www/front_src/src/Resources/Details/tabs/Details/storedDetailsCards.ts
@@ -1,4 +1,4 @@
-import { getStoredOrDefault, store } from '../../../storage';
+import { getStoredOrDefault } from '../../../storage';
 
 const key = 'centreon-resource-status-details-card-21.10';
 
@@ -17,9 +17,4 @@ const getStoredOrDefaultDetailsCards = (
   });
 };
 
-const storeDetailsCards = (detailsCards: Array<string>): void => {
-  cachedDetailsCards = detailsCards;
-  store({ key, value: detailsCards });
-};
-
-export { getStoredOrDefaultDetailsCards, storeDetailsCards, key };
+export { getStoredOrDefaultDetailsCards, key };


### PR DESCRIPTION
## Description

This fixes the "Configure pollers" button to expand it to the full contained width.
This also fixes the user decoder.
![Screenshot 2022-02-01 at 16 44 32](https://user-images.githubusercontent.com/12515407/152001005-92d275a8-3f07-4316-8e17-83c5ed3623b3.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

The "Configure pollers" button takes the full contained width.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
