### PR TITLE
Add state for service in the API return

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Service.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Service.yml
@@ -150,6 +150,7 @@ Centreon\Domain\Monitoring\Service:
         state:
             type: int
             groups:
+                - 'service_min'
                 - 'service_main'
                 - 'service_full'
         stateType:


### PR DESCRIPTION
## Description

In the documentation of API v2, it's possible to get service state with the param "show_service=true" but in reality the state of services was not presents. 

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>
With the modification below and after application cache generation, the state of services appears in the API return.
