### PR TITLE
fix(login) : fix first ldap authentification error

### DIFF
--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -213,6 +213,16 @@ class CentreonAuth
                 } elseif ($this->passwdOk == 1) {
                     if (isset($this->ldap_store_password[$arId]) && $this->ldap_store_password[$arId]) {
                         if (!isset($this->userInfos["contact_passwd"])) {
+                            // Retrieving the created contact_id
+                            $res = $this->pearDB->prepare(
+                                "SELECT contact_id FROM contact
+                                WHERE ar_id = :arId"
+                            );
+                            $res->bindValue(':arId', $arId, \PDO::PARAM_STR);
+                            $res->execute();
+                            $row = $res->fetch();
+                            $this->userInfos['contact_id'] = $row['contact_id'];
+
                             $hashedPassword = password_hash($this->password, self::PASSWORD_HASH_ALGORITHM);
                             $contact = new \CentreonContact($this->pearDB);
                             $contact->addPasswordByContactId(

--- a/www/class/centreonContact.class.php
+++ b/www/class/centreonContact.class.php
@@ -252,6 +252,31 @@ class CentreonContact
     }
 
     /**
+     * Find contact id from alias
+     *
+     * @param string $alias
+     * @return int|null
+     */
+    public function findContactIdByAlias(string $alias): ?int
+    {
+        $contactId = null;
+
+        $statement = $this->db->prepare(
+            "SELECT contact_id
+            FROM contact
+            WHERE contact_alias = :contactAlias"
+        );
+        $statement->bindValue(':contactAlias', $alias, \PDO::PARAM_STR);
+        $statement->execute();
+
+        if ($row = $statement->fetch()) {
+            $contactId = (int) $row['contact_id'];
+        }
+
+        return $contactId;
+    }
+
+    /**
      * Get password security policy
      *
      * @return array<string,mixed>

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -590,6 +590,7 @@ class CentreonLDAP
             $this->debug("LDAP Search : " . (isset($numberReturned) ? $numberReturned : "0") . " entries found");
         } else {
             $this->debug("LDAP Search : cannot retrieve entries");
+            return [];
         }
 
 

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -585,8 +585,13 @@ class CentreonLDAP
         $sr = ldap_search($this->ds, $basedn, $filter, $attr, 0, $searchLimit, $searchTimeout);
 
         /* Sort */
-        $number_returned = ldap_count_entries($this->ds, $sr);
-        $this->debug("LDAP Search : " . (isset($number_returned) ? $number_returned : "0") . " entries found");
+        if ($sr !== false) {
+            $number_returned = ldap_count_entries($this->ds, $sr);
+            $this->debug("LDAP Search : " . (isset($number_returned) ? $number_returned : "0") . " entries found");
+        } else {
+            $this->debug("LDAP Search : no entries found");
+        }
+
 
         $info = ldap_get_entries($this->ds, $sr);
         $this->debug("LDAP Search : " . $info["count"]);

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -599,9 +599,9 @@ class CentreonLDAP
         ldap_free_result($sr);
 
         /* Format the result */
-        $results = array();
+        $results = [];
         for ($i = 0; $i < $info['count']; $i++) {
-            $result = array();
+            $result = [];
             $result['dn'] = $info[$i]['dn'] ?? "";
             $result['alias'] = $info[$i][$this->userSearchInfo['alias']][0] ?? "";
             $result['name'] = $info[$i][$this->userSearchInfo['name']][0] ?? "";

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -586,10 +586,10 @@ class CentreonLDAP
 
         /* Sort */
         if ($sr !== false) {
-            $number_returned = ldap_count_entries($this->ds, $sr);
-            $this->debug("LDAP Search : " . (isset($number_returned) ? $number_returned : "0") . " entries found");
+            $numberReturned = ldap_count_entries($this->ds, $sr);
+            $this->debug("LDAP Search : " . (isset($numberReturned) ? $numberReturned : "0") . " entries found");
         } else {
-            $this->debug("LDAP Search : no entries found");
+            $this->debug("LDAP Search : cannot retrieve entries");
         }
 
 


### PR DESCRIPTION
## Description

**Fixes** MON-12438

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

* run : docker run -d -p 389 registry.centreon.com/mon-openldap-dataset:latest
* connect to centreon and enable "openldap" in Administration > Parameters > LDAP
* disconnect from centreon and reconnect with these credentials : login centreon-ldap100 / pass : centreon-ldap100
* check if there is any errors displayed in the login page and the files /var/log/php-fpm/centreon-error.log and /var/log/centreon/sql-error.log
