### PR TITLE
Fix(UI): Fix UTC timezone

### DIFF
--- a/www/front_src/src/Resources/useDateTimePickerAdapter.ts
+++ b/www/front_src/src/Resources/useDateTimePickerAdapter.ts
@@ -97,8 +97,35 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
       return date.tz(timezone).startOf('day') as dayjs.Dayjs;
     };
 
+    public startOfMonth = (date: dayjs.Dayjs): dayjs.Dayjs => {
+      return date.tz(timezone).endOf('month') as dayjs.Dayjs;
+    };
+
+    public endOfMonth = (date: dayjs.Dayjs): dayjs.Dayjs => {
+      return date.tz(timezone).endOf('month') as dayjs.Dayjs;
+    };
+
+    public isSameMonth = (
+      date: dayjs.Dayjs,
+      comparing: dayjs.Dayjs,
+    ): boolean => {
+      return date.tz(timezone).isSame(comparing.tz(timezone), 'month');
+    };
+
+    public getMonth = (date: dayjs.Dayjs): number => {
+      return date.tz(timezone).month();
+    };
+
     public getDaysInMonth = (date: dayjs.Dayjs): number => {
       return date.tz(timezone).daysInMonth();
+    };
+
+    public getWeekdays = (): Array<string> => {
+      const start = dayjs().locale(locale).tz(timezone).startOf('week');
+
+      return [0, 1, 2, 3, 4, 5, 6].map((diff) =>
+        this.formatByString(start.add(diff, 'day'), 'dd'),
+      );
     };
 
     public mergeDateAndTime = (
@@ -110,9 +137,9 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
 
       if (equals(timezone, 'UTC')) {
         return dateWithTimezone
-          .hour(timeWithTimezone.hour() - getLocalAndConfiguredTimezoneOffset())
-          .minute(timeWithTimezone.minute())
-          .second(timeWithTimezone.second());
+          .add(timeWithTimezone.hour(), 'hour')
+          .add(timeWithTimezone.minute(), 'minute')
+          .add(timeWithTimezone.second(), 'second');
       }
 
       return dateWithTimezone


### PR DESCRIPTION
## Description

This fixes the day selection when the user uses the UTC timezone.


NOTE: I'm pretty confident about the fix on 22.04 but we need to try it on 21.10 because we have changed the Material UI version and the date time picker library.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Change the user timezone to 'UTC'
- Go to Resource Status
- Add a downtime on a resource
- Open the date time picker
- -> The correct date and month are displayed
- Change the date
- -> The date is correctly updated
- Change hours and minutes
- -> The date is correctly updated 

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
