### PR TITLE
fix(conf) keep all acl groups when editing contact with non-admin user

### DIFF
--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -155,7 +155,7 @@ if (($o == MODIFY_CONTACT || $o == WATCH_CONTACT) && $contactId) {
                                 WHERE `contact_contact_id` = '" . intval($contactId) . "'");
     for ($i = 0; $data = $DBRESULT->fetchRow(); $i++) {
         if (!$centreon->user->admin && !isset($allowedAclGroups[$data['acl_group_id']])) {
-            $initialValues['contact_acl_groups'] = $data['acl_group_id'];
+            $initialValues['contact_acl_groups'][] = $data['acl_group_id'];
         } else {
             $cct["contact_acl_groups"][$i] = $data["acl_group_id"];
         }


### PR DESCRIPTION
## Description

When editing contact while being connected with non-admin user, acl groups not common between contact and connected user where lost

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create an Access Group “ALL-access-except-ACL-edition” (with a Resource Access and a Action Access)
2. Create a Menus Access “ALL-except-ACL” and link it to “ALL-access-except-ACL-edition” access group
![image](https://user-images.githubusercontent.com/88387848/153595582-c97932c1-a433-413e-988f-79325cab5709.png)
3. Create a contact ContactEditor and link it to “ALL-access-except-ACL-edition” access group
4. Create an Access Group “GroupTest” (with a Resource Access, a Menus Access and a Action Access)
5. Create a contact ContactTest and link it to “GroupTest” and “ALL-access-except-ACL-edition” access groups
6. Connect to the GUI with ContactEditor 
7. Edit the configuration of ContactTestcontact (for example change its password) and save the form
Received result
The contact ContactTest isn’t linked to any access group
Expected result
The contact ContactTest is still linked to “GroupTest” and “ALL-access-except-ACL-edition” access groups

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
