### PR TITLE
fix(serviceDetails): escape possible html tags in performance data

### DIFF
--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -416,7 +416,9 @@ if (!is_null($host_id)) {
          */
         $centreon->CentreonGMT->getMyGMTFromSession(session_id(), $pearDB);
         $service_status['command_line'] = str_replace(' -', "\n\t-", $service_status['command_line']);
-        $service_status['performance_data'] = CentreonUtils::escapeAll(str_replace(' \'', "\n'", $service_status['performance_data']));
+        $service_status['performance_data'] = CentreonUtils::escapeAll(
+            str_replace(' \'', "\n'", $service_status['performance_data'])
+        );
         if ($service_status['current_state'] !== "") {
             $service_status["status_color"] =
                 $centreon->optGen["color_" . strtolower($service_status["current_state"])];

--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -416,7 +416,7 @@ if (!is_null($host_id)) {
          */
         $centreon->CentreonGMT->getMyGMTFromSession(session_id(), $pearDB);
         $service_status['command_line'] = str_replace(' -', "\n\t-", $service_status['command_line']);
-        $service_status['performance_data'] = str_replace(' \'', "\n'", $service_status['performance_data']);
+        $service_status['performance_data'] = CentreonUtils::escapeAll(str_replace(' \'', "\n'", $service_status['performance_data']));
         if ($service_status['current_state'] !== "") {
             $service_status["status_color"] =
                 $centreon->optGen["color_" . strtolower($service_status["current_state"])];


### PR DESCRIPTION
## Description

This PR intends to escape all html tags that could possibly appear in performaance data
From this
![image](https://user-images.githubusercontent.com/31647811/152829852-ddf18f57-2d8a-4bd9-b9e5-1b69fcf7c2d2.png)

To this

![image](https://user-images.githubusercontent.com/31647811/152829980-ac68fe14-bb42-408a-8242-373d89ebc709.png)


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>
Jira ticket details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
