### PR TITLE
fix(conf/export) fix getSeverity when a host template is disabled

### DIFF
--- a/www/class/config-generate/host.class.php
+++ b/www/class/config-generate/host.class.php
@@ -41,7 +41,7 @@ class Host extends AbstractHost
     const VERTICAL_NOTIFICATION = 1;
     const CLOSE_NOTIFICATION = 2;
     const CUMULATIVE_NOTIFICATION = 3;
-    
+
     protected $hosts_by_name = array();
     protected $hosts = null;
     protected $generate_filename = 'hosts.cfg';
@@ -249,7 +249,7 @@ class Host extends AbstractHost
             && (is_null($host[$attributeAdditive]) || $host[$attributeAdditive] != 1)) {
             return $results;
         }
-        
+
         $hostsTpl = HostTemplate::getInstance($this->dependencyInjector)->hosts;
         $hostIdCache = null;
         foreach ($host['htpl'] as $hostIdTopLevel) {
@@ -426,7 +426,7 @@ class Host extends AbstractHost
                     $severity_id = $hosts_tpl[$host_id2]['severity_id'];
                     break;
                 }
-                $stack2 = array_merge($hosts_tpl[$host_id2]['htpl'], $stack2);
+                $stack2 = array_merge($hosts_tpl[$host_id2]['htpl'] ?? [], $stack2);
             }
 
             if ($severity_id) {
@@ -473,9 +473,9 @@ class Host extends AbstractHost
         $this->getHostGroups($host);
         $this->getParents($host);
         $this->getSeverity($host['host_id']);
-        
+
         $this->manageNotificationInheritance($host);
-        
+
         $this->getServices($host);
         $this->getServicesByHg($host);
 
@@ -538,7 +538,7 @@ class Host extends AbstractHost
     {
         // we pass null because it can be a meta_host with host_register = '2'
         $host = $this->getHostById($hostId, null);
-    
+
         $this->getContacts($host);
         $this->getContactGroups($host);
         $this->getHostTemplates($host, false);

--- a/www/class/config-generate/host.class.php
+++ b/www/class/config-generate/host.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2022 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under

--- a/www/class/config-generate/host.class.php
+++ b/www/class/config-generate/host.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2022 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -38,9 +38,9 @@ require_once dirname(__FILE__) . '/abstract/service.class.php';
 
 class Host extends AbstractHost
 {
-    const VERTICAL_NOTIFICATION = 1;
-    const CLOSE_NOTIFICATION = 2;
-    const CUMULATIVE_NOTIFICATION = 3;
+    public const VERTICAL_NOTIFICATION = 1;
+    public const CLOSE_NOTIFICATION = 2;
+    public const CUMULATIVE_NOTIFICATION = 3;
 
     protected $hosts_by_name = array();
     protected $hosts = null;
@@ -156,8 +156,10 @@ class Host extends AbstractHost
                     }
                     $loop[$hostId] = 1;
                     // if notifications_enabled is disabled. We don't go in branch
-                    if (!is_null($hostsTpl[$hostId]['notifications_enabled'])
-                        && (int)$hostsTpl[$hostId]['notifications_enabled'] === 0) {
+                    if (
+                        !is_null($hostsTpl[$hostId]['notifications_enabled'])
+                        && (int)$hostsTpl[$hostId]['notifications_enabled'] === 0
+                    ) {
                         continue;
                     }
 
@@ -214,8 +216,10 @@ class Host extends AbstractHost
                     }
                     $loop[$hostId] = 1;
 
-                    if (!is_null($hostsTpl[$hostId]['notifications_enabled'])
-                        && (int)$hostsTpl[$hostId]['notifications_enabled'] === 0) {
+                    if (
+                        !is_null($hostsTpl[$hostId]['notifications_enabled'])
+                        && (int)$hostsTpl[$hostId]['notifications_enabled'] === 0
+                    ) {
                         continue;
                     }
 
@@ -245,8 +249,10 @@ class Host extends AbstractHost
     private function manageVerticalInheritance(array &$host, string $attribute, string $attributeAdditive): array
     {
         $results = $host[$attribute . '_cache'];
-        if (count($results) > 0
-            && (is_null($host[$attributeAdditive]) || $host[$attributeAdditive] != 1)) {
+        if (
+            count($results) > 0
+            && (is_null($host[$attributeAdditive]) || $host[$attributeAdditive] != 1)
+        ) {
             return $results;
         }
 
@@ -267,15 +273,20 @@ class Host extends AbstractHost
                     }
                     $loop[$hostId] = 1;
 
-                    if (!is_null($hostsTpl[$hostId]['notifications_enabled'])
-                        && (int)$hostsTpl[$hostId]['notifications_enabled'] === 0) {
+                    if (
+                        !is_null($hostsTpl[$hostId]['notifications_enabled'])
+                        && (int)$hostsTpl[$hostId]['notifications_enabled'] === 0
+                    ) {
                         continue;
                     }
 
                     if (count($hostsTpl[$hostId][$attribute . '_cache']) > 0) {
                         $computedCache = array_merge($computedCache, $hostsTpl[$hostId][$attribute . '_cache']);
                         $currentLevelCatch = $level;
-                        if (is_null($hostsTpl[$hostId][$attributeAdditive]) || $hostsTpl[$hostId][$attributeAdditive] != 1) {
+                        if (
+                            is_null($hostsTpl[$hostId][$attributeAdditive])
+                            || $hostsTpl[$hostId][$attributeAdditive] != 1
+                        ) {
                             break;
                         }
                     }
@@ -307,7 +318,7 @@ class Host extends AbstractHost
      * @param array $host
      * @param array $cg
      */
-    private function setContactGroups(array &$host, array $cg = []) : void
+    private function setContactGroups(array &$host, array $cg = []): void
     {
         $cgInstance = Contactgroup::getInstance($this->dependencyInjector);
         $cgResult = '';
@@ -328,7 +339,7 @@ class Host extends AbstractHost
      * @param array $host
      * @param array $contacts
      */
-    private function setContacts(array &$host, array $contacts = []) : void
+    private function setContacts(array &$host, array $contacts = []): void
     {
         $contactInstance = Contact::getInstance($this->dependencyInjector);
         $contactResult = '';
@@ -534,7 +545,7 @@ class Host extends AbstractHost
      * @param int $hostId
      * @return array
      */
-    public function getCgAndContacts(int $hostId) : array
+    public function getCgAndContacts(int $hostId): array
     {
         // we pass null because it can be a meta_host with host_register = '2'
         $host = $this->getHostById($hostId, null);


### PR DESCRIPTION
## Description

Only modification is line 441, others are just phpcs fixes

When a host template in the inheritence tree of a host is disabled and neither the host nor its templates have a severit, this cause theconfiguration export to freeze and the following php error:

`[19-Jan-2022 11:23:18 Europe/Paris] PHP Fatal error: Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given in /usr/share/centreon/www/class/config-generate/host.class.php:429`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Having a Centreon platform with at least:
- A host template  ‘HostTemplateA'
- A host template ‘HostTemplateB’ inheriting from HostTemplateA 
- A host ‘HostTest’ inheriting from HostTemplateB
- None of the above having a severity
2. Disable the HostTemplateA from the Configuration  >  Host  >  Templates menu
3. Generate the poller configuration (Configuration  >  Pollers)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
