### PR TITLE
fix(ci) : replace file_get_content by curl to disable allow_url_fopen (22.04 to 20.10)

### DIFF
--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -91,7 +91,6 @@ function getWikiVersion($apiWikiURL)
     /* Get contents */
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
-    curl_setopt($curl, CURLOPT_POST, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_HTTPHEADER, json_encode($httpOpts));
     $content = curl_exec($curl);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -85,7 +85,7 @@ function getWikiVersion($apiWikiURL)
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_POST, true);
-    curl_setopt($curl, CURLOPT_HTTPHEADER, 'Content-type: application/x-www-form-urlencoded');
+    curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: application/x-www-form-urlencoded'));
     curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
     $content = curl_exec($curl);
     curl_close($curl);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -72,11 +72,11 @@ function getWikiVersion($apiWikiURL)
         return;
     }
 
-    $post = array(
+    $post = [
         'action' => 'query',
         'meta' => 'siteinfo',
         'format' => 'json',
-    );
+    ];
 
     $data = http_build_query($post);
 
@@ -85,7 +85,7 @@ function getWikiVersion($apiWikiURL)
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_POST, true);
-    curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: application/x-www-form-urlencoded'));
+    curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-type: application/x-www-form-urlencoded']);
     curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
     $content = curl_exec($curl);
     curl_close($curl);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -78,22 +78,13 @@ function getWikiVersion($apiWikiURL)
         'format' => 'json',
     );
 
-    $data = http_build_query($post);
-
-    $httpOpts = array(
-        'http' => array(
-            'method' => 'POST',
-            'header' => "Content-type: application/x-www-form-urlencoded",
-            'content' => $data,
-        )
-    );
-
     /* Get contents */
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_POST, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($curl, CURLOPT_HTTPHEADER, $httpOpts);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-type: application/json']);
+    curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($post));
     $content = curl_exec($curl);
     curl_close($curl);
     $content = json_decode($content);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -80,19 +80,20 @@ function getWikiVersion($apiWikiURL)
 
     $data = http_build_query($post);
 
-    $httpOpts = array(
-        'http' => array(
-            'method' => 'POST',
-            'header' => "Content-type: application/x-www-form-urlencoded",
-            'content' => $data,
-        )
-    );
-
-    /* Create context */
-    $httpContext = stream_context_create($httpOpts);
+    $httpOpts = [
+        'method' => 'POST',
+        'header' => "Content-type: application/x-www-form-urlencoded",
+        'content' => $data,
+    ];
 
     /* Get contents */
-    $content = @file_get_contents($apiWikiURL, false, $httpContext);
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
+    curl_setopt($curl, CURLOPT_POST, true);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, $httpOpts);
+    $content = curl_exec($curl);
+    curl_close($curl);
     $content = json_decode($content);
 
     $wikiStringVersion = $content->query->general->generator;

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -80,17 +80,18 @@ function getWikiVersion($apiWikiURL)
 
     $data = http_build_query($post);
 
-    $httpOpts = [
-        'method' => 'POST',
-        'header' => "Content-type: application/x-www-form-urlencoded",
-        'content' => $data,
-    ];
+    $httpOpts = array(
+        'http' => array(
+            'method' => 'POST',
+            'header' => "Content-type: application/x-www-form-urlencoded",
+            'content' => $data,
+        )
+    );
 
     /* Get contents */
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_POST, true);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, $httpOpts);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_HTTPHEADER, $httpOpts);
     $content = curl_exec($curl);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -90,6 +90,7 @@ function getWikiVersion($apiWikiURL)
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_POST, true);
+    curl_setopt($curl, CURLOPT_POSTFIELDS, $httpOpts);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_HTTPHEADER, $httpOpts);
     $content = curl_exec($curl);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -78,13 +78,22 @@ function getWikiVersion($apiWikiURL)
         'format' => 'json',
     );
 
+    $data = http_build_query($post);
+
+    $httpOpts = array(
+        'http' => array(
+            'method' => 'POST',
+            'header' => "Content-type: application/x-www-form-urlencoded",
+            'content' => $data,
+        )
+    );
+
     /* Get contents */
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_POST, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-type: application/json']);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($post));
+    curl_setopt($curl, CURLOPT_HTTPHEADER, json_encode($httpOpts));
     $content = curl_exec($curl);
     curl_close($curl);
     $content = json_decode($content);

--- a/www/include/configuration/configKnowledge/functions.php
+++ b/www/include/configuration/configKnowledge/functions.php
@@ -80,19 +80,13 @@ function getWikiVersion($apiWikiURL)
 
     $data = http_build_query($post);
 
-    $httpOpts = array(
-        'http' => array(
-            'method' => 'POST',
-            'header' => "Content-type: application/x-www-form-urlencoded",
-            'content' => $data,
-        )
-    );
-
     /* Get contents */
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $apiWikiURL);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($curl, CURLOPT_HTTPHEADER, json_encode($httpOpts));
+    curl_setopt($curl, CURLOPT_POST, true);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, 'Content-type: application/x-www-form-urlencoded');
+    curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
     $content = curl_exec($curl);
     curl_close($curl);
     $content = json_decode($content);


### PR DESCRIPTION
## Description

**Fixes** MON-12055

Related to [this ticket](https://centreon.atlassian.net/jira/software/c/projects/MON/boards/113?modal=detail&selectedIssue=MON-12055&sprint=662)
This PR means to avoid some errors when we want to get informations from a endpoint with php configuration allow_url_fopen set to off

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Just see if the ci run well after [this modification](https://centreon.atlassian.net/jira/software/c/projects/MON/boards/113?modal=detail&selectedIssue=MON-12055&sprint=662) on centreon-build
