### PR TITLE
fix(conf) fix contact update when user is not admin

### DIFF
--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -150,8 +150,8 @@ if (($o == MODIFY_CONTACT || $o == WATCH_CONTACT) && $contactId) {
     /**
      * Get ACL informations for this user
      */
-    $DBRESULT = $pearDB->query("SELECT acl_group_id 
-                                FROM `acl_group_contacts_relations` 
+    $DBRESULT = $pearDB->query("SELECT acl_group_id
+                                FROM `acl_group_contacts_relations`
                                 WHERE `contact_contact_id` = '" . intval($contactId) . "'");
     for ($i = 0; $data = $DBRESULT->fetchRow(); $i++) {
         if (!$centreon->user->admin && !isset($allowedAclGroups[$data['acl_group_id']])) {
@@ -202,7 +202,7 @@ if (isset($contactId)) {
 $contactTpl = array(null => "           ");
 $DBRESULT = $pearDB->query("SELECT contact_id, contact_name
                             FROM contact
-                            WHERE contact_register = '0' $strRestrinction 
+                            WHERE contact_register = '0' $strRestrinction
                             ORDER BY contact_name");
 while ($contacts = $DBRESULT->fetchRow()) {
     $contactTpl[$contacts["contact_id"]] = $contacts["contact_name"];
@@ -857,11 +857,6 @@ $valid = false;
 
 if ($form->validate() && $from_list_menu == false) {
     $cctObj = $form->getElement('contact_id');
-    if (!$centreon->user->admin && $contactId) {
-        $form->removeElement('contact_admin');
-        $form->removeElement('reach_api');
-        $form->removeElement('reach_api_rt');
-    }
     if ($form->getSubmitValue("submitA")) {
         $newContactId = insertContactInDB();
         $cctObj->setValue($contactId);


### PR DESCRIPTION
## Description

Updating a contact when connected user is non-admin result in a PHP error and a blank page


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>
Prerequisites: 
- a centreon platform with a non-admin user, with enough privileges to modify contacts
- another contact (admin or not)

1. Login with the non-admin user
2. open an existing contact configuration
3. Modify anything on the contact and save (eg. the user email)
=> PhP error and blak page

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
