### PR TITLE
fix(resource): do not display cancelled downtimes

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1753,7 +1753,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             ON `cmts`.host_id = d.host_id AND `cmts`.service_id = d.service_id
             AND `cmts`.deletion_time IS NULL
         WHERE d.host_id = :hostId AND d.service_id = :serviceId
-            AND d.deletion_time IS NULL AND ((NOW() BETWEEN FROM_UNIXTIME(d.actual_start_time)
+            AND d.deletion_time IS NULL AND d.cancelled = 0 AND ((NOW() BETWEEN FROM_UNIXTIME(d.actual_start_time)
             AND FROM_UNIXTIME(d.actual_end_time)) OR ((NOW() > FROM_UNIXTIME(d.actual_start_time)
             AND d.actual_end_time IS NULL)))
         ORDER BY d.entry_time DESC';


### PR DESCRIPTION
## Description

This PR ensures to only return downtimes that are not cancelled.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira issue

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
