### PR TITLE
fix(monitoring): fix regression on command line obfuscation

### DIFF
--- a/src/Core/Application/RealTime/UseCase/FindService/FindService.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindService.php
@@ -31,6 +31,7 @@ use Centreon\Domain\Security\AccessGroup;
 use Core\Domain\RealTime\Model\Acknowledgement;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Monitoring\Host as LegacyHost;
 use Centreon\Domain\Monitoring\Service as LegacyService;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringServiceInterface;
 use Core\Application\RealTime\Repository\ReadHostRepositoryInterface;
@@ -260,11 +261,12 @@ class FindService
         ) {
             try {
                 $legacyService = (new LegacyService())
+                    ->setHost((new LegacyHost())->setId($service->getHostId()))
                     ->setId($service->getId())
-                    ->setCheckCommand($service->getCommandLine());
+                    ->setCommandLine($service->getCommandLine());
 
                 $this->monitoringService->hidePasswordInServiceCommandLine($legacyService);
-                $obfuscatedCommandLine = $legacyService->getCheckCommand();
+                $obfuscatedCommandLine = $legacyService->getCommandLine();
             } catch (\Throwable $ex) {
                 $this->debug(
                     "Failed to hide password in service command line",


### PR DESCRIPTION
## Description

fix regression on command line obfuscation in service details panel

**Fixes** MON-12400

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)