### PR TITLE
enh(api): get password remaining time in legacy user endpoint

### DIFF
--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005-2021 Centreon
+ * Copyright 2005-2022 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -34,8 +34,9 @@
  *
  */
 
-require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once __DIR__ . "/webService.class.php";
+require_once __DIR__ . '/webService.class.php';
+require_once  __DIR__ . '/../../class/centreonDB.class.php';
+require_once  __DIR__ . '/../../class/centreonContact.class.php';
 
 class CentreonTopCounter extends CentreonWebService
 {
@@ -261,7 +262,7 @@ class CentreonTopCounter extends CentreonWebService
             $autoLoginKey = $row['contact_autologin_key'] ?? null;
         }
 
-        return array(
+        return [
             'userId' => $this->centreon->user->user_id,
             'fullname' => $this->centreon->user->name,
             'username' => $this->centreon->user->alias,
@@ -269,8 +270,38 @@ class CentreonTopCounter extends CentreonWebService
             'timezone' => $this->centreon->CentreonGMT->getActiveTimezone($this->centreon->user->gmt),
             'hasAccessToProfile' => $this->hasAccessToProfile,
             'autologinkey' => $autoLoginKey,
-            'soundNotificationsEnabled' => $this->soundNotificationsEnabled
-        );
+            'soundNotificationsEnabled' => $this->soundNotificationsEnabled,
+            'password_remaining_time' => $this->getPasswordRemainingTime(),
+        ];
+    }
+
+    /**
+     * Get password remaining time
+     * null : never expired
+     * int : number of seconds before expiration
+     *
+     * @return int|null
+     */
+    private function getPasswordRemainingTime(): ?int
+    {
+        $passwordRemainingTime = null;
+        $contact = new CentreonContact($this->pearDB);
+        $passwordCreationDate = $contact->findLastPasswordCreationDate((int) $this->centreon->user->user_id);
+
+        if ($passwordCreationDate !== null) {
+            $passwordPolicy = $contact->getPasswordSecurityPolicy();
+            $expirationDelay = $passwordPolicy['password_expiration']['expiration_delay'];
+            $excludedUsers = $passwordPolicy['password_expiration']['excluded_users'];
+
+            if ($expirationDelay !== null && !in_array($this->centreon->user->alias, $excludedUsers)) {
+                $passwordRemainingTime = $passwordCreationDate->getTimestamp() + $expirationDelay - time();
+                if ($passwordRemainingTime < 0) {
+                    $passwordRemainingTime = 0;
+                }
+            }
+        }
+
+        return $passwordRemainingTime;
     }
 
     /**

--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -35,8 +35,8 @@
  */
 
 require_once __DIR__ . '/webService.class.php';
-require_once  __DIR__ . '/../../class/centreonDB.class.php';
-require_once  __DIR__ . '/../../class/centreonContact.class.php';
+require_once __DIR__ . '/../../class/centreonDB.class.php';
+require_once __DIR__ . '/../../class/centreonContact.class.php';
 
 class CentreonTopCounter extends CentreonWebService
 {

--- a/www/class/centreonContact.class.php
+++ b/www/class/centreonContact.class.php
@@ -388,6 +388,32 @@ class CentreonContact
     }
 
     /**
+     * Find last password creation date by contact id
+     *
+     * @param int $contactId
+     * @return \DateTimeImmutable|null
+     */
+    public function findLastPasswordCreationDate(int $contactId): ?\DateTimeImmutable
+    {
+        $creationDate = null;
+
+        $statement = $this->db->prepare(
+            "SELECT creation_date
+            FROM contact_password
+            WHERE contact_id = :contactId
+            ORDER BY creation_date DESC LIMIT 1"
+        );
+        $statement->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        if ($row = $statement->fetch()) {
+            $creationDate = (new \DateTimeImmutable())->setTimestamp((int) $row['creation_date']);
+        }
+
+        return $creationDate;
+    }
+
+    /**
      * Check if a user password respects configured policy when updated (delay, reuse)
      *
      * @param array<string,mixed> $passwordPolicy
@@ -398,16 +424,11 @@ class CentreonContact
      */
     private function respectPasswordChangePolicyOrFail(array $passwordPolicy, string $password, int $contactId): void
     {
-        $statement = $this->db->prepare(
-            "SELECT creation_date FROM contact_password "
-            . "WHERE contact_id = :contactId "
-            . "ORDER BY creation_date DESC LIMIT 1"
-        );
-        $statement->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
-        $statement->execute();
-        if ($passwordCreationDate = $statement->fetchColumn()) {
+        $passwordCreationDate = $this->findLastPasswordCreationDate($contactId);
+
+        if ($passwordCreationDate !== null) {
             $delayBeforeNewPassword = (int) $passwordPolicy['delay_before_new_password'];
-            $isPasswordCanBeChanged = (int) $passwordCreationDate + $delayBeforeNewPassword < time();
+            $isPasswordCanBeChanged = $passwordCreationDate->getTimestamp() + $delayBeforeNewPassword < time();
             if (!$isPasswordCanBeChanged) {
                 throw new \Exception(
                     _("You can't change your password because the delay before changing password is not over.")


### PR DESCRIPTION
## Description

get password remaining time in legacy user endpoint

**Fixes** MON-12519

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)