### PR TITLE
inversing colors in widget tabs to be blue as active and white as pas…

### DIFF
--- a/www/Themes/Centreon-Light/variables.css
+++ b/www/Themes/Centreon-Light/variables.css
@@ -1,1 +1,10 @@
 @import "../Generic-theme/Variables-css/variables.css";
+
+:root {
+    --ui-tabs-nav-li-anchor-background-color: #fff;
+    --ui-anchor-state-default-font-color: #00a499;
+    --global-view-ui-active-tabs-border-color: #fff;
+    --ui-anchor-state-active-visited-font-color: #fff;
+    --ui-state-processing-anchor-background-color: #009fdf;
+    --global-view-ui-border-color: #00a499;
+}


### PR DESCRIPTION
## Description
Inversing widget color tabs to be blue as active and white as passive.

**Fixes** # MON-12370

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
