### PR TITLE
fix(macros): Add update script to clean host macros duplicated

### DIFF
--- a/www/install/php/Update-21.10.4.php
+++ b/www/install/php/Update-21.10.4.php
@@ -42,7 +42,14 @@ try {
 
     $errorMessage  = 'Unable to delete logger entry in cb_tag';
     $statement = $pearDB->query("DELETE FROM cb_tag WHERE tagname = 'logger'");
+    $pearDB->commit();
 
+    $errorMessage = 'Cannot purge host macros';
+    $cache = loadHosts($pearDB);
+    $pearDB->beginTransaction();
+    foreach ($cache as $hostId => $value) {
+        cleanDuplicateHostMacros($pearDB, $centreonLog, $cache, (int) $hostId);
+    }
     $pearDB->commit();
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {
@@ -56,4 +63,102 @@ try {
         " - Trace : " . $e->getTraceAsString()
     );
     throw new \Exception($versionOfTheUpgrade . $errorMessage, (int)$e->getCode(), $e);
+}
+
+/**
+ * @param CentreonDb $db
+ * @return array<int, array<string, mixed>>
+ */
+function loadHosts(CentreonDb $db): array
+{
+    $stmt = $db->prepare('SELECT host_id, host_name FROM host');
+    $stmt->execute();
+    $cache = $stmt->fetchAll(PDO::FETCH_GROUP | PDO::FETCH_UNIQUE | PDO::FETCH_ASSOC);
+
+    $stmt = $db->prepare(
+        'SELECT host_host_id, host_tpl_id 
+         FROM host_template_relation ORDER BY `host_host_id`, `order` ASC'
+    );
+    $stmt->execute();
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $cache[$row['host_host_id']]['htpl'][] = $row['host_tpl_id'];
+    }
+
+    $stmt = $db->prepare(
+        'SELECT host_macro_id, host_host_id, host_macro_name, host_macro_value
+        FROM on_demand_macro_host'
+    );
+    $stmt->execute();
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $cache[$row['host_host_id']]['macros'][$row['host_macro_name']] = $row;
+    }
+
+    return $cache;
+}
+
+/**
+ * @param CentreonDb $db
+ * @param CentreonLog $centreonLog
+ * @param array<int, array<string, mixed>> $cache
+ * @param int $srcHostId
+ */
+function cleanDuplicateHostMacros(
+    CentreonDb $db,
+    CentreonLog $centreonLog,
+    array $cache,
+    int $srcHostId
+): void {
+    global $versionOfTheUpgrade;
+
+    if (!isset($cache[$srcHostId]['htpl']) || !isset($cache[$srcHostId]['macros'])) {
+        return ;
+    }
+
+    $loop = [];
+    $stack = [];
+
+    $macros = $cache[$srcHostId]['macros'];
+    $stack = $cache[$srcHostId]['htpl'];
+    while (($hostId = array_shift($stack)) !== null) {
+        if (isset($loop[$hostId])) {
+            continue;
+        }
+        $loop[$hostId] = 1;
+
+        foreach ($macros as $macroName => $macro) {
+            if (isset($macro['checked']) && $macro['checked'] === 1) {
+                continue;
+            }
+
+            if (isset($cache[$hostId]['macros'][$macroName])) {
+                $macro['checked'] = 1;
+                if ($cache[$hostId]['macros'][$macroName]['host_macro_value'] === $macro['host_macro_value']) {
+                    $centreonLog->insertLog(
+                        4,
+                        $versionOfTheUpgrade . "host " . $cache[$hostId]['host_name'] . " delete macro " . $macroName
+                    );
+                    $db->query(
+                        'DELETE FROM on_demand_macro_host WHERE host_macro_id = ' . (int) $macro['host_macro_id']
+                    );
+                }
+            }
+        }
+
+        if (isset($cache[$hostId]['htpl'])) {
+            $stack = array_merge($cache[$hostId]['htpl'], $stack);
+        }
+    }
+
+    // clean empty macros with no macros inherited
+    foreach ($macros as $macroName => $macro) {
+        if (!isset($macro['checked']) && empty($macro['host_macro_value'])) {
+            $centreonLog->insertLog(
+                4,
+                $versionOfTheUpgrade . "host " . $cache[$srcHostId]['host_name'] . " delete macro " . $macroName
+            );
+            $db->query(
+                'DELETE FROM on_demand_macro_host WHERE host_macro_id = ' . (int) $macro['host_macro_id']
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Description

Since last 21.10.x version, hosts macros can be duplicated when you save the configuration.
Already done for develop: https://github.com/centreon/centreon/pull/10649

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

create host X with a host template Y with macros
modify host X
macros from host template Y are saved in host X

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
