### PR TITLE
fix(secu) replace tabulation in command help display

### DIFF
--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -81,8 +81,8 @@ if ($commandId !== false) {
 }
 
 // Secure command
-$search = ['#S#', '#BS#', '../'];
-$replace = ['/', "\\", '/'];
+$search = ['#S#', '#BS#', '../', "\t"];
+$replace = ['/', "\\", '/', ' '];
 $command = str_replace($search, $replace, $command);
 $command = escapeshellcmd($command);
 


### PR DESCRIPTION
## Description

Command path traversal resulting in RCE

Launching this command : 
`curl -s -b 'PHPSESSID=your_token' "https://your_platform/centreon/main.get.php?p=60801&o=h&min=1" -d 'command_id=&command_name=..../..../..../..../..../bin/bash%09-c%09id%09--' | grep -B 1 --color 'uid='`
Result in uid list being displayed instead of the command help 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
