### PR TITLE
IBT-607-Protect_hostname_in_grant_priv_user_centreon_when_created

### DIFF
--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -98,7 +98,7 @@ $mandatoryPrivileges = [
     'EVENT',
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
-$query = "GRANT " . $privilegesQuery . " ON `%s`.* TO " . $parameters['db_user'] . "@" . $host;
+$query = "GRANT " . $privilegesQuery . " ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
 $flushQuery = "FLUSH PRIVILEGES";
 
 try {


### PR DESCRIPTION
## Description
Currently, you have a syntax violation error when `GRANT ALL PRIVILEGES ON %s.* TO "centreon"@" . $host . WITH GRANT OPTION;`, because the host name is not protected by a simple quote. I think it's because of the STRICT MODE in MariaDB 10.5
This action is done just after the creation of the centreon user. 
Currently, the PR is proposed for 22.04, but this is an identified problem on 21.10. It would be great if it could backport.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

You have to do a fresh install with a remote database.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
