### PR TITLE
enh(ui): adapt Select2 component to dark mode

### DIFF
--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -48,4 +48,14 @@
     --option-color:  #fff;
     --form-table-list-header-h3-font-color: #00bfb3;
     --info-box-h4-font-color: #fff;
+    --select2-container-selection-multiple-background-color: var(--body-background);
+    --selected2-results-header-background-color: var(--body-background);
+    --select2-results-header-color: #2196F3;
+    --placeholder-font-color: var(--body-color);
+    --select2-dropdown-border-color: var(--body-background);
+    --select2-result-option-highlighted-aria-selected-true-background-color: #2196F3;
+    --select2-results-background-color: var(--body-background);
+    --select2-results-option-font-color: #fff;
+    --select2-results-option-highlighted-color: #fff;
+    --selected2-results-header-border-bottom-color: var(--body-color);
 }

--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -53,9 +53,15 @@
     --select2-results-header-color: #2196F3;
     --placeholder-font-color: var(--body-color);
     --select2-dropdown-border-color: var(--body-background);
-    --select2-result-option-highlighted-aria-selected-true-background-color: #2196F3;
+    --select2-result-option-highlighted-aria-selected-true-background-color: #10069f;
     --select2-results-background-color: var(--body-background);
     --select2-results-option-font-color: #fff;
     --select2-results-option-highlighted-color: #fff;
     --selected2-results-header-border-bottom-color: var(--body-color);
+    --select2-selection-multiple-color: var(--body-color);
+    --select2-selection-multiple-border-color: #181a1b;
+    --select2-results-option-highlighted-background-color: var(--body-color);
+    --select2-selection-multiple-content-background-color: var(--select2-selection-multiple-border-color);
+    --select2-selection-choice-remove-background-color: var(--select2-selection-multiple-border-color);
+    --select2-results-option-highlighted-color-aria-selected: #2196f3;
 }

--- a/www/Themes/Generic-theme/Variables-css/color-variables.css
+++ b/www/Themes/Generic-theme/Variables-css/color-variables.css
@@ -145,6 +145,7 @@
     --color-wewak: #f1a899;
     --color-dusty-gray: #999;
     --color-mariner: #3875d7;
+    --color-shark: #2a2d2f;
     --color-white-rgba-8 :rgba(240, 240, 240, 0.8);
     --color-white-rgba-5 :rgba(255, 255, 255, 0.5);
     --color-black-rgba-54 :rgba(0, 0, 0, 0.54);

--- a/www/Themes/Generic-theme/Variables-css/color-variables.css
+++ b/www/Themes/Generic-theme/Variables-css/color-variables.css
@@ -14,6 +14,7 @@
     --color-red: #ff0000;
     --color-orange: #FFA500;
     --color-gray: #808080;
+    --color-gray-2: #888;
     --color-very-light-grey: #CCC;
     --color-silver:#BBB;
     --color-silver-2: #c3c3c3;
@@ -108,8 +109,10 @@
     --color-tickle-me-pink: #F778A1;
     --color-olivine: #99C68E;
     --color-alabaster: #f9f9f9;
+    --color-alabaster-2: #f7f7f7;
     --color-mercury: #E6E6E6;
     --color-mercury-2: #e9e9e9;
+    --color-mercury-3: #e4e4e4;
     --color-super-nova: #F8C706;
     --color-mischka: #e0e0ea;
     --color-apple: #50ce36;
@@ -140,6 +143,8 @@
     --color-congo-brown: #5f3f3f;
     --color-cindrella: #fddfdf;
     --color-wewak: #f1a899;
+    --color-dusty-gray: #999;
+    --color-mariner: #3875d7;
     --color-white-rgba-8 :rgba(240, 240, 240, 0.8);
     --color-white-rgba-5 :rgba(255, 255, 255, 0.5);
     --color-black-rgba-54 :rgba(0, 0, 0, 0.54);

--- a/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/www/Themes/Generic-theme/Variables-css/variables.css
@@ -59,7 +59,7 @@
     --select2-close-mask-background-color: var(--color-white);
     --select2-selection-single-background-color: var(--color-white);
     --select2-selection-single-border-color: var(--color-silver-chalice);
-    --select2-selection-rendered-border-color: var(--color-charcoal);
+    --select2-selection-rendered-font-color: var(--color-charcoal);
     --select2-selection-placeholder-border-color: var(--color-charcoal);
     --select2-selection-placeholder-font-color: var(--color-dusty-gray);
     --select2-selection-arrow-border-color: var(--color-gray-2);
@@ -103,6 +103,9 @@
     --select2-classic-result-option-highlighted-aria-selected-background-color: var(--color-mariner);
     --select2-classic-result-option-highlighted-aria-selected-font-color: var(--color-white);
     --select2-classic-open-dropdown-border-color: var(--color-cornflower-blue);
+    --select2-results-background-color: var(--color-white);
+    --select2-results-option-font-color: var(--color-charcoal);
+    --select2-multiple-choice-remove-hover-font-color: var(--color-mine-shaft);
     /*************/
 
     /** HR **/
@@ -113,6 +116,10 @@
     --p-color-description-color : var(--color-grey-chateau);
     --p-description-a-visited-color : var(--color-maya-blue);
     /******/
+
+    /** Placeholder **/
+    --placeholder-font-color: var(--body-color);
+    /****************/
 
     /** Wrappers **/
     --center-box-border-color : var(--color-iron);
@@ -130,20 +137,21 @@
     /** Select 2 **/
     --select2-container-selection-background-color : var(--color-white);
     --select2-container-selection-border-color : var(--color-silver);
-    --select2-selection-choice-remove-background-color : var(--color-navy-bleu);
-    --select2-selection-multiple-color : var(--color-white);
-    --select2-selection-multiple-border-color : var(--color-malibu);
+    --select2-selection-choice-remove-background-color : var(--color-alto-5);
+    --select2-selection-multiple-color : var(--color-tundora);
+    --select2-selection-multiple-border-color : var(--color-alto-5);
     --select2-selection-multiple-content-border-color-top : var(--select2-selection-multiple-border-color);
     --select2-selection-multiple-content-border-color-bottom : var(--select2-selection-multiple-border-color);
-    --select2-selection-multiple-content-border-color-right : var(--select2-selection-multiple-border-color);
+    --select2-selection-multiple-content-border-color-right : none;
     --select2-selection-multiple-content-color : var(--color-navy-bleu);
-    --select2-selection-multiple-content-background-color : var(--color-columbia-blue);
-    --select2-results-option-highlighted-background-color : var(--color-navy-bleu);
-    --select2-results-option-highlighted-color : var(--color-black);
-    --select2-results-option-highlighted-color-aria-selected : var(--color-columbia-blue);
+    --select2-selection-multiple-content-background-color : var(--color-alto-5);
+    --select2-results-option-highlighted-background-color : var(--color-tundora);
+    --select2-results-option-highlighted-color : var(--color-white);
+    --select2-results-option-highlighted-color-aria-selected : var(--color-primary-dark);
+    --select2-results-option-highlighted-color-aria-selected-font-color: var(--color-white);
     --selected2-results-header-background-color : var(--color-wild-sand);
     --selected2-results-header-border-bottom-color :var(--color-white-lilac);
-    --select2-results-header-color : var(--color-pasific-bleu);
+    --select2-results-header-color : var(--color-primary-dark);
     /**************/
 
     /** Tooltip **/

--- a/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/www/Themes/Generic-theme/Variables-css/variables.css
@@ -53,6 +53,58 @@
     --select-background-color : var(--color-white);
     /***********/
 
+    /** select 2 style2.css **/
+    --select2-dropdown-background-color: var(--color-white);
+    --select2-dropdown-border-color: var(--color-silver-chalice);
+    --select2-close-mask-background-color: var(--color-white);
+    --select2-selection-single-background-color: var(--color-white);
+    --select2-selection-single-border-color: var(--color-silver-chalice);
+    --select2-selection-rendered-border-color: var(--color-charcoal);
+    --select2-selection-placeholder-border-color: var(--color-charcoal);
+    --select2-selection-placeholder-font-color: var(--color-dusty-gray);
+    --select2-selection-arrow-border-color: var(--color-gray-2);
+    --select2-selection-arrow-b-border-color: var(--color-gray-2);
+    --select2-selection-single-disabled-background-color: var(--color-gallery);
+    --select2-container-selection-multiple-background-color: var(--color-white);
+    --select2-container-selection-multiple-border-color: var(--color-silver-chalice);
+    --select2-container-selection-multiple-placeholder-font-color: var(--color-dusty-gray);
+    --select2--selection-multiple-disabled-background-color: var(--color-gallery);
+    --select2-selection-choice-background-color: var(--color-mercury-3);
+    --select2-selection-choice-border-color: var(--color-silver-chalice);
+    --select2-selection-choice-remove-font-color: var(--color-dusty-gray);
+    --select2-selection-choice-remove-hover-font-color: var(--color-mine-shaft);
+    --select2-search-field-border-color: var(--color-silver-chalice);
+    --select2-result-option-aria-disabled-true-font-color: var(--color-dusty-gray);
+    --select2-result-option-aria-selected-true-background-color: var(--color-alto);
+    --select2-result-option-highlighted-aria-selected-true-font-color: var(--color-white);
+    --select2-result-option-highlighted-aria-selected-true-background-color: var(--color-cornflower-blue);
+    --select2-classic-selection-single-background-color: var(--color-alabaster-2);
+    --select2-classic-selection-single-border-color: var(--color-silver-chalice);
+    --select2-classic-selection-single-focus-border-color: var(--color-cornflower-blue);
+    --select2-classic-selection-rendered-font-color: var(--color-charcoal);
+    --select2-classic-selection-placeholder-font-color: var(--color-dusty-gray);
+    --select2-classic-selection-arrow-background-color: var(--color-alto);
+    --select2-classic-selection-arrow-border-left-color: var(--color-silver-chalice);
+    --select2-classic-selection-arrow-b-border-color: var(--color-gray-2);
+    --select2-classic-selection-arrow-rtl-border-right-color: var(--color-silver-chalice);
+    --select2-classic-open-selection-single-border-color: var(--color-cornflower-blue);
+    --select2-open-classic-selection-arrow-b-border-color: var(--color-gray-2);
+    --select2-classic-selection-multiple-background-color: var(--color-white);
+    --select2-classic-selection-multiple-border-color: var(--color-silver-chalice);
+    --select2-classic-selection-multiple-focus-border-color: var(--color-cornflower-blue);
+    --select2-classic-selection-multiple-choice-background-color: var(--color-mercury-3);
+    --select2-classic-selection-multiple-choice-border-color: var(--color-silver-chalice);
+    --select2-classic-selection-multiple-choice-remove-font-color: var(--color-gray-2);
+    --select2-classic-selection-multiple-choice-remove-hover-font-color: var(--color-martar);
+    --select2-classic-selection-multiple-open-border-color: var(--color-cornflower-blue);
+    --select2-search-dropdown-field-border-color: var(--color-silver-chalice);
+    --select2-classic-dropdown-background-color: var(--color-white);
+    --select2-classic-result-option-aria-disabled-true-font-color: var(--color-gray);
+    --select2-classic-result-option-highlighted-aria-selected-background-color: var(--color-mariner);
+    --select2-classic-result-option-highlighted-aria-selected-font-color: var(--color-white);
+    --select2-classic-open-dropdown-border-color: var(--color-cornflower-blue);
+    /*************/
+
     /** HR **/
     --hr-background-color : var(--color-very-light-grey);
     /*******/

--- a/www/Themes/Generic-theme/style.css
+++ b/www/Themes/Generic-theme/style.css
@@ -421,8 +421,8 @@ p.description a, p.description a:visited {
     border-bottom: 1px solid var(--select2-selection-multiple-border-color);
     border-right: 1px solid var(--select2-selection-multiple-border-color);
     border-top: 1px solid var(--select2-selection-multiple-border-color);
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-top-right-radius: 16px;
+    border-bottom-right-radius: 16px;
     margin-right: 0 !important;
     float: right;
 }
@@ -433,8 +433,8 @@ p.description a, p.description a:visited {
     border-top: 1px solid var(--select2-selection-multiple-content-border-color-top);
     border-bottom: 1px solid var(--select2-selection-multiple-content-border-color-bottom);
     border-right: 1px solid var(--select2-selection-multiple-content-border-color-right);
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-top-left-radius: 16px;
+    border-bottom-left-radius: 16px;
     color: var(--select2-results-option-highlighted-background-color);
     background-color: var(--select2-selection-multiple-content-background-color);
     float: left;

--- a/www/Themes/Generic-theme/style.css
+++ b/www/Themes/Generic-theme/style.css
@@ -393,6 +393,10 @@ p.description a, p.description a:visited {
     margin-top: 0 !important;
 }
 
+::placeholder {
+    color: var(--placeholder-font-color);
+}
+
 .select2-container--default .select2-selection--single {
     background-color: var(--select2-container-selection-background-color);
     border: 1px solid var(--select2-container-selection-border-color) !important;
@@ -412,25 +416,28 @@ p.description a, p.description a:visited {
 /* Remove button on element in multiple select select2 */
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
     color: var(--select2-selection-multiple-color) !important;
-    margin-left: 2px;
     padding: 2px 5px;
     background-color: var(--select2-selection-choice-remove-background-color);
-    border: 1px solid var(--select2-selection-multiple-border-color);
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-bottom: 1px solid var(--select2-selection-multiple-border-color);
+    border-right: 1px solid var(--select2-selection-multiple-border-color);
+    border-top: 1px solid var(--select2-selection-multiple-border-color);
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
     margin-right: 0 !important;
+    float: right;
 }
 
 /* Content for display text in selected element on select 2 fields */
 .select2-container--default .select2-selection--multiple .select2-selection__choice .select2-content {
-    padding: 2px 5px;
+    padding: 2px 0px 2px 8px;
     border-top: 1px solid var(--select2-selection-multiple-content-border-color-top);
     border-bottom: 1px solid var(--select2-selection-multiple-content-border-color-bottom);
     border-right: 1px solid var(--select2-selection-multiple-content-border-color-right);
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
     color: var(--select2-results-option-highlighted-background-color);
     background-color: var(--select2-selection-multiple-content-background-color);
+    float: left;
 }
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
     background-color: var(--select2-results-option-highlighted-background-color);
@@ -442,6 +449,7 @@ p.description a, p.description a:visited {
 
 .select2-container--default .select2-results__option[aria-selected=true] {
     background-color: var(--select2-results-option-highlighted-color-aria-selected) !important;
+    color: var(--select2-results-option-highlighted-color-aria-selected-font-color);
 }
 
 .formTable .select2-container--default .select2-selection--multiple .select2-selection__rendered {

--- a/www/include/common/javascript/jquery/plugins/select2/css/select2.css
+++ b/www/include/common/javascript/jquery/plugins/select2/css/select2.css
@@ -1,5 +1,7 @@
 /* Caution in the original lib the ".select2-dropdown" z-index was 1051 but as the popup has a z-index of 1053 and
  to avoid impacts in the other pages or popups, we modified this z-index to 1065 */
+@import "www/Themes/Generic-theme/Variables-css/variables.css";
+
 .select2-container {
   box-sizing: border-box;
   display: inline-block;
@@ -50,8 +52,8 @@
         -webkit-appearance: none; }
 
 .select2-dropdown {
-  background-color: white;
-  border: 1px solid #aaa;
+  background-color: var(--select2-dropdown-background-color);
+  border: 1px solid var(--select2-dropdown-border-color);
   border-radius: 4px;
   box-sizing: border-box;
   display: block;
@@ -116,7 +118,7 @@
   width: auto;
   opacity: 0;
   z-index: 99;
-  background-color: #fff;
+  background-color: var(--select2-close-mask-background-color);
   filter: alpha(opacity=0); }
 
 .select2-hidden-accessible {
@@ -130,18 +132,18 @@
   width: 1px !important; }
 
 .select2-container--default .select2-selection--single {
-  background-color: #fff;
-  border: 1px solid #aaa;
+  background-color: var(--select2-selection-single-background-color);
+  border: 1px solid var(--select2-selection-single-border-color);
   border-radius: 4px; }
   .select2-container--default .select2-selection--single .select2-selection__rendered {
-    color: #444;
+    color: var(--select2-selection-rendered-border-color);
     line-height: 28px; }
   .select2-container--default .select2-selection--single .select2-selection__clear {
     cursor: pointer;
     float: right;
     font-weight: bold; }
   .select2-container--default .select2-selection--single .select2-selection__placeholder {
-    color: #999; }
+    color: var(--select2-selection-placeholder-font-color); }
   .select2-container--default .select2-selection--single .select2-selection__arrow {
     height: 26px;
     position: absolute;
@@ -149,7 +151,7 @@
     right: 1px;
     width: 20px; }
     .select2-container--default .select2-selection--single .select2-selection__arrow b {
-      border-color: #888 transparent transparent transparent;
+      border-color: var(--select2-selection-arrow-border-color) transparent transparent transparent;
       border-style: solid;
       border-width: 5px 4px 0 4px;
       height: 0;
@@ -168,18 +170,18 @@
   right: auto; }
 
 .select2-container--default.select2-container--disabled .select2-selection--single {
-  background-color: #eee;
+  background-color: var(--select2-selection-single-disabled-background-color);
   cursor: default; }
   .select2-container--default.select2-container--disabled .select2-selection--single .select2-selection__clear {
     display: none; }
 
 .select2-container--default.select2-container--open .select2-selection--single .select2-selection__arrow b {
-  border-color: transparent transparent #888 transparent;
+  border-color: transparent transparent var(--select2-selection-arrow-b-border-color) transparent;
   border-width: 0 4px 5px 4px; }
 
 .select2-container--default .select2-selection--multiple {
-  background-color: white;
-  border: 1px solid #aaa;
+  background-color: var(--select2-container-selection-multiple-background-color);
+  border: 1px solid var(--select2-container-selection-multiple-border-color);
   border-radius: 4px;
   cursor: text; }
   .select2-container--default .select2-selection--multiple .select2-selection__rendered {
@@ -191,7 +193,7 @@
     .select2-container--default .select2-selection--multiple .select2-selection__rendered li {
       list-style: none; }
   .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
-    color: #999;
+    color: var(--select2-container-selection-multiple-placeholder-font-color);;
     margin-top: 5px;
     float: left; }
   .select2-container--default .select2-selection--multiple .select2-selection__clear {
@@ -201,8 +203,8 @@
     margin-top: 5px;
     margin-right: 10px; }
   .select2-container--default .select2-selection--multiple .select2-selection__choice {
-    background-color: #e4e4e4;
-    border: 1px solid #aaa;
+    background-color: var(--select2-selection-choice-background-color);;
+    border: 1px solid var(--select2-selection-choice-border-color);
     border-radius: 4px;
     cursor: default;
     float: left;
@@ -210,7 +212,7 @@
     margin-top: 5px;
     padding: 0 5px; }
   .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
-    color: #999;
+    color: var(--select2-selection-choice-remove-font-color);
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
@@ -234,7 +236,7 @@
   outline: 0; }
 
 .select2-container--default.select2-container--disabled .select2-selection--multiple {
-  background-color: #eee;
+  background-color: var(--select2--selection-multiple-disabled-background-color);
   cursor: default; }
 
 .select2-container--default.select2-container--disabled .select2-selection__choice__remove {
@@ -249,7 +251,7 @@
   border-bottom-right-radius: 0; }
 
 .select2-container--default .select2-search--dropdown .select2-search__field {
-  border: 1px solid #aaa; }
+  border: 1px solid var(--select2-search-field-border-color); }
 
 .select2-container--default .select2-search--inline .select2-search__field {
   background: transparent;
@@ -266,10 +268,10 @@
   padding: 0; }
 
 .select2-container--default .select2-results__option[aria-disabled=true] {
-  color: #999; }
+  color: var(--select2-result-option-aria-disabled-true-font-color); }
 
 .select2-container--default .select2-results__option[aria-selected=true] {
-  background-color: #ddd; }
+  background-color: var(--select2-result-option-aria-selected-true-background-color); }
 
 .select2-container--default .select2-results__option .select2-results__option {
   padding-left: 1em; }
@@ -292,8 +294,8 @@
             padding-left: 6em; }
 
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
-  background-color: #5897fb;
-  color: white; }
+  background-color: var(--select2-result-option-highlighted-aria-selected-true-background-color);
+  color: var(--select2-result-option-highlighted-aria-selected-true-font-color); }
 
 .select2-container--default .select2-results__group {
   cursor: default;
@@ -301,8 +303,8 @@
   padding: 6px; }
 
 .select2-container--classic .select2-selection--single {
-  background-color: #f7f7f7;
-  border: 1px solid #aaa;
+  background-color: var(--select2-classic-selection-single-background-color);
+  border: 1px solid var(--select2-classic-selection-single-border-color);
   border-radius: 4px;
   outline: 0;
   background-image: -webkit-linear-gradient(top, white 50%, #eeeeee 100%);
@@ -311,9 +313,9 @@
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFFFF', endColorstr='#FFEEEEEE', GradientType=0); }
   .select2-container--classic .select2-selection--single:focus {
-    border: 1px solid #5897fb; }
+    border: 1px solid var(--select2-classic-selection-single-focus-border-color); }
   .select2-container--classic .select2-selection--single .select2-selection__rendered {
-    color: #444;
+    color: var(--select2-classic-selection-rendered-font-color);
     line-height: 28px; }
   .select2-container--classic .select2-selection--single .select2-selection__clear {
     cursor: pointer;
@@ -321,11 +323,11 @@
     font-weight: bold;
     margin-right: 10px; }
   .select2-container--classic .select2-selection--single .select2-selection__placeholder {
-    color: #999; }
+    color: var(--select2-classic-selection-placeholder-font-color); }
   .select2-container--classic .select2-selection--single .select2-selection__arrow {
-    background-color: #ddd;
+    background-color: var(--select2-classic-selection-arrow-background-color);
     border: none;
-    border-left: 1px solid #aaa;
+    border-left: 1px solid var(--select2-classic-selection-arrow-border-left-color);
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
     height: 26px;
@@ -339,7 +341,7 @@
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFEEEEEE', endColorstr='#FFCCCCCC', GradientType=0); }
     .select2-container--classic .select2-selection--single .select2-selection__arrow b {
-      border-color: #888 transparent transparent transparent;
+      border-color: var(--select2-classic-selection-arrow-b-border-color) transparent transparent transparent;
       border-style: solid;
       border-width: 5px 4px 0 4px;
       height: 0;
@@ -355,7 +357,7 @@
 
 .select2-container--classic[dir="rtl"] .select2-selection--single .select2-selection__arrow {
   border: none;
-  border-right: 1px solid #aaa;
+  border-right: 1px solid var(--select2-classic-selection-arrow-rtl-border-right-color);
   border-radius: 0;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
@@ -363,12 +365,12 @@
   right: auto; }
 
 .select2-container--classic.select2-container--open .select2-selection--single {
-  border: 1px solid #5897fb; }
+  border: 1px solid var(--select2-classic-open-selection-single-border-color); }
   .select2-container--classic.select2-container--open .select2-selection--single .select2-selection__arrow {
     background: transparent;
     border: none; }
     .select2-container--classic.select2-container--open .select2-selection--single .select2-selection__arrow b {
-      border-color: transparent transparent #888 transparent;
+      border-color: transparent transparent var(--select2-open-classic-selection-arrow-b-border-color) transparent;
       border-width: 0 4px 5px 4px; }
 
 .select2-container--classic.select2-container--open.select2-container--above .select2-selection--single {
@@ -392,13 +394,13 @@
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFEEEEEE', endColorstr='#FFFFFFFF', GradientType=0); }
 
 .select2-container--classic .select2-selection--multiple {
-  background-color: white;
-  border: 1px solid #aaa;
+  background-color: var(--select2-classic-selection-multiple-background-color);
+  border: 1px solid var(--select2-classic-selection-multiple-border-color);
   border-radius: 4px;
   cursor: text;
   outline: 0; }
   .select2-container--classic .select2-selection--multiple:focus {
-    border: 1px solid #5897fb; }
+    border: 1px solid var(--select2-classic-selection-multiple-focus-border-color); }
   .select2-container--classic .select2-selection--multiple .select2-selection__rendered {
     list-style: none;
     margin: 0;
@@ -406,8 +408,8 @@
   .select2-container--classic .select2-selection--multiple .select2-selection__clear {
     display: none; }
   .select2-container--classic .select2-selection--multiple .select2-selection__choice {
-    background-color: #e4e4e4;
-    border: 1px solid #aaa;
+    background-color: var(--select2-classic-selection-multiple-choice-background-color);
+    border: 1px solid var(--select2-classic-selection-multiple-choice-border-color);
     border-radius: 4px;
     cursor: default;
     float: left;
@@ -415,13 +417,13 @@
     margin-top: 5px;
     padding: 0 5px; }
   .select2-container--classic .select2-selection--multiple .select2-selection__choice__remove {
-    color: #888;
+    color: var(--select2-classic-selection-multiple-choice-remove-font-color);
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
     margin-right: 2px; }
     .select2-container--classic .select2-selection--multiple .select2-selection__choice__remove:hover {
-      color: #555; }
+      color: var(--select2-classic-selection-multiple-choice-remove-hover-font-color); }
 
 .select2-container--classic[dir="rtl"] .select2-selection--multiple .select2-selection__choice {
   float: right; }
@@ -435,7 +437,7 @@
   margin-right: auto; }
 
 .select2-container--classic.select2-container--open .select2-selection--multiple {
-  border: 1px solid #5897fb; }
+  border: 1px solid var(--select2-classic-selection-multiple-open-border-color); }
 
 .select2-container--classic.select2-container--open.select2-container--above .select2-selection--multiple {
   border-top: none;
@@ -448,7 +450,7 @@
   border-bottom-right-radius: 0; }
 
 .select2-container--classic .select2-search--dropdown .select2-search__field {
-  border: 1px solid #aaa;
+  border: 1px solid var(--select2-search-dropdown-field-border-color);
   outline: 0; }
 
 .select2-container--classic .select2-search--inline .select2-search__field {
@@ -456,7 +458,7 @@
   box-shadow: none; }
 
 .select2-container--classic .select2-dropdown {
-  background-color: white;
+  background-color: var(--select2-classic-dropdown-background-color);
   border: 1px solid transparent; }
 
 .select2-container--classic .select2-dropdown--above {
@@ -473,11 +475,11 @@
   padding: 0; }
 
 .select2-container--classic .select2-results__option[aria-disabled=true] {
-  color: grey; }
+  color: var(--select2-classic-result-option-aria-disabled-true-font-color); }
 
 .select2-container--classic .select2-results__option--highlighted[aria-selected] {
-  background-color: #3875d7;
-  color: white; }
+  background-color: var(--select2-classic-result-option-highlighted-aria-selected-background-color);
+  color: var(--select2-classic-result-option-highlighted-aria-selected-font-color); }
 
 .select2-container--classic .select2-results__group {
   cursor: default;
@@ -485,4 +487,4 @@
   padding: 6px; }
 
 .select2-container--classic.select2-container--open .select2-dropdown {
-  border-color: #5897fb; }
+  border-color: var(--select2-classic-open-dropdown-border-color); }

--- a/www/include/common/javascript/jquery/plugins/select2/css/select2.css
+++ b/www/include/common/javascript/jquery/plugins/select2/css/select2.css
@@ -65,7 +65,8 @@
   z-index: 1065; }
 
 .select2-results {
-  display: block; }
+  display: block;
+  background-color: var(--select2-results-background-color);}
 
 .select2-results__options {
   list-style: none;
@@ -136,7 +137,7 @@
   border: 1px solid var(--select2-selection-single-border-color);
   border-radius: 4px; }
   .select2-container--default .select2-selection--single .select2-selection__rendered {
-    color: var(--select2-selection-rendered-border-color);
+    color: var(--select2-selection-rendered-font-color);
     line-height: 28px; }
   .select2-container--default .select2-selection--single .select2-selection__clear {
     cursor: pointer;
@@ -193,7 +194,7 @@
     .select2-container--default .select2-selection--multiple .select2-selection__rendered li {
       list-style: none; }
   .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
-    color: var(--select2-container-selection-multiple-placeholder-font-color);;
+    color: var(--select2-container-selection-multiple-placeholder-font-color);
     margin-top: 5px;
     float: left; }
   .select2-container--default .select2-selection--multiple .select2-selection__clear {
@@ -218,7 +219,7 @@
     font-weight: bold;
     margin-right: 2px; }
     .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
-      color: #333; }
+      color: var(--select2-multiple-choice-remove-hover-font-color); }
 
 .select2-container--default[dir="rtl"] .select2-selection--multiple .select2-selection__choice, .select2-container--default[dir="rtl"] .select2-selection--multiple .select2-selection__placeholder, .select2-container--default[dir="rtl"] .select2-selection--multiple .select2-search--inline {
   float: right; }
@@ -262,7 +263,8 @@
 
 .select2-container--default .select2-results > .select2-results__options {
   max-height: 200px;
-  overflow-y: auto; }
+  overflow-y: auto;
+  color: var(--select2-results-option-font-color)}
 
 .select2-container--default .select2-results__option[role=group] {
   padding: 0; }


### PR DESCRIPTION
## Description

Applying dark mode to select 2 including exporting other variables of style2.css.

**Fixes** # MON-12031

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
