### PR TITLE
fix(security): list only local users for password expiration policy

### DIFF
--- a/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
+++ b/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
@@ -67,7 +67,7 @@ class DbReadUserRepository extends AbstractRepositoryDRB implements ReadUserRepo
         // Search
         $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
         $request .= $searchRequest !== null ? $searchRequest . ' AND ' : ' WHERE ';
-        $request .= "contact_register = 1";
+        $request .= 'contact_register = 1';
 
         // Sort
         $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();

--- a/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
+++ b/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
@@ -48,6 +48,7 @@ class DbReadUserRepository extends AbstractRepositoryDRB implements ReadUserRepo
             'alias' => 'contact_alias',
             'name' => 'contact_name',
             'email' => 'contact_email',
+            'provider_name' => 'contact_auth_type',
         ]);
     }
 
@@ -66,7 +67,7 @@ class DbReadUserRepository extends AbstractRepositoryDRB implements ReadUserRepo
         // Search
         $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
         $request .= $searchRequest !== null ? $searchRequest . ' AND ' : ' WHERE ';
-        $request .= 'contact_register = 1';
+        $request .= "contact_register = 1";
 
         // Sort
         $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();

--- a/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/PasswordExpiration/ExcludedUsers.tsx
+++ b/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/PasswordExpiration/ExcludedUsers.tsx
@@ -46,17 +46,23 @@ const ExcludedUsers = (): JSX.Element => {
   const { t } = useTranslation();
   const { values, setFieldValue } = useFormikContext<FormikValues>();
 
-  const getEndpoint = (parameters): string =>
+  const getEndpoint = ({ search, ...parameters }): string =>
     buildListingEndpoint({
       baseEndpoint: contactsEndpoint,
       parameters: {
         ...parameters,
         search: {
-          regex: {
-            fields: ['provider_name'],
-            value: '^local$',
-          },
+          conditions: [
+            {
+              field: 'provider_name',
+              values: {
+                $eq: 'local',
+              },
+            },
+            ...(search?.conditions || []),
+          ].filter(Boolean),
         },
+        sort: { alias: 'ASC' },
       },
     });
 

--- a/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/PasswordExpiration/ExcludedUsers.tsx
+++ b/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/PasswordExpiration/ExcludedUsers.tsx
@@ -49,7 +49,15 @@ const ExcludedUsers = (): JSX.Element => {
   const getEndpoint = (parameters): string =>
     buildListingEndpoint({
       baseEndpoint: contactsEndpoint,
-      parameters,
+      parameters: {
+        ...parameters,
+        search: {
+          regex: {
+            fields: ['provider_name'],
+            value: '^local$',
+          },
+        },
+      },
     });
 
   const getRenderedOptionText = React.useCallback((option): JSX.Element => {

--- a/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/index.test.tsx
+++ b/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/index.test.tsx
@@ -246,7 +246,15 @@ describe('Password expiration policy', () => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         buildListingEndpoint({
           baseEndpoint: contactsEndpoint,
-          parameters: { page: 1 },
+          parameters: {
+            page: 1,
+            search: {
+              regex: {
+                fields: ['provider_name'],
+                value: '^local$',
+              },
+            },
+          },
         }),
         cancelTokenRequestParam,
       );

--- a/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/index.test.tsx
+++ b/www/front_src/src/Authentication/Form/PasswordExpirationPolicy/index.test.tsx
@@ -249,11 +249,16 @@ describe('Password expiration policy', () => {
           parameters: {
             page: 1,
             search: {
-              regex: {
-                fields: ['provider_name'],
-                value: '^local$',
-              },
+              conditions: [
+                {
+                  field: 'provider_name',
+                  values: {
+                    $eq: 'local',
+                  },
+                },
+              ].filter(Boolean),
             },
+            sort: { alias: 'ASC' },
           },
         }),
         cancelTokenRequestParam,


### PR DESCRIPTION
## Description

list only local users for password expiration policy

**Fixes** MON-12040

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)