### PR TITLE
fix(php): fix some existing warnings and adapt tests to default ldap configuration

### DIFF
--- a/features/bootstrap/ClapiContext.php
+++ b/features/bootstrap/ClapiContext.php
@@ -18,6 +18,7 @@ class ClapiContext extends CentreonContext
         "TRAP",
         "HTPL",
         "CG",
+        "LDAP",
         "HOST",
         "STPL",
         "HG",

--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -973,7 +973,7 @@ function insertLdapContactInDB($tmpContacts = array())
 
         if (!isset($ldapInstances[$arId])) {
             $ldap = new CentreonLDAP($pearDB, null, $arId);
-            $ldapAdmin = new CentreonLDAPAdmin($pearDB);
+            $ldapAdmin = new CentreonLdapAdmin($pearDB);
             $opt = $ldapAdmin->getGeneralOptions($arId);
             if (isset($opt['ldap_contact_tmpl']) && $opt['ldap_contact_tmpl']) {
                 $contactTemplates[$arId] = $opt['ldap_contact_tmpl'];
@@ -1282,10 +1282,12 @@ function validatePasswordCreation(array $fields)
 {
     global $pearDB;
     $errors = [];
-    $password = $fields['contact_passwd'];
-    if (empty($password)) {
+
+    if (empty($fields['contact_passwd'])) {
         return true;
     }
+
+    $password = $fields['contact_passwd'];
 
     try {
         $contact = new \CentreonContact($pearDB);
@@ -1307,11 +1309,13 @@ function validatePasswordModification(array $fields)
 {
     global $pearDB;
     $errors = [];
-    $password = $fields['contact_passwd'];
-    $contactId = $fields['contact_id'];
-    if (empty($password)) {
+
+    if (empty($fields['contact_passwd'])) {
         return true;
     }
+
+    $password = $fields['contact_passwd'];
+    $contactId = $fields['contact_id'];
 
     try {
         $contact = new \CentreonContact($pearDB);

--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -172,7 +172,10 @@ $notifCgs = $cg->getListContactgroup(false);
 
 if (
     $centreon->optGen['ldap_auth_enable'] == 1
-    && $cct['contact_auth_type'] == 'ldap' && isset($cct['ar_id']) && $cct['ar_id']
+    && !empty($cct['contact_id'])
+    && $cct['contact_auth_type'] === 'ldap'
+    && !empty($cct['ar_id'])
+    && !empty($cct['contact_ldap_dn'])
 ) {
     $ldap = new CentreonLDAP($pearDB, null, $cct['ar_id']);
     if (false !== $ldap->connect()) {
@@ -818,7 +821,11 @@ if ($o == WATCH_CONTACT) {
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
 }
 
-if ($centreon->optGen['ldap_auth_enable'] == 1 && $cct['contact_auth_type'] == 'ldap') {
+if (
+    !empty($cct['contact_id'])
+    && $centreon->optGen['ldap_auth_enable'] == 1
+    && $cct['contact_auth_type'] === 'ldap'
+) {
     $tpl->assign("ldap_group", _("Group Ldap"));
     if (isset($cgLdap)) {
         $tpl->assign("ldapGroups", $cgLdap);


### PR DESCRIPTION
## Description

fix some existing warnings and adapt tests to default ldap configuration

**Fixes** MON-12076

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)