### PR TITLE
enh(conf/broker) add db_type to new unified_sql output

### DIFF
--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -620,7 +620,7 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (69, 'storage_db_type', 'Storage DB type', 'Target DBMS.', 'select', NULL),
 (74, 'path', 'Path', 'Path of the lua script.', 'text', NULL),
 (75, 'connections_count', 'Number of connection to the database', 'Usually cpus/2', 'int', NULL),
-(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL)
+(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL),
 (77, 'db_type', 'DB type', 'Target DBMS.', 'text', 'T=options:C=value:CK=key:K=unified_sql_db_type');
 
 INSERT INTO `cb_fieldgroup` (`cb_fieldgroup_id`, `groupname`, `displayname`, `multiple`, `group_parent_id`) VALUES

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -164,7 +164,8 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('openid_connect_client_id', ''),
 ('openid_connect_client_secret', ''),
 ('openid_connect_client_basic_auth', '0'),
-('openid_connect_verify_peer', '0');
+('openid_connect_verify_peer', '0'),
+('unified_sql_db_type', 'mysql');
 
 --
 -- Contenu de la table `giv_components_template`
@@ -619,7 +620,8 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (69, 'storage_db_type', 'Storage DB type', 'Target DBMS.', 'select', NULL),
 (74, 'path', 'Path', 'Path of the lua script.', 'text', NULL),
 (75, 'connections_count', 'Number of connection to the database', 'Usually cpus/2', 'int', NULL),
-(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL);
+(76, 'tls_hostname', 'TLS Host name', 'Expected TLS certificate common name (CN) - leave blank if unsure.', 'text', NULL)
+(77, 'db_type', 'DB type', 'Target DBMS.', 'text', 'T=options:C=value:CK=key:K=unified_sql_db_type');
 
 INSERT INTO `cb_fieldgroup` (`cb_fieldgroup_id`, `groupname`, `displayname`, `multiple`, `group_parent_id`) VALUES
 (1, 'filters', '', 0, NULL),
@@ -902,7 +904,8 @@ INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`
 (34, 43, 1, 14),
 (34, 47, 0, 15),
 (34, 49, 0, 16),
-(34, 50, 0, 17);
+(34, 50, 0, 17),
+(34, 77, 1, 18);
 
 --
 -- Contenu de la table `cb_type_field_relation`

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -180,6 +180,16 @@ try {
             VALUES ($tagId, $typeId, 0)"
     );
 
+    $errorMessage = 'Unable to update options table';
+    $statement = $pearDB->query("INSERT INTO options VALUES ('unified_sql_db_type', 'mysql')");
+
+    $errorMessage = 'Unable to update cb_field table';
+    $statement = $pearDB->query(
+        "INSERT INTO cb_field (fieldname, displayname, description, fieldtype, external)
+            VALUES ('db_type', 'DB type', 'Target DBMS.', 'text', 'T=options:C=value:CK=key:K=unified_sql_db_type')"
+    );
+    $fieldId = $pearDB->lastInsertId();
+
     $errorMessage = 'Unable to update cb_type_field_relation table';
     $inputs = [];
     $statement = $pearDB->query(
@@ -194,6 +204,8 @@ try {
     if (empty($inputs)) {
         throw new Exception("Cannot find fields in cb_type_field_relation table");
     }
+
+    $inputs[] = ['cb_field_id' => $fieldId, 'is_required' => 1];
 
     $query = "INSERT INTO `cb_type_field_relation` (`cb_type_id`, `cb_field_id`, `is_required`, `order_display`)";
     foreach ($inputs as $key => $input) {


### PR DESCRIPTION
## Description

Add db_type with fixed value 'mysql' in unified_sql broker output

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
