### PR TITLE
fix(secu): sanitize ACL group inputs

### DIFF
--- a/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2022 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -163,7 +164,9 @@ function multipleGroupInDB($groups = array(), $nbrDup = array())
     global $pearDB, $centreon;
 
     foreach ($groups as $key => $value) {
-        $dbResult = $pearDB->query("SELECT * FROM acl_groups WHERE acl_group_id = '" . $key . "' LIMIT 1");
+        $dbResult = $pearDB->prepare("SELECT * FROM acl_groups WHERE acl_group_id = :aclGroupId LIMIT 1");
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
         $row = $dbResult->fetch();
         $row["acl_group_id"] = '';
 
@@ -181,9 +184,10 @@ function multipleGroupInDB($groups = array(), $nbrDup = array())
                 }
             }
 
-            if (testGroupExistence($acl_group_name)) {
-                $val ? $rq = "INSERT INTO acl_groups VALUES (" . $val . ")" : $rq = null;
-                $pearDB->query($rq);
+            if (testGroupExistence($acl_group_name) && $val) {
+                $groupExist = $pearDB->prepare("INSERT INTO acl_groups VALUES (:aclGroups)");
+                $groupExist->bindValue('aclGroups', $val, PDO::PARAM_STR);
+                $groupExist->execute();
                 $dbResult = $pearDB->query("SELECT MAX(acl_group_id) FROM acl_groups");
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();

--- a/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -203,7 +203,7 @@ function multipleGroupInDB($groups = array(), $nbrDup = array())
                 }
             }
 
-            if (testGroupExistence($acl_group_name) && $val) {
+            if (testGroupExistence($acl_group_name)) {
                 $val ? $rq = "INSERT INTO acl_groups VALUES (" . $val . ")" : $rq = null;
                 $pearDB->query($rq);
                 $dbResult = $pearDB->query("SELECT MAX(acl_group_id) FROM acl_groups");

--- a/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -99,15 +99,22 @@ function enableGroupInDB($acl_group_id = null, $groups = array())
     }
 
     if ($acl_group_id) {
-        $groups = array($acl_group_id => "1");
+        $groups = [$acl_group_id => "1"];
     }
 
     foreach ($groups as $key => $value) {
-        $pearDB->query("UPDATE acl_groups SET acl_group_activate = '1' WHERE acl_group_id = '" . $key . "'");
-        $query = "SELECT acl_group_name FROM `acl_groups` WHERE acl_group_id = '" . (int)$key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
+        $dbResult = $pearDB->prepare("UPDATE acl_groups SET acl_group_activate = '1' WHERE acl_group_id = :aclGroupId");
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
+
+        $dbResult = $pearDB->prepare(
+            "SELECT acl_group_name FROM `acl_groups`
+            WHERE acl_group_id = :aclGroupId LIMIT 1"
+        );
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
         $row = $dbResult->fetch();
-        $centreon->CentreonLogAction->insertLog("access group", $key, $row['acl_group_name'], "enable");
+        $centreon->CentreonLogAction->insertLog("access group", (int) $key, $row['acl_group_name'], "enable");
     }
 }
 
@@ -127,11 +134,18 @@ function disableGroupInDB($acl_group_id = null, $groups = array())
     }
 
     foreach ($groups as $key => $value) {
-        $pearDB->query("UPDATE acl_groups SET acl_group_activate = '0' WHERE acl_group_id = '" . $key . "'");
-        $query = "SELECT acl_group_name FROM `acl_groups` WHERE acl_group_id = '" . (int)$key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
+        $dbResult = $pearDB->prepare(
+            "UPDATE acl_groups SET acl_group_activate = '0' WHERE acl_group_id = :aclGroupId"
+        );
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
+        $dbResult = $pearDB->prepare(
+            "SELECT acl_group_name FROM `acl_groups` WHERE acl_group_id = :aclGroupId LIMIT 1"
+        );
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
         $row = $dbResult->fetch();
-        $centreon->CentreonLogAction->insertLog("access group", $key, $row['acl_group_name'], "disable");
+        $centreon->CentreonLogAction->insertLog("access group", (int) $key, $row['acl_group_name'], "disable");
     }
 }
 
@@ -145,11 +159,16 @@ function deleteGroupInDB($groups = array())
     global $pearDB, $centreon;
 
     foreach ($groups as $key => $value) {
-        $query = "SELECT acl_group_name FROM `acl_groups` WHERE acl_group_id = '" . (int)$key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
+        $dbResult = $pearDB->prepare(
+            "SELECT acl_group_name FROM `acl_groups` WHERE acl_group_id = :aclGroupId LIMIT 1"
+        );
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
         $row = $dbResult->fetch();
-        $pearDB->query("DELETE FROM acl_groups WHERE acl_group_id = '" . $key . "'");
-        $centreon->CentreonLogAction->insertLog("access group", $key, $row['acl_group_name'], "d");
+        $dbResult = $pearDB->prepare("DELETE FROM acl_groups WHERE acl_group_id = :aclGroupId");
+        $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
+        $dbResult->execute();
+        $centreon->CentreonLogAction->insertLog("access group", (int) $key, $row['acl_group_name'], "d");
     }
 }
 

--- a/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -185,9 +185,8 @@ function multipleGroupInDB($groups = array(), $nbrDup = array())
             }
 
             if (testGroupExistence($acl_group_name) && $val) {
-                $groupExist = $pearDB->prepare("INSERT INTO acl_groups VALUES (:aclGroups)");
-                $groupExist->bindValue('aclGroups', $val, PDO::PARAM_STR);
-                $groupExist->execute();
+                $val ? $rq = "INSERT INTO acl_groups VALUES (" . $val . ")" : $rq = null;
+                $pearDB->query($rq);
                 $dbResult = $pearDB->query("SELECT MAX(acl_group_id) FROM acl_groups");
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();

--- a/www/include/options/accessLists/groupsACL/formGroupConfig.php
+++ b/www/include/options/accessLists/groupsACL/formGroupConfig.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2022 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -41,11 +42,13 @@ require_once _CENTREON_PATH_ . 'www/class/centreonLDAP.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';
 
 /*
- * Retreive information
+ * Retrieve information
  */
 $group = array();
 if (($o == "c" || $o == "w") && $acl_group_id) {
-    $DBRESULT = $pearDB->query("SELECT * FROM acl_groups WHERE acl_group_id = '" . $acl_group_id . "' LIMIT 1");
+    $DBRESULT = $pearDB->prepare("SELECT * FROM acl_groups WHERE acl_group_id = :aclGroupId LIMIT 1");
+    $DBRESULT->bindValue('aclGroupId', $acl_group_id, PDO::PARAM_INT);
+    $DBRESULT->execute();
     /*
      * Set base value
      */
@@ -54,12 +57,15 @@ if (($o == "c" || $o == "w") && $acl_group_id) {
     /*
      * Set Contact Childs
      */
-    $query = "SELECT DISTINCT contact_contact_id "
-        . "FROM acl_group_contacts_relations "
-        . "WHERE acl_group_id = '" . $acl_group_id . "' "
-        . "AND contact_contact_id NOT IN "
-        . "(SELECT contact_id FROM contact WHERE contact_admin = '1')";
-    $DBRESULT = $pearDB->query($query);
+    $query = "SELECT DISTINCT contact_contact_id
+        FROM acl_group_contacts_relations
+        WHERE acl_group_id = :aclGroupId
+        AND contact_contact_id NOT IN
+        (SELECT contact_id FROM contact WHERE contact_admin = '1')";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue('aclGroupId', $acl_group_id, PDO::PARAM_INT);
+    $DBRESULT->execute();
+
     for ($i = 0; $contacts = $DBRESULT->fetchRow(); $i++) {
         $group["cg_contacts"][$i] = $contacts["contact_contact_id"];
     }
@@ -68,10 +74,12 @@ if (($o == "c" || $o == "w") && $acl_group_id) {
     /*
      * Set ContactGroup Childs
      */
-    $query = "SELECT DISTINCT cg_cg_id "
-        . "FROM acl_group_contactgroups_relations "
-        . "WHERE acl_group_id = '" . $acl_group_id . "'";
-    $DBRESULT = $pearDB->query($query);
+    $query = "SELECT DISTINCT cg_cg_id
+        FROM acl_group_contactgroups_relations
+        WHERE acl_group_id = :aclGroupId";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue('aclGroupId', $acl_group_id, PDO::PARAM_INT);
+    $DBRESULT->execute();
     for ($i = 0; $contactgroups = $DBRESULT->fetchRow(); $i++) {
         $group["cg_contactGroups"][$i] = $contactgroups["cg_cg_id"];
     }
@@ -80,10 +88,12 @@ if (($o == "c" || $o == "w") && $acl_group_id) {
     /*
      * Set Menu link List
      */
-    $query = "SELECT DISTINCT acl_topology_id "
-        . "FROM acl_group_topology_relations "
-        . "WHERE acl_group_id = '" . $acl_group_id . "'";
-    $DBRESULT = $pearDB->query($query);
+    $query = "SELECT DISTINCT acl_topology_id
+        FROM acl_group_topology_relations
+        WHERE acl_group_id = :aclGroupId";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue('aclGroupId', $acl_group_id, PDO::PARAM_INT);
+    $DBRESULT->execute();
     for ($i = 0; $data = $DBRESULT->fetchRow(); $i++) {
         $group["menuAccess"][$i] = $data["acl_topology_id"];
     }
@@ -92,12 +102,14 @@ if (($o == "c" || $o == "w") && $acl_group_id) {
     /*
      * Set resources List
      */
-    $query = 'SELECT DISTINCT argr.acl_res_id '
-        . 'FROM acl_res_group_relations argr, acl_resources ar '
-        . 'WHERE argr.acl_res_id = ar.acl_res_id '
-        . 'AND ar.locked = 0 '
-        . 'AND argr.acl_group_id = "' . $acl_group_id . '" ';
-    $DBRESULT = $pearDB->query($query);
+    $query = "SELECT DISTINCT argr.acl_res_id
+        FROM acl_res_group_relations argr, acl_resources ar
+        WHERE argr.acl_res_id = ar.acl_res_id
+        AND ar.locked = 0
+        AND argr.acl_group_id = :aclGroupId";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue('aclGroupId', $acl_group_id, PDO::PARAM_INT);
+    $DBRESULT->execute();
     for ($i = 0; $data = $DBRESULT->fetchRow(); $i++) {
         $group["resourceAccess"][$i] = $data["acl_res_id"];
     }
@@ -107,10 +119,12 @@ if (($o == "c" || $o == "w") && $acl_group_id) {
     /*
      * Set Action List
      */
-    $query = "SELECT DISTINCT acl_action_id "
-        . "FROM acl_group_actions_relations "
-        . "WHERE acl_group_id = '" . $acl_group_id . "'";
-    $DBRESULT = $pearDB->query($query);
+    $query = "SELECT DISTINCT acl_action_id
+        FROM acl_group_actions_relations
+        WHERE acl_group_id = :aclGroupId";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue('aclGroupId', $acl_group_id, PDO::PARAM_INT);
+    $DBRESULT->execute();
     for ($i = 0; $data = $DBRESULT->fetchRow(); $i++) {
         $group["actionAccess"][$i] = $data["acl_action_id"];
     }

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -71,7 +71,7 @@ $select = is_array($select) ? sanitize_input_array($select) : [];
 $acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? null, FILTER_VALIDATE_INT) ?? null;
 
 $postO = filter_var($_POST['o1'] ?? $_POST['o2'] ?? null, FILTER_SANITIZE_STRING);
-("" !== $postO) ? $o = $postO : $o = null;
+$o = ("" !== $postO) ? $postO : null;
 
 switch ($o) {
     case "a":

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -63,7 +63,7 @@ function sanitize_input_array(array $inputArray): array
 }
 
 $dupNbr = $_GET['dupNbr'] ?? $_POST['dupNbr'] ?? null;
-is_array($dupNbr) ? $dupNbr = sanitize_input_array($dupNbr) : $dupNbr = [];
+$dupNbr = is_array($dupNbr) ? sanitize_input_array($dupNbr) : [];
 
 $select = $_GET['select'] ?? $_POST['select'] ?? null;
 is_array($select) ? $select = sanitize_input_array($select) : $select = [];

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -49,7 +49,8 @@ $path = "./include/options/accessLists/groupsACL/";
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
-function sanitize_input_array(array $inputArray): array {
+function sanitize_input_array(array $inputArray): array
+{
     $sanitizedArray = [];
     foreach ($inputArray as $key => $value) {
         $key = filter_var($key, FILTER_VALIDATE_INT);

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -70,7 +70,8 @@ $select = is_array($select) ? sanitize_input_array($select) : [];
 
 $acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? null, FILTER_VALIDATE_INT) ?? null;
 
-$postO = filter_var($_POST['o1'] ?? $_POST['o2'] ?? null, FILTER_SANITIZE_STRING);
+// Caution $o may already be set from the GET or from the POST.
+$postO = filter_var($_POST['o1'] ?? $_POST['o2'] ?? $o ?? null, FILTER_SANITIZE_STRING);
 $o = ("" !== $postO) ? $postO : null;
 
 switch ($o) {

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2022 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -38,18 +38,6 @@ if (!isset($centreon)) {
     exit();
 }
 
-isset($_GET["acl_group_id"]) ? $cG = $_GET["acl_group_id"] : $cG = null;
-isset($_POST["acl_group_id"]) ? $cP = $_POST["acl_group_id"] : $cP = null;
-$cG ? $acl_group_id = $cG : $acl_group_id = $cP;
-
-isset($_GET["select"]) ? $cG = $_GET["select"] : $cG = null;
-isset($_POST["select"]) ? $cP = $_POST["select"] : $cP = null;
-$cG ? $select = $cG : $select = $cP;
-
-isset($_GET["dupNbr"]) ? $cG = $_GET["dupNbr"] : $cG = null;
-isset($_POST["dupNbr"]) ? $cP = $_POST["dupNbr"] : $cP = null;
-$cG ? $dupNbr = $cG : $dupNbr = $cP;
-
 /*
  *  Path to the configuration dir
  */
@@ -61,25 +49,38 @@ $path = "./include/options/accessLists/groupsACL/";
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
-if (isset($_POST["o1"]) && isset($_POST["o2"])) {
-    if ($_POST["o1"] != "") {
-        $o = $_POST["o1"];
+function sanitize_input_array(array $inputArray): array {
+    $sanitizedArray = [];
+    foreach ($inputArray as $key => $value) {
+        $key = filter_var($key, FILTER_VALIDATE_INT);
+        $value = filter_var($value, FILTER_VALIDATE_INT);
+        if (false !== $key && false !== $value) {
+            $sanitizedArray[$key] = $value;
+        }
     }
-    if ($_POST["o2"] != "") {
-        $o = $_POST["o2"];
-    }
+    return $sanitizedArray;
 }
+
+$dupNbr = $_GET['dupNbr'] ?? $_POST['dupNbr'] ?? null;
+is_array($dupNbr) ? $dupNbr = sanitize_input_array($dupNbr) : $dupNbr = [];
+
+$select = $_GET['select'] ?? $_POST['select'] ?? null;
+is_array($select) ? $select = sanitize_input_array($select) : $select = [];
+
+$acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? null, FILTER_VALIDATE_INT) ?? null;
+
+$postO = filter_var($_POST['o1'] ?? $_POST['o2'] ?? null, FILTER_SANITIZE_STRING);
+("" !== $postO) ? $o = $postO : $o = null;
 
 switch ($o) {
     case "a":
-        require_once($path . "formGroupConfig.php");
-        break; #Add a  an access group
+        #Add an access group
     case "w":
-        require_once($path . "formGroupConfig.php");
-        break; #Watch a  an access group
+        #Watch an access group
     case "c":
+        #Modify an access group
         require_once($path . "formGroupConfig.php");
-        break; #Modify a  an access group
+        break;
     case "s":
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
@@ -94,7 +95,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            enableGroupInDB(null, isset($select) ? $select : array());
+            enableGroupInDB(null, $select);
         } else {
             unvalidFormMessage();
         }
@@ -114,7 +115,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            disableGroupInDB(null, isset($select) ? $select : array());
+            disableGroupInDB(null, $select);
         } else {
             unvalidFormMessage();
         }
@@ -124,7 +125,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            multipleGroupInDB(isset($select) ? $select : array(), $dupNbr);
+            multipleGroupInDB($select, $dupNbr);
         } else {
             unvalidFormMessage();
         }
@@ -134,7 +135,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            deleteGroupInDB(isset($select) ? $select : array());
+            deleteGroupInDB($select);
         } else {
             unvalidFormMessage();
         }

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -66,7 +66,7 @@ $dupNbr = $_GET['dupNbr'] ?? $_POST['dupNbr'] ?? null;
 $dupNbr = is_array($dupNbr) ? sanitize_input_array($dupNbr) : [];
 
 $select = $_GET['select'] ?? $_POST['select'] ?? null;
-is_array($select) ? $select = sanitize_input_array($select) : $select = [];
+$select = is_array($select) ? sanitize_input_array($select) : [];
 
 $acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? null, FILTER_VALIDATE_INT) ?? null;
 

--- a/www/include/options/accessLists/groupsACL/listGroupConfig.php
+++ b/www/include/options/accessLists/groupsACL/listGroupConfig.php
@@ -137,6 +137,7 @@ for ($i = 0; $group = $statement->fetchRow(); $i++) {
     $rq3 = "SELECT COUNT(*) AS nbr FROM acl_group_contactgroups_relations WHERE acl_group_id = :aclGroupId ";
     $dbResult3 = $pearDB->prepare($rq3);
     $dbResult3->bindValue('aclGroupId', $group['acl_group_id'], PDO::PARAM_INT);
+    $dbResult3->execute();
     $cgNbr = $dbResult3->fetchRow();
     $dbResult3->closeCursor();
 

--- a/www/include/options/accessLists/groupsACL/listGroupConfig.php
+++ b/www/include/options/accessLists/groupsACL/listGroupConfig.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2022 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -126,16 +126,17 @@ for ($i = 0; $group = $statement->fetchRow(); $i++) {
 
     /* Contacts */
     $ctNbr = array();
-    $rq2 = "SELECT COUNT(*) AS nbr FROM acl_group_contacts_relations " .
-        "WHERE acl_group_id = '" . $group['acl_group_id'] . "'";
-    $dbResult2 = $pearDB->query($rq2);
+    $rq2 = "SELECT COUNT(*) AS nbr FROM acl_group_contacts_relations WHERE acl_group_id = :aclGroupId ";
+    $dbResult2 = $pearDB->prepare($rq2);
+    $dbResult2->bindValue(':aclGroupId', $group['acl_group_id'], PDO::PARAM_INT);
+    $dbResult2->execute();
     $ctNbr = $dbResult2->fetchRow();
     $dbResult2->closeCursor();
 
     $cgNbr = array();
-    $rq3 = "SELECT COUNT(*) AS nbr FROM acl_group_contactgroups_relations " .
-        "WHERE acl_group_id = '" . $group['acl_group_id'] . "'";
-    $dbResult3 = $pearDB->query($rq3);
+    $rq3 = "SELECT COUNT(*) AS nbr FROM acl_group_contactgroups_relations WHERE acl_group_id = :aclGroupId ";
+    $dbResult3 = $pearDB->prepare($rq3);
+    $dbResult3->bindValue('aclGroupId', $group['acl_group_id'], PDO::PARAM_INT);
     $cgNbr = $dbResult3->fetchRow();
     $dbResult3->closeCursor();
 


### PR DESCRIPTION
## Description

sanitize inputs used in ACL group page and form
bindvalues when required

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
