### PR TITLE
enh(API): Interfaces for renew password use case

### DIFF
--- a/config/routes/Centreon/security/authentication.yaml
+++ b/config/routes/Centreon/security/authentication.yaml
@@ -12,3 +12,8 @@ centreon_application_authentication_logout:
     methods: POST
     path: /authentication/logout
     controller: 'Core\Infrastructure\Security\Api\LogoutSession\LogoutSessionController'
+
+centreon_security__renew_user_password:
+    methods: PUT
+    path: /authentication/users/{alias}/password
+    controller: 'Core\Infrastructure\Security\Api\RenewPasswordController'

--- a/src/Core/Application/Common/UseCase/NotFoundResponse.php
+++ b/src/Core/Application/Common/UseCase/NotFoundResponse.php
@@ -25,7 +25,7 @@ namespace Core\Application\Common\UseCase;
 
 use Core\Application\Common\UseCase\ResponseStatusInterface;
 
-abstract class NotFoundResponse implements ResponseStatusInterface
+class NotFoundResponse implements ResponseStatusInterface
 {
     /**
      * @param string $objectNotFound

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPassword.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPassword.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPassword.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPassword.php
@@ -58,6 +58,7 @@ class RenewPassword
             $presenter->setResponseStatus(new ErrorResponse('Invalid credentials'));
             return;
         }
+        //@Todo: Check that new password follow the security policy.
 
         $newPassword = password_hash($renewPasswordRequest->newPassword, \CentreonAuth::PASSWORD_HASH_ALGORITHM);
         $user->setPassword($newPassword);

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPassword.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPassword.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Security\UseCase\RenewPassword;
+
+class RenewPassword
+{
+    public function __construct(
+        ReadContactRepositoryInterface $readRepository,
+        WriteContactRepositoryInterface $writeRepository
+    ) {
+
+    }
+
+    public function __invoke(RenewPasswordPresenterInterface $presenter, RenewPasswordRequest $renewPasswordRequest)
+    {
+
+    }
+}

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordPresenterInterface.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordPresenterInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordPresenterInterface.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordPresenterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Security\UseCase\RenewPassword;
+
+use Core\Application\Common\UseCase\PresenterInterface;
+
+interface RenewPasswordPresenterInterface extends PresenterInterface
+{
+    /**
+     * Present no content.
+     */
+    public function present(): void;
+}

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordRequest.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordRequest.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Security\UseCase\RenewPassword;
+
+class RenewPasswordRequest
+{
+    /**
+     * @var string
+     */
+    public string $oldPassword;
+
+    /**
+     * @var string
+     */
+    public string $newPassword;
+}

--- a/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordRequest.php
+++ b/src/Core/Application/Security/UseCase/RenewPassword/RenewPasswordRequest.php
@@ -28,6 +28,11 @@ class RenewPasswordRequest
     /**
      * @var string
      */
+    public string $userAlias;
+
+    /**
+     * @var string
+     */
     public string $oldPassword;
 
     /**

--- a/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Core\Application\User\Repository;
+
+use Core\Domain\User\Model\User;
+
+interface ReadUserRepositoryInterface
+{
+    /**
+     * Find a user with his alias.
+     *
+     * @return User|null
+     */
+    public function findUserByAlias(): ?User;
+}

--- a/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
@@ -7,9 +7,10 @@ use Core\Domain\User\Model\User;
 interface ReadUserRepositoryInterface
 {
     /**
-     * Find a user with his alias.
+     * Find a user by his alias.
      *
+     * @param string $alias
      * @return User|null
      */
-    public function findUserByAlias(): ?User;
+    public function findUserByAlias(string $alias): ?User;
 }

--- a/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/ReadUserRepositoryInterface.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
 namespace Core\Application\User\Repository;
 
 use Core\Domain\User\Model\User;

--- a/src/Core/Application/User/Repository/WriteUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/WriteUserRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Core\Application\User\Repository;
+
+use Core\Domain\User\Model\User;
+
+interface WriteUserRepositoryInterface
+{
+    /**
+     * Renew password of user.
+     *
+     * @param User $user
+     */
+    public function renewPassword(User $user): void;
+}

--- a/src/Core/Application/User/Repository/WriteUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/WriteUserRepositoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Application/User/Repository/WriteUserRepositoryInterface.php
+++ b/src/Core/Application/User/Repository/WriteUserRepositoryInterface.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
 namespace Core\Application\User\Repository;
 
 use Core\Domain\User\Model\User;

--- a/src/Core/Domain/User/Model/User.php
+++ b/src/Core/Domain/User/Model/User.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Domain/User/Model/User.php
+++ b/src/Core/Domain/User/Model/User.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
 namespace Core\Domain\User\Model;
 
 class User

--- a/src/Core/Domain/User/Model/User.php
+++ b/src/Core/Domain/User/Model/User.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Core\Domain\User\Model;
+
+class User
+{
+    /**
+     * @param integer $id
+     * @param string $alias
+     * @param string $password
+     */
+    public function __construct(private int $id, private string $alias, private string $password)
+    {
+    }
+
+    /**
+     * @return integer
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     * @return self
+     */
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+        return $this;
+    }
+}

--- a/src/Core/Infrastructure/Security/Api/Exception/RenewPasswordApiException.php
+++ b/src/Core/Infrastructure/Security/Api/Exception/RenewPasswordApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Core\Infrastructure\Security\Api\Exception;
+
+class RenewPasswordApiException extends \Exception
+{
+}

--- a/src/Core/Infrastructure/Security/Api/Exception/RenewPasswordApiException.php
+++ b/src/Core/Infrastructure/Security/Api/Exception/RenewPasswordApiException.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
 namespace Core\Infrastructure\Security\Api\Exception;
 
 class RenewPasswordApiException extends \Exception

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Security\Api\RenewPassword;
+
+use JsonSchema\Validator;
+use JsonSchema\Constraints\Constraint;
+use Symfony\Component\HttpFoundation\Request;
+use Centreon\Application\Controller\AbstractController;
+use Core\Application\Security\UseCase\RenewPassword\RenewPassword;
+use Core\Application\Security\UseCase\RenewPassword\RenewPasswordRequest;
+use Core\Infrastructure\Security\Api\Exception\RenewPasswordApiException;
+use Core\Application\Security\UseCase\RenewPassword\RenewPasswordPresenterInterface;
+
+class RenewPasswordController extends AbstractController
+{
+    /**
+     * @param RenewPassword $useCase
+     * @param Request $request
+     * @param RenewPasswordPresenterInterface $presenter
+     * @return object
+     */
+    public function __invoke(
+        RenewPassword $useCase,
+        Request $request,
+        RenewPasswordPresenterInterface $presenter
+    ): object {
+        $this->validateDataSent($request, __DIR__ . '/RenewPasswordSchema.json');
+        $renewPasswordRequest = $this->createRenewPasswordRequest($request);
+        $useCase($presenter, $renewPasswordRequest);
+        return $presenter->show();
+    }
+
+    /**
+     * Validate the data sent.
+     *
+     * @param Request $request Request sent by client
+     * @param string $jsonValidationFile Json validation file
+     * @throws \Exception
+     */
+    private function validateDataSent(Request $request, string $jsonValidationFile): void
+    {
+        $receivedData = json_decode((string) $request->getContent(), true);
+        if (!is_array($receivedData)) {
+            throw new RenewPasswordApiException('Error when decoding your sent data');
+        }
+        $receivedData = Validator::arrayToObjectRecursive($receivedData);
+        $validator = new Validator();
+        $validator->validate(
+            $receivedData,
+            (object) [
+                '$ref' => 'file://' . realpath(
+                    $jsonValidationFile
+                )
+            ],
+            Constraint::CHECK_MODE_VALIDATE_SCHEMA
+        );
+
+        if (!$validator->isValid()) {
+            $message = '';
+            foreach ($validator->getErrors() as $error) {
+                $message .= sprintf("[%s] %s\n", $error['property'], $error['message']);
+            }
+            throw new RenewPasswordApiException($message);
+        }
+    }
+
+    /**
+     * @param Request $request
+     * @return RenewPasswordRequest
+     */
+    private function createRenewPasswordRequest(Request $request): RenewPasswordRequest
+    {
+        $requestData = json_decode((string) $request->getContent(), true);
+        $renewPasswordRequest = new RenewPasswordRequest();
+        $renewPasswordRequest->oldPassword = $requestData['old_password'];
+        $renewPasswordRequest->newPassword = $requestData['new_password'];
+
+        return $renewPasswordRequest;
+    }
+}

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
@@ -43,10 +43,11 @@ class RenewPasswordController extends AbstractController
     public function __invoke(
         RenewPassword $useCase,
         Request $request,
-        RenewPasswordPresenterInterface $presenter
+        RenewPasswordPresenterInterface $presenter,
+        string $alias
     ): object {
         $this->validateDataSent($request, __DIR__ . '/RenewPasswordSchema.json');
-        $renewPasswordRequest = $this->createRenewPasswordRequest($request);
+        $renewPasswordRequest = $this->createRenewPasswordRequest($request, $alias);
         $useCase($presenter, $renewPasswordRequest);
         return $presenter->show();
     }
@@ -56,7 +57,7 @@ class RenewPasswordController extends AbstractController
      *
      * @param Request $request Request sent by client
      * @param string $jsonValidationFile Json validation file
-     * @throws \Exception
+     * @throws RenewPasswordApiException
      */
     private function validateDataSent(Request $request, string $jsonValidationFile): void
     {
@@ -89,10 +90,11 @@ class RenewPasswordController extends AbstractController
      * @param Request $request
      * @return RenewPasswordRequest
      */
-    private function createRenewPasswordRequest(Request $request): RenewPasswordRequest
+    private function createRenewPasswordRequest(Request $request, string $userAlias): RenewPasswordRequest
     {
         $requestData = json_decode((string) $request->getContent(), true);
         $renewPasswordRequest = new RenewPasswordRequest();
+        $renewPasswordRequest->userAlias = $userAlias;
         $renewPasswordRequest->oldPassword = $requestData['old_password'];
         $renewPasswordRequest->newPassword = $requestData['new_password'];
 

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
@@ -38,6 +38,7 @@ class RenewPasswordController extends AbstractController
      * @param RenewPassword $useCase
      * @param Request $request
      * @param RenewPasswordPresenterInterface $presenter
+     * @param string $alias
      * @return object
      */
     public function __invoke(

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordController.php
@@ -89,6 +89,7 @@ class RenewPasswordController extends AbstractController
 
     /**
      * @param Request $request
+     * @param string $userAlias
      * @return RenewPasswordRequest
      */
     private function createRenewPasswordRequest(Request $request, string $userAlias): RenewPasswordRequest

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordSchema.json
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordSchema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Update local provider configuration",
+    "type": "object",
+    "required": [
+        "old_password",
+        "new_password"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "old_password": {
+            "type": "string"
+        },
+        "new_password": {
+            "type": "string"
+        }
+    }
+}

--- a/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordSchema.json
+++ b/src/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordSchema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Update local provider configuration",
+    "title": "Update Password for user",
     "type": "object",
     "required": [
         "old_password",

--- a/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
+++ b/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Application\Security\UseCase\RenewPassword;
+
+use PHPUnit\Framework\TestCase;
+use Core\Domain\User\Model\User;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\User\Repository\ReadUserRepositoryInterface;
+use Core\Application\Security\UseCase\RenewPassword\RenewPassword;
+use Core\Application\User\Repository\WriteUserRepositoryInterface;
+use Core\Application\Security\UseCase\RenewPassword\RenewPasswordRequest;
+use Core\Application\Security\UseCase\RenewPassword\RenewPasswordPresenterInterface;
+
+class RenewPasswordTest extends TestCase
+{
+    /**
+     * @var ReadUserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $readRepository;
+
+    /**
+     * @var WriteUserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $writeRepository;
+
+    /**
+     * @var RenewPasswordPresenterInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $presenter;
+
+    public function setUp(): void
+    {
+        $this->readRepository = $this->createMock(ReadUserRepositoryInterface::class);
+        $this->writeRepository = $this->createMock(WriteUserRepositoryInterface::class);
+        $this->presenter = $this->createMock(RenewPasswordPresenterInterface::class);
+    }
+
+    public function testUseCaseWithNotFoundUser()
+    {
+        $request = new RenewPasswordRequest();
+        $request->userAlias = 'invalidUser';
+        $request->oldPassword = 'toto';
+        $request->newPassword = 'tata';
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findUserByAlias')
+            ->willReturn(null);
+
+        $this->presenter
+            ->expects($this->once())
+            ->method('setResponseStatus')
+            ->with(new NotFoundResponse('User'));
+
+        $useCase = new RenewPassword($this->readRepository, $this->writeRepository);
+
+        $useCase($this->presenter, $request);
+    }
+
+    public function testUseCaseWithInvalidPassword()
+    {
+        $request = new RenewPasswordRequest();
+        $request->userAlias = 'admin';
+        $request->oldPassword = 'toto';
+        $request->newPassword = 'tata';
+
+        $password = password_hash('titi', \CentreonAuth::PASSWORD_HASH_ALGORITHM);
+        $user = new User(1, 'admin', $password);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findUserByAlias')
+            ->willReturn($user);
+
+        $this->presenter
+            ->expects($this->once())
+            ->method('setResponseStatus')
+            ->with(new ErrorResponse('Invalid credentials'));
+
+        $useCase = new RenewPassword($this->readRepository, $this->writeRepository);
+
+        $useCase($this->presenter, $request);
+    }
+
+    public function testUseCaseWithValidParameters()
+    {
+        $request = new RenewPasswordRequest();
+        $request->userAlias = 'admin';
+        $request->oldPassword = 'toto';
+        $request->newPassword = 'tata';
+
+        $password = password_hash('toto', \CentreonAuth::PASSWORD_HASH_ALGORITHM);
+        $user = new User(1, 'admin', $password);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findUserByAlias')
+            ->willReturn($user);
+
+        $this->writeRepository
+            ->expects($this->once())
+            ->method('renewPassword');
+
+        $this->presenter
+            ->expects($this->once())
+            ->method('setResponseStatus')
+            ->with(new NoContentResponse());
+
+        $useCase = new RenewPassword($this->readRepository, $this->writeRepository);
+
+        $useCase($this->presenter, $request);
+    }
+}

--- a/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
+++ b/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
+++ b/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
@@ -60,8 +60,6 @@ class RenewPasswordTest extends TestCase
 
     /**
      * Test that a NotFoundResponse is set when the user is not found.
-     *
-     * @return void
      */
     public function testUseCaseWithNotFoundUser()
     {
@@ -87,8 +85,6 @@ class RenewPasswordTest extends TestCase
 
     /**
      * Test that an ErrorResponse is set when the password is invalid.
-     *
-     * @return void
      */
     public function testUseCaseWithInvalidPassword()
     {
@@ -117,8 +113,6 @@ class RenewPasswordTest extends TestCase
 
     /**
      * Test that a no content response is set if everything goes well.
-     *
-     * @return void
      */
     public function testUseCaseWithValidParameters()
     {

--- a/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
+++ b/tests/php/Core/Application/Security/UseCase/RenewPassword/RenewPasswordTest.php
@@ -58,6 +58,11 @@ class RenewPasswordTest extends TestCase
         $this->presenter = $this->createMock(RenewPasswordPresenterInterface::class);
     }
 
+    /**
+     * Test that a NotFoundResponse is set when the user is not found.
+     *
+     * @return void
+     */
     public function testUseCaseWithNotFoundUser()
     {
         $request = new RenewPasswordRequest();
@@ -80,6 +85,11 @@ class RenewPasswordTest extends TestCase
         $useCase($this->presenter, $request);
     }
 
+    /**
+     * Test that an ErrorResponse is set when the password is invalid.
+     *
+     * @return void
+     */
     public function testUseCaseWithInvalidPassword()
     {
         $request = new RenewPasswordRequest();
@@ -105,6 +115,11 @@ class RenewPasswordTest extends TestCase
         $useCase($this->presenter, $request);
     }
 
+    /**
+     * Test that a no content response is set if everything goes well.
+     *
+     * @return void
+     */
     public function testUseCaseWithValidParameters()
     {
         $request = new RenewPasswordRequest();

--- a/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
+++ b/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
+++ b/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
@@ -33,6 +33,9 @@ class RenewPasswordControllerTest extends TestCase
         $this->presenter = $this->createMock(RenewPasswordPresenterInterface::class);
     }
 
+    /**
+     * Test that an exception is thrown is the received payload is invalid.
+     */
     public function testExceptionIsThrownWithInvalidPayload()
     {
         $controller = new RenewPasswordController();

--- a/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
+++ b/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Infrastructure\Security\Api\RenewPassword;
+
+use Core\Application\Security\UseCase\RenewPassword\RenewPassword;
+use Core\Application\Security\UseCase\RenewPassword\RenewPasswordPresenterInterface;
+use Core\Infrastructure\Security\Api\Exception\RenewPasswordApiException;
+use Core\Infrastructure\Security\Api\RenewPassword\RenewPasswordController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class RenewPasswordControllerTest extends TestCase
+{
+    /**
+     * @var RenewPassword&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $useCase;
+
+    /**
+     * @var Request&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $request;
+
+    /**
+     * @var RenewPasswordPresenterInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $presenter;
+
+    public function setUp(): void
+    {
+        $this->useCase = $this->createMock(RenewPassword::class);
+        $this->request = $this->createMock(Request::class);
+        $this->presenter = $this->createMock(RenewPasswordPresenterInterface::class);
+    }
+
+    public function testExceptionIsThrownWithInvalidPayload()
+    {
+        $controller = new RenewPasswordController();
+
+        $invalidPayload = json_encode([
+            'old_password' => 'titi'
+        ]);
+        $this->request
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn($invalidPayload);
+
+        $this->expectException(RenewPasswordApiException::class);
+        $controller($this->useCase, $this->request, $this->presenter, 'admin');
+    }
+}

--- a/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
+++ b/tests/php/Core/Infrastructure/Security/Api/RenewPassword/RenewPasswordControllerTest.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
 namespace Tests\Infrastructure\Security\Api\RenewPassword;
 
 use Core\Application\Security\UseCase\RenewPassword\RenewPassword;


### PR DESCRIPTION
## Description

This PR intends to add interfaces for renew password use case

**Fixes** # MON-12290

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [] I have made corresponding changes to the **documentation**.
- [] I have **rebased** my development branch on the base branch (master, maintenance).
