### PR TITLE
Fix(UI): Fix all timezones

### DIFF
--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -463,8 +463,13 @@ describe(Actions, () => {
   });
 
   it('cannot send a downtime request when the Downtime action is clicked and the input dates have an invalid format', async () => {
-    const { getByLabelText, getAllByText, findByText, getByText } =
-      renderActions();
+    const {
+      getByLabelText,
+      getAllByText,
+      findByText,
+      getByText,
+      findAllByText,
+    } = renderActions();
 
     const selectedResources = [host];
 
@@ -472,21 +477,23 @@ describe(Actions, () => {
       context.setSelectedResources?.(selectedResources);
     });
 
+    await findAllByText(labelSetDowntime);
+
     fireEvent.click(head(getAllByText(labelSetDowntime)) as HTMLElement);
 
     await findByText(labelDowntimeByAdmin);
 
-    userEvent.type(getByLabelText(labelStartTime), 'l');
+    userEvent.type(getByLabelText(labelStartTime), '{backspace}l');
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(
         last(getAllByText(labelSetDowntime)) as HTMLElement,
-      ).toBeDisabled(),
-    );
+      ).toBeDisabled();
+    });
 
     expect(getByText(labelInvalidFormat)).toBeInTheDocument();
 
-    userEvent.type(getByLabelText(labelStartTime), '{backspace}');
+    userEvent.type(getByLabelText(labelStartTime), '{backspace}M');
 
     await waitFor(() =>
       expect(last(getAllByText(labelSetDowntime)) as HTMLElement).toBeEnabled(),

--- a/www/front_src/src/Resources/useDateTimePickerAdapter.ts
+++ b/www/front_src/src/Resources/useDateTimePickerAdapter.ts
@@ -48,9 +48,11 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
     return newValue;
   };
 
+  const isUTCTimezone = equals('UTC');
+
   class Adapter extends DayjsAdapter {
     public formatByString = (value, formatKey: string): string => {
-      return format({ date: value, formatString: formatKey });
+      return format({ date: value.tz(timezone), formatString: formatKey });
     };
 
     public isEqual = (value, comparing): boolean => {
@@ -59,13 +61,17 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
       }
 
       return equals(
-        format({ date: value, formatString: 'LT' }),
-        format({ date: comparing, formatString: 'LT' }),
+        format({ date: value.tz(timezone), formatString: 'LT' }),
+        format({ date: comparing.tz(timezone), formatString: 'LT' }),
       );
     };
 
     public getHours = (date): number => {
-      return date.tz(timezone).get('hour');
+      if (isUTCTimezone(timezone)) {
+        return date.tz(timezone).get('hour');
+      }
+
+      return date.tz(timezone).clone().get('hour');
     };
 
     public setHours = (date: dayjs.Dayjs, count: number): dayjs.Dayjs => {
@@ -86,15 +92,26 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
     };
 
     public isSameDay = (date: dayjs.Dayjs, comparing: dayjs.Dayjs): boolean => {
-      return date.tz(timezone).isSame(comparing.tz(timezone), 'day');
+      return equals(
+        this.startOfDay(date).get('date'),
+        this.startOfDay(comparing).get('date'),
+      );
     };
 
     public startOfDay = (date: dayjs.Dayjs): dayjs.Dayjs => {
-      return date.tz(timezone).startOf('day') as dayjs.Dayjs;
+      if (isUTCTimezone(timezone)) {
+        return date.tz(timezone).endOf('day');
+      }
+
+      return date.tz(timezone).clone().endOf('day') as dayjs.Dayjs;
     };
 
     public endOfDay = (date: dayjs.Dayjs): dayjs.Dayjs => {
-      return date.tz(timezone).startOf('day') as dayjs.Dayjs;
+      if (isUTCTimezone(timezone)) {
+        return date.tz(timezone).endOf('day');
+      }
+
+      return date.tz(timezone).clone().endOf('day') as dayjs.Dayjs;
     };
 
     public startOfMonth = (date: dayjs.Dayjs): dayjs.Dayjs => {
@@ -132,15 +149,18 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
       date: dayjs.Dayjs,
       time: dayjs.Dayjs,
     ): dayjs.Dayjs => {
-      const dateWithTimezone = date.tz(timezone);
-      const timeWithTimezone = time.tz(timezone);
+      if (isUTCTimezone(timezone)) {
+        const dateWithTimezone = date.tz(timezone);
+        const timeWithTimezone = time.tz(timezone);
 
-      if (equals(timezone, 'UTC')) {
         return dateWithTimezone
           .add(timeWithTimezone.hour(), 'hour')
           .add(timeWithTimezone.minute(), 'minute')
           .add(timeWithTimezone.second(), 'second');
       }
+
+      const dateWithTimezone = date.tz(timezone).clone();
+      const timeWithTimezone = time.tz(timezone).clone();
 
       return dateWithTimezone
         .hour(timeWithTimezone.hour())

--- a/www/front_src/src/Resources/useDateTimePickerAdapter.ts
+++ b/www/front_src/src/Resources/useDateTimePickerAdapter.ts
@@ -61,8 +61,8 @@ const useDateTimePickerAdapter = (): UseDateTimePickerAdapterProps => {
       }
 
       return equals(
-        format({ date: value.tz(timezone), formatString: 'LT' }),
-        format({ date: comparing.tz(timezone), formatString: 'LT' }),
+        format({ date: value, formatString: 'LT' }),
+        format({ date: comparing, formatString: 'LT' }),
       );
     };
 


### PR DESCRIPTION
## Description

This fixes all the wrong display due to timezones.

Tested with the following timezones:
- Europe/Paris
- Europe/Helsinki
- Europe/London
- UTC
- Asia/Chita
- Australia/Sydney
- Africa/Dakar
- Atlantic/Madeira
- Africa/Abidjan
- America/Vancouver
- Asia/Kabul

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Change the timezone on your account
- Go to Resources Status
- Add a downtime
- Change the start date
- -> The correct date and hour are displayed following your timezone

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
