### PR TITLE
fix(secu) sanitize ldap parameters and use prepare statements

### DIFF
--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -186,7 +186,7 @@ class CentreonLdapAdmin
             );
             $statement->bindValue(':ar_name', $options['ar_name'], \PDO::PARAM_STR);
             $statement->bindValue(':ar_description', $options['ar_description'], \PDO::PARAM_STR);
-            $statement->bindValue(':ar_enable', $options['ldap_auth_enable']['ldap_auth_enable'], \PDO::PARAM_INT);
+            $statement->bindValue(':ar_enable', $options['ldap_auth_enable']['ldap_auth_enable'], \PDO::PARAM_STR);
             $statement->bindValue(':ar_sync_base_date', $options['ar_sync_base_date'], \PDO::PARAM_INT);
             $statement->execute();
             $maxArIdSql = "SELECT MAX(ar_id) as last_id FROM auth_ressource WHERE ar_name = :ar_name";
@@ -207,7 +207,7 @@ class CentreonLdapAdmin
             );
             $statement->bindValue(':ar_name', $options['ar_name'], \PDO::PARAM_STR);
             $statement->bindValue(':ar_description', $options['ar_description'], \PDO::PARAM_STR);
-            $statement->bindValue(':ar_enable', $options['ldap_auth_enable']['ldap_auth_enable'], \PDO::PARAM_INT);
+            $statement->bindValue(':ar_enable', $options['ldap_auth_enable']['ldap_auth_enable'], \PDO::PARAM_STR);
             $statement->bindValue(':ar_sync_base_date', $options['ar_sync_base_date'], \PDO::PARAM_INT);
             $statement->bindValue(':ar_id', $arId, \PDO::PARAM_INT);
             $statement->execute();

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -564,14 +564,10 @@ class CentreonLdapAdmin
     public function deleteConfiguration($configList = [])
     {
         if (count($configList)) {
-
-            foreach ($configList as $val) {
-                $statement = $this->db->prepare(
-                    "DELETE FROM auth_ressource WHERE ar_id IN (:configList)"
-                );
-                $statement->bindValue(':configList', $val, \PDO::PARAM_INT);
-                $statement->execute();
-            }
+            $statement = $this->db->prepare(
+                "DELETE FROM auth_ressource WHERE ar_id IN (" . implode(',', $configList) . ")"
+            );
+            $statement->execute();
         }
     }
 
@@ -582,19 +578,16 @@ class CentreonLdapAdmin
      * @param array $configList
      * @return void
      */
-    public function setStatus($status, $configList = array())
+    public function setStatus($status, $configList = [])
     {
         if (count($configList)) {
-            foreach ($configList as $val) {
-                $statement = $this->db->prepare(
-                    "UPDATE auth_ressource
-                    SET ar_enable = :ar_enable
-                    WHERE ar_id IN (:configList)"
-                );
-                $statement->bindValue(':ar_enable', $status, \PDO::PARAM_INT);
-                $statement->bindValue(':configList', $val, \PDO::PARAM_INT);
-                $statement->execute();
-            }
+            $statement = $this->db->prepare(
+                "UPDATE auth_ressource
+                SET ar_enable = :ar_enable
+                WHERE ar_id IN (" . implode(',', $configList) . ")"
+            );
+            $statement->bindValue(':ar_enable', $status, \PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 
@@ -654,13 +647,11 @@ class CentreonLdapAdmin
                     $ldapContactIdList[] = $row['contact_id'];
                 }
                 if (!empty($ldapContactIdList)) {
-                    foreach ($ldapContactIdList as $val) {
-                        $statement = $this->db->prepare(
-                            "DELETE FROM contact_password WHERE contact_id IN (:contactIds)"
-                        );
-                        $statement->bindValue(':contactIds', $val, \PDO::PARAM_INT);
-                        $statement->execute();
-                    }
+                    $statement = $this->db->prepare(
+                        "DELETE FROM contact_password WHERE contact_id IN ("
+                        . implode(',', $ldapContactIdList) . ")"
+                    );
+                    $statement->execute();
                 }
             }
         }

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -60,6 +60,29 @@ class CentreonLdapAdmin
     }
 
     /**
+     * used to sanitize key and value in array
+     * @param array<mixed> $inputArray
+     * @return array<mixed>
+     */
+    public function sanitizeInputArray(array $inputArray): array
+    {
+        $sanitizedArray = [];
+        foreach ($inputArray as $key => $value) {
+            if ($key === 'address') {
+                $key = filter_var($key, FILTER_SANITIZE_STRING);
+                $value = filter_var($value, FILTER_SANITIZE_STRING);
+            } else {
+                $key = filter_var($key, FILTER_VALIDATE_INT);
+                $value = filter_var($value, FILTER_VALIDATE_INT);
+            }
+            if (false !== $key && false !== $value) {
+                $sanitizedArray[$key] = $value;
+            }
+        }
+        return $sanitizedArray;
+    }
+
+    /**
      * Get ldap parameters
      *
      * @return array
@@ -108,20 +131,19 @@ class CentreonLdapAdmin
      */
     protected function updateLdapServers($arId)
     {
-        $centreonUtils = new CentreonUtils();
         $statement = $this->db->prepare("DELETE FROM auth_ressource_host WHERE auth_ressource_id = :auth_ressource_id");
         $statement->bindValue(':auth_ressource_id', $arId, \PDO::PARAM_INT);
         $statement->execute();
         if (isset($_REQUEST['address']) && is_array($_REQUEST['address'])) {
-            $addressList = $centreonUtils->sanitizeInputArrayNew($_REQUEST['address']);
+            $addressList = $this->sanitizeInputArray($_REQUEST['address']);
             $portList = isset($_REQUEST['port'])
-                ? $centreonUtils->sanitizeInputArrayNew($_REQUEST['port'])
+                ? $this->sanitizeInputArray($_REQUEST['port'])
                 : null;
             $sslList = isset($_REQUEST['ssl'])
-                ? $centreonUtils->sanitizeInputArrayNew($_REQUEST['ssl'])
+                ? $this->sanitizeInputArray($_REQUEST['ssl'])
                 : null;
             $tlsList = isset($_REQUEST['tls'])
-            ? $centreonUtils->sanitizeInputArrayNew($_REQUEST['tls'])
+            ? $this->sanitizeInputArray($_REQUEST['tls'])
             : null;
             $insertStr = "";
             $i = 1;

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -599,13 +599,16 @@ class CentreonLdapAdmin
     public function setStatus($status, $configList = [])
     {
         if (count($configList)) {
-            $statement = $this->db->prepare(
-                "UPDATE auth_ressource
-                SET ar_enable = :ar_enable
-                WHERE ar_id IN (" . implode(',', $configList) . ")"
-            );
-            $statement->bindValue(':ar_enable', $status, \PDO::PARAM_STR);
-            $statement->execute();
+            foreach ($configList as $val) {
+                $statement = $this->db->prepare(
+                    "UPDATE auth_ressource
+                    SET ar_enable = :ar_enable
+                    WHERE ar_id IN (:ar_id)"
+                );
+                $statement->bindValue(':ar_id', $val, \PDO::PARAM_STR);
+                $statement->bindValue(':ar_enable', $status, \PDO::PARAM_STR);
+                $statement->execute();
+            }
         }
     }
 

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -532,7 +532,7 @@ class CentreonLdapAdmin
     {
         $sql = "SELECT ar_id, ar_enable, ar_name, ar_description, ar_sync_base_date FROM auth_ressource ";
         if ($search != "") {
-            $sql .= "WHERE ar_name LIKE '%:ar_name%' ";
+            $sql .= "WHERE ar_name LIKE :ar_name ";
         }
         $sql .= "ORDER BY ar_name ";
         if (!is_null($offset) && !is_null($limit)) {
@@ -541,7 +541,7 @@ class CentreonLdapAdmin
         $res = $this->db->prepare($sql);
 
         if ($search != "") {
-            $res->bindValue(':ar_name', $search, \PDO::PARAM_STR);
+            $res->bindValue(':ar_name', "%$search%", \PDO::PARAM_STR);
         }
         if (!is_null($offset) && !is_null($limit)) {
             $res->bindValue(':offset', $offset, \PDO::PARAM_INT);

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -73,7 +73,7 @@ class CentreonLdapAdmin
                 $key = filter_var($key, FILTER_VALIDATE_INT);
                 $value = filter_var($value, FILTER_VALIDATE_INT);
             }
-            if ((false !== $key || $key !== '') && (false !== $value || $key !== '')) {
+            if ((false !== $key || $key !== '') && (false !== $value || $value !== '')) {
                 $sanitizedArray[$key] = $value;
             }
         }

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -379,16 +379,14 @@ class CentreonLdapAdmin
     public function addTemplate($options = [])
     {
         try {
-            $statement = $this->db->prepare(
+            $this->db->query(
                 "INSERT INTO auth_ressource (ar_type, ar_enable) VALUES ('ldap_tmpl', '0')"
             );
-            $statement->execute();
         } catch (\PDOException $e) {
             return false;
         }
         try {
-            $dbResult = $this->db->prepare("SELECT MAX(ar_id) as id FROM auth_ressource WHERE ar_type = 'ldap_tmpl'");
-            $dbResult->execute();
+            $dbResult = $this->db->query("SELECT MAX(ar_id) as id FROM auth_ressource WHERE ar_type = 'ldap_tmpl'");
             $row = $dbResult->fetch();
         } catch (\PDOException $e) {
             return false;
@@ -463,12 +461,11 @@ class CentreonLdapAdmin
     public function getTemplate($id = 0)
     {
         if ($id === 0) {
-            $res = $this->db->prepare(
+            $res = $this->db->query(
                 "SELECT ar_id
                  FROM auth_ressource
                  WHERE ar_type = 'ldap_tmpl'"
             );
-            $res->execute();
             if ($res->rowCount() === 0) {
                 return [];
             }
@@ -584,10 +581,11 @@ class CentreonLdapAdmin
     public function deleteConfiguration($configList = [])
     {
         if (count($configList)) {
-            $statement = $this->db->prepare(
-                "DELETE FROM auth_ressource WHERE ar_id IN (" . implode(',', $configList) . ")"
+            $this->db->query(
+                "DELETE FROM auth_ressource
+                WHERE ar_id
+                IN (" . implode(',', $configList) . ")"
             );
-            $statement->execute();
         }
     }
 
@@ -667,11 +665,10 @@ class CentreonLdapAdmin
                     $ldapContactIdList[] = $row['contact_id'];
                 }
                 if (!empty($ldapContactIdList)) {
-                    $statement = $this->db->prepare(
-                        "DELETE FROM contact_password WHERE contact_id IN ("
-                        . implode(',', $ldapContactIdList) . ")"
+                    $contactIds = implode(', ', $ldapContactIdList);
+                    $this->db->query(
+                        "DELETE FROM contact_password WHERE contact_id IN ($contactIds)"
                     );
-                    $statement->execute();
                 }
             }
         }

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -100,18 +100,43 @@ class CentreonLdapAdmin
     }
 
     /**
+     * used to sanitize key and value in array
+     * @param array<mixed> $inputArray
+     * @return array<mixed>
+     */
+    public function sanitizeInputArray(array $inputArray): array
+    {
+        $sanitizedArray = [];
+        foreach ($inputArray as $key => $value) {
+            if ($key === 'address') {
+                $key = filter_var($key, FILTER_SANITIZE_STRING);
+                $value = filter_var($value, FILTER_SANITIZE_STRING);
+            } else {
+                $key = filter_var($key, FILTER_VALIDATE_INT);
+                $value = filter_var($value, FILTER_VALIDATE_INT);
+            }
+            if (false !== $key && false !== $value) {
+                $sanitizedArray[$key] = $value;
+            }
+        }
+        return $sanitizedArray;
+    }
+
+    /**
      * Update Ldap servers
      *
      * @param int $arId | auth resource id
      */
     protected function updateLdapServers($arId)
     {
-        $this->db->query("DELETE FROM auth_ressource_host WHERE auth_ressource_id = " . $this->db->escape($arId));
+        $statement = $this->db->prepare("DELETE FROM auth_ressource_host WHERE auth_ressource_id = :auth_ressource_id");
+        $statement->bindValue(':auth_ressource_id', $arId, \PDO::PARAM_INT);
+        $statement->execute();
         if (isset($_REQUEST['address'])) {
-            $addressList = $_REQUEST['address'] ?? null;
-            $portList = $_REQUEST['port'] ?? null;
-            $sslList = $_REQUEST['ssl'] ?? null;
-            $tlsList = $_REQUEST['tls'] ?? null;
+            $addressList = sanitizeInputArray($_REQUEST['address']);
+            $portList = isset($_REQUEST['port']) ? sanitizeInputArray($_REQUEST['port']) : null;
+            $sslList = isset($_REQUEST['ssl']) ? sanitizeInputArray($_REQUEST['ssl']) : null;
+            $tlsList = isset($_REQUEST['tls']) ? sanitizeInputArray($_REQUEST['tls']) : null;
             $insertStr = "";
             $i = 1;
             foreach ($addressList as $key => $addr) {
@@ -128,11 +153,13 @@ class CentreonLdapAdmin
                 $i++;
             }
             if ($insertStr) {
-                $this->db->query(
+                $$statement = $this->db->prepare(
                     "INSERT INTO auth_ressource_host
                     (auth_ressource_id, host_address, host_port, use_ssl, use_tls, host_order)
-                    VALUES $insertStr"
+                    VALUES :insertStr"
                 );
+                $statement->bindValue(':insertStr', $insertStr, \PDO::PARAM_STR);
+                $statement->execute();
             }
         }
     }
@@ -167,30 +194,39 @@ class CentreonLdapAdmin
                     "LDAP PARAM - Warning the reference date wasn\'t set for LDAP : " . $options['ar_name']
                 );
             }
-            $this->db->query(
-                "INSERT INTO auth_ressource (ar_name, ar_description, ar_type, ar_enable, ar_sync_base_date) 
-                VALUES ('" . $this->db->escape($options['ar_name']) . "',
-                    '" . $this->db->escape($options['ar_description']) . "',
-                    'ldap',
-                    '" . $options['ldap_auth_enable']['ldap_auth_enable'] . "',
-                    '" . $options['ar_sync_base_date'] . "')"
+            $statement = $this->db->prepare(
+                "INSERT INTO auth_ressource (ar_name, ar_description, ar_type, ar_enable, ar_sync_base_date)
+                VALUES (:ar_name, :ar_description,'ldap', :ar_enable, :ar_sync_base_date"
             );
+            $statement->bindValue(':ar_name', $options['ar_name'], \PDO::PARAM_STR);
+            $statement->bindValue(':ar_description', $options['ar_description'], \PDO::PARAM_STR);
+            $statement->bindValue(':ar_enable', $options['ldap_auth_enable']['ldap_auth_enable'], \PDO::PARAM_INT);
+            $statement->bindValue(':ar_sync_base_date', $ $options['ar_sync_base_date'], \PDO::PARAM_INT);
+            $statement->execute();
             $maxArIdSql = "SELECT MAX(ar_id) as last_id
                           FROM auth_ressource
-                          WHERE ar_name = '" . $this->db->escape($options['ar_name']) . "'";
-            $res = $this->db->query($maxArIdSql);
+                          WHERE ar_name = :ar_name";
+            $res = $this->db->prepare($maxArIdSql);
+            $res->bindValue(':ar_name', $options['ar_name'], \PDO::PARAM_STR);
+            $res->execute();
             $row = $res->fetch();
             $arId = $row['last_id'];
             unset($res);
         } else {
-            $this->db->query(
+            $statement = $this->db->prepare(
                 "UPDATE auth_ressource
-                SET ar_name = '" . $this->db->escape($options['ar_name']) . "',
-                ar_description = '" . $this->db->escape($options['ar_description']) . "',
-                ar_enable = '" . $options['ldap_auth_enable']['ldap_auth_enable'] . "',
-                ar_sync_base_date = '" . $options['ar_sync_base_date'] . "'
-                WHERE ar_id = " . $this->db->escape($arId)
+                SET ar_name = :ar_name,
+                ar_description = :ar_description,
+                ar_enable = :ar_enable,
+                ar_sync_base_date = :ar_sync_base_date
+                WHERE ar_id = :ar_id"
             );
+            $statement->bindValue(':ar_name', $options['ar_name'], \PDO::PARAM_STR);
+            $statement->bindValue(':ar_description', $options['ar_description'], \PDO::PARAM_STR);
+            $statement->bindValue(':ar_enable', $options['ldap_auth_enable']['ldap_auth_enable'], \PDO::PARAM_INT);
+            $statement->bindValue(':ar_sync_base_date', $ $options['ar_sync_base_date'], \PDO::PARAM_INT);
+            $statement->bindValue(':ar_id', $arId, \PDO::PARAM_INT);
+            $statement->execute();
         }
         $knownParameters = $this->getLdapParameters();
         if (
@@ -228,16 +264,19 @@ class CentreonLdapAdmin
             }
             if (isset($gopt[$key])) {
                 $query = "UPDATE `auth_ressource_info`
-                    SET `ari_value` = '" . $this->db->escape($value, false) . "'
-                    WHERE `ari_name` = '" . $this->db->escape($key) . "'
-                    AND ar_id = " . $this->db->escape($arId);
+                    SET `ari_value` = :ari_value
+                    WHERE `ari_name` = :ari_name
+                    AND ar_id = :ar_id";
             } else {
                 $query = "INSERT INTO `auth_ressource_info`
                     (`ar_id`, `ari_name`, `ari_value`)
-                    VALUES (" . $this->db->escape($arId) . ", '" . $this->db->escape($key) . "', '" .
-                    $this->db->escape($value, false) . "')";
+                    VALUES (:ar_id, :ari_name, :ari_value)";
             }
-            $this->db->query($query);
+            $statement = $this->db->prepare($query);
+            $statement->bindvalue(':ar_id', $arId, \PDO::PARAM_INT);
+            $statement->bindvalue(':ari_name', $key, \PDO::PARAM_STR);
+            $statement->bindvalue(':ari_value', $value, \PDO::PARAM_STR);
+            $statement->execute();
         }
         $this->updateLdapServers($arId);
 
@@ -255,11 +294,13 @@ class CentreonLdapAdmin
      */
     public function getGeneralOptions($arId)
     {
-        $gopt = array();
+        $gopt = [];
         $query = "SELECT `ari_name`, `ari_value` FROM `auth_ressource_info`
             WHERE `ari_name` <> 'bind_pass'
-            AND ar_id = " . $this->db->escape($arId);
-        $res = $this->db->query($query);
+            AND ar_id = :ar_id";
+        $res = $this->db->prepare($query);
+        $res->bindValue(':ar_id', $arId, \PDO::PARAM_INT);
+        $res->execute();
         while ($row = $res->fetch()) {
             $gopt[$row['ari_name']] = $row['ari_value'];
         }
@@ -280,12 +321,15 @@ class CentreonLdapAdmin
         $use_tls = isset($params['use_tls']) ? 1 : 0;
         $sql = "INSERT INTO auth_ressource_host " .
             "(auth_ressource_id, host_address, host_port, use_ssl, use_tls, host_order) " .
-            "VALUES ($arId, '" . $this->db->escape($params['hostname']) . "', '" .
-            $this->db->escape($params['port']) . "', " .
-            $use_ssl . ", " .
-            $use_tls . ", '" .
-            $this->db->escape($params['order']) . "')";
-        $this->db->query($sql);
+            "VALUES (:ar_id, :hostname, :port, :use_ssl, :use_tls, :host_order)";
+        $statement = $this->db->prepare($sql);
+        $statement->bindvalue(':ar_id', $arId, \PDO::PARAM_INT);
+        $statement->bindvalue(':hostname', $params['hostname'], \PDO::PARAM_STR);
+        $statement->bindvalue(':port', $params['port'], \PDO::PARAM_INT);
+        $statement->bindvalue(':use_ssl', $use_ssl, \PDO::PARAM_INT);
+        $statement->bindvalue(':use_tls', $use_tls, \PDO::PARAM_INT);
+        $statement->bindvalue(':host_order', $params['order'], \PDO::PARAM_INT);
+        $statement->execute();
     }
 
     /**
@@ -302,15 +346,23 @@ class CentreonLdapAdmin
         }
         $use_ssl = isset($params['use_ssl']) ? 1 : 0;
         $use_tls = isset($params['use_tls']) ? 1 : 0;
-        $sql = "UPDATE auth_ressource_host 
-            SET host_address = '" . $this->db->escape($params['hostname']) . "',
-            host_port = '" . $this->db->escape($params['port']) . "',
-            host_order = '" . $this->db->escape($params['order']) . "',
-            use_ssl = " . $use_ssl . ",
-            use_tls = " . $use_tls . "
-            WHERE ldap_host_id = " . $this->db->escape($params['id']) . "
-            AND auth_ressource_id = " . $arId;
-        $this->db->query($sql);
+        $sql = "UPDATE auth_ressource_host
+            SET host_address = :hostname,
+            host_port = :host_port,
+            host_order = :host_order,
+            use_ssl = :use_ssl,
+            use_tls = :use_tls
+            WHERE ldap_host_id = :ldap_host_id
+            AND auth_ressource_id = :ar_id";
+        $statement = $this->db->prepare($sql);
+        $statement->bindvalue(':hostname', $params['hostname'], \PDO::PARAM_STR);
+        $statement->bindvalue(':host_port', $params['port'], \PDO::PARAM_INT);
+        $statement->bindvalue(':host_order', $params['order'], \PDO::PARAM_INT);
+        $statement->bindvalue(':use_ssl', $use_ssl, \PDO::PARAM_INT);
+        $statement->bindvalue(':use_tls', $use_tls, \PDO::PARAM_INT);
+        $statement->bindvalue(':ldap_host_id', $params['id'], \PDO::PARAM_INT);
+        $statement->bindvalue(':ar_id', $arId, \PDO::PARAM_INT);
+        $statement->execute();
     }
 
     /**
@@ -319,17 +371,19 @@ class CentreonLdapAdmin
      * @param array $options A hash table with options for connections and search in ldap
      * @return int|bool The id of connection, false on error
      */
-    public function addTemplate($options = array())
+    public function addTemplate($options = [])
     {
         try {
-            $this->db->query(
+            $statement = $this->db->prepare(
                 "INSERT INTO auth_ressource (ar_type, ar_enable) VALUES ('ldap_tmpl', '0')"
             );
+            $statement->execute();
         } catch (\PDOException $e) {
             return false;
         }
         try {
-            $dbResult = $this->db->query("SELECT MAX(ar_id) as id FROM auth_ressource WHERE ar_type = 'ldap_tmpl'");
+            $dbResult = $this->db->prepare("SELECT MAX(ar_id) as id FROM auth_ressource WHERE ar_type = 'ldap_tmpl'");
+            $dbResult->execute();
             $row = $dbResult->fetch();
         } catch (\PDOException $e) {
             return false;
@@ -337,11 +391,14 @@ class CentreonLdapAdmin
         $id = $row['id'];
         foreach ($options as $key => $value) {
             try {
-                $this->db->query(
+                $statement = $this->db->prepare(
                     "INSERT INTO auth_ressource_info
-                    (ar_id, ari_name, ari_value) VALUES (" . CentreonDB::escape($id) . ", '" .
-                    $this->db->escape($key) . "', '" . $this->db->escape($value) . "')"
+                    (ar_id, ari_name, ari_value) VALUES (:ar_id, :ari_name, :ari_value)"
                 );
+                $statement->bindvalue(':ar_id', $id, \PDO::PARAM_INT);
+                $statement->bindvalue(':ari_name', $key, \PDO::PARAM_INT);
+                $statement->bindvalue(':ari_value', $value, \PDO::PARAM_INT);
+                $statement->execute();
             } catch (\PDOException $e) {
                 return false;
             }
@@ -366,17 +423,24 @@ class CentreonLdapAdmin
         foreach ($options as $key => $value) {
             try {
                 if (isset($config[$key])) {
-                    $sth = $this->db->query(
-                        "UPDATE auth_ressource_info SET ari_value = '" . $this->db->escape($value) . "'
-                        WHERE ar_id = " . CentreonDB::escape($id) . " AND ari_name = '" . $this->db->escape($key) . "'"
+                    $statement = $this->db->prepare(
+                        "UPDATE auth_ressource_info SET ari_value = :ari_value
+                        WHERE ar_id = :ar_id AND ari_name = :ari_name"
                     );
+                    $statement->bindvalue(':ar_id', $id, \PDO::PARAM_INT);
+                    $statement->bindvalue(':ari_name', $key, \PDO::PARAM_STR);
+                    $statement->bindvalue(':ari_value', $value, \PDO::PARAM_INT);
+                    $statement->execute();
                 } else {
-                    $sth = $this->db->query(
+                    $statement = $this->db->prepare(
                         "INSERT INTO auth_ressource_info
                         (ar_id, ari_name, ari_value)
-                        VALUES (" . CentreonDB::escape($id) . ", '" . $this->db->escape($key) . "', '" .
-                        $this->db->escape($value) . "')"
+                        VALUES (:ar_id, :ari_name, :ari_value)"
                     );
+                    $statement->bindvalue(':ar_id', $id, \PDO::PARAM_INT);
+                    $statement->bindvalue(':ari_name', $key, \PDO::PARAM_STR);
+                    $statement->bindvalue(':ari_value', $value, \PDO::PARAM_INT);
+                    $statement->execute();
                 }
             } catch (\PDOException $e) {
                 return false;
@@ -393,23 +457,26 @@ class CentreonLdapAdmin
      */
     public function getTemplate($id = 0)
     {
-        if ($id == 0) {
-            $res = $this->db->query(
-                "SELECT ar_id 
-                 FROM auth_ressource 
+        if ($id === 0) {
+            $res = $this->db->prepare(
+                "SELECT ar_id
+                 FROM auth_ressource
                  WHERE ar_type = 'ldap_tmpl'"
             );
-            if ($res->rowCount() == 0) {
-                return array();
+            $res->execute();
+            if ($res->rowCount() === 0) {
+                return [];
             }
             $row = $res->fetch();
             $id = $row['ar_id'];
         }
         $query = "SELECT ari_name, ari_value
                  FROM auth_ressource_info
-                 WHERE ar_id = " . CentreonDB::escape($id);
-        $res = $this->db->query($query);
-        $list = array();
+                 WHERE ar_id = :ar_id";
+        $res = $this->db->prepare($query);
+        $res->bindValue(':ar_id', $id, \PDO::PARAM_INT);
+        $res->execute();
+        $list = [];
         while ($row = $res->fetch()) {
             $list[$row['ari_name']] = $row['ari_value'];
         }
@@ -480,14 +547,23 @@ class CentreonLdapAdmin
     {
         $sql = "SELECT ar_id, ar_enable, ar_name, ar_description, ar_sync_base_date FROM auth_ressource ";
         if ($search != "") {
-            $sql .= "WHERE ar_name LIKE '%" . $this->db->escape($search) . "%' ";
+            $sql .= "WHERE ar_name LIKE '%:ar_name%' ";
         }
         $sql .= "ORDER BY ar_name ";
         if (!is_null($offset) && !is_null($limit)) {
-            $sql .= "LIMIT $offset,$limit";
+            $sql .= "LIMIT :offset,:limit";
         }
-        $res = $this->db->query($sql);
-        $tab = array();
+        $res = $this->db->prepare($sql);
+
+        if ($search != "") {
+            $res->bindValue(':ar_name', $search, \PDO::PARAM_STR);
+        }
+        if (!is_null($offset) && !is_null($limit)) {
+            $res->bindValue(':offset', $offset, \PDO::PARAM_INT);
+            $res->bindValue(':limit', $limit, \PDO::PARAM_INT);
+        }
+        $res->execute();
+        $tab = [];
         while ($row = $res->fetch()) {
             $tab[] = $row;
         }
@@ -500,14 +576,16 @@ class CentreonLdapAdmin
      * @param array $configList
      * @return void
      */
-    public function deleteConfiguration($configList = array())
+    public function deleteConfiguration($configList = [])
     {
         if (count($configList)) {
-            $this->db->query(
-                "DELETE FROM auth_ressource 
-                WHERE ar_id 
-                IN (" . implode(',', $configList) . ")"
+            $statement = $this->db->prepare(
+                "DELETE FROM auth_ressource
+                WHERE ar_id
+                IN (:configList)"
             );
+            $statement->bindValue(':configList', implode(',', $configList), \PDO::PARAM_STR);
+            $statement->execute();
         }
     }
 
@@ -521,11 +599,14 @@ class CentreonLdapAdmin
     public function setStatus($status, $configList = array())
     {
         if (count($configList)) {
-            $this->db->query(
-                "UPDATE auth_ressource 
-                SET ar_enable = '" . $this->db->escape($status) . "'
-                WHERE ar_id IN (" . implode(',', $configList) . ")"
+            $statement = $this->db->prepare(
+                "UPDATE auth_ressource
+                SET ar_enable = :ar_enable
+                WHERE ar_id IN (:configList)"
             );
+            $statement->bindValue(':ar_enable', $status, \PDO::PARAM_INT);
+            $statement->bindValue(':configList', implode(',', $configList), \PDO::PARAM_STR);
+            $statement->execute();
         }
     }
 
@@ -537,13 +618,14 @@ class CentreonLdapAdmin
      */
     public function getServersFromResId($arId)
     {
-        $res = $this->db->query(
+        $res = $this->db->prepare(
             "SELECT host_address, host_port, use_ssl, use_tls
             FROM auth_ressource_host
-            WHERE auth_ressource_id = " . $this->db->escape($arId) .
-            " ORDER BY host_order"
+            WHERE auth_ressource_id = :auth_ressource_id ORDER BY host_order"
         );
-        $arr = array();
+        $res->bindValue(':auth_ressource_id', $arId, \PDO::PARAM_INT);
+        $res->execute();
+        $arr = [];
         $i = 0;
         while ($row = $res->fetch()) {
             $arr[$i]['address_#index#'] = $row['host_address'];
@@ -567,12 +649,13 @@ class CentreonLdapAdmin
      */
     private function manageContactPasswords($arId)
     {
-        $result = $this->db->query(
+        $result = $this->db->prepare(
             'SELECT ari_value ' .
             'FROM auth_ressource_info ' .
-            'WHERE ar_id = ' . $this->db->escape($arId) . ' ' .
-            'AND ari_name = "ldap_store_password" '
+            'WHERE ar_id = :ar_id AND ari_name = "ldap_store_password" '
         );
+        $result->bindValue(':arId', $arId, \PDO::PARAM_INT);
+        $result->execute();
         if ($row = $result->fetch()) {
             if ($row['ari_value'] == '0') {
                 $statement = $this->db->prepare("SELECT contact_id FROM contact WHERE ar_id = :arId");
@@ -584,9 +667,11 @@ class CentreonLdapAdmin
                 }
                 if (!empty($ldapContactIdList)) {
                     $contactIds = implode(', ', $ldapContactIdList);
-                    $this->db->query(
-                        "DELETE FROM contact_password WHERE contact_id IN ($contactIds)"
+                    $statement = $this->db->prepare(
+                        "DELETE FROM contact_password WHERE contact_id IN (:contactIds)"
                     );
+                    $statement->bindValue(':contactIds', $contactIds, \PDO::PARAM_STR);
+                    $statement->execute();
                 }
             }
         }

--- a/www/class/CentreonLDAPAdmin.class.php
+++ b/www/class/CentreonLDAPAdmin.class.php
@@ -34,8 +34,6 @@
  *
  */
 
-require_once 'centreonUtils.class.php';
-
 /**
  * Ldap Administration class
  */

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -800,7 +800,7 @@ class CentreonLDAP
     {
         if ($this->debugImport) {
             $msg = $this->db->escape($msg);
-            error_log("[" . date("d/m/Y H:i") . "] $msg\n", 3, $this->debugPath . "ldapsearch.log");
+            error_log("[" . date("d/m/Y H:i") . "] $msg" . PHP_EOL, 3, $this->debugPath . "ldapsearch.log");
         }
     }
 

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -298,7 +298,7 @@ class CentreonLDAP
      * @param string $username The username
      * @return string|bool The dn string or false if not found
      */
-    public function findUserDn($username): string|bool
+    public function findUserDn($username)
     {
         if (trim($this->userSearchInfo['filter']) == '') {
             return false;
@@ -795,7 +795,8 @@ class CentreonLDAP
     private function debug($msg): void
     {
         if ($this->debugImport) {
-            error_log("[" . date("d/m/Y H:i") . "] " . $msg . "\n", 3, $this->debugPath . "ldapsearch.log");
+            $msg = $this->db->escape($msg);
+            error_log("[" . date("d/m/Y H:i") . "] $msg\n", 3, $this->debugPath . "ldapsearch.log");
         }
     }
 

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -775,9 +775,9 @@ class CentreonLDAP
         if (isset($this->constuctCache[$id])) {
             return $this->constuctCache[$id];
         }
-        $query = "SELECT ari_name, ari_value 
-                 FROM auth_ressource_info 
-                 WHERE ari_name IN ('bind_dn', 'bind_pass', 'protocol_version') 
+        $query = "SELECT ari_name, ari_value
+                 FROM auth_ressource_info
+                 WHERE ari_name IN ('bind_dn', 'bind_pass', 'protocol_version')
                  AND ar_id = :ar_id";
         $dbResult = $this->db->prepare($query);
         $dbResult->bindValue(':ar_id', $id, \PDO::PARAM_INT);
@@ -800,7 +800,7 @@ class CentreonLDAP
     {
         if ($this->debugImport) {
             $msg = $this->db->escape($msg);
-            error_log("[" . date("d/m/Y H:i") . "] $msg" . PHP_EOL, 3, $this->debugPath . "ldapsearch.log");
+            error_log("[" . date("d/m/Y H:i") . "] $msg", 3, $this->debugPath . "ldapsearch.log");
         }
     }
 
@@ -849,7 +849,6 @@ class CentreonLDAP
      */
     private function getCnFromDn($dn)
     {
-
         if (preg_match('/(?i:(?<=cn=)).*?(?=,[A-Za-z]{0,2}=|$)/', $dn, $dnArray)) {
             return !empty($dnArray) ? $dnArray[0] : false;
         }

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -78,13 +78,12 @@ class CentreonLDAP
             $use_dns_srv = $row['ari_value'];
         }
 
-        $dbResult = $this->db->prepare(
+        $dbResult = $this->db->query(
             "SELECT `key`, `value`
             FROM `options`
             WHERE `key`
             IN ('debug_ldap_import', 'debug_path')"
         );
-        $dbResult->execute();
         while ($row = $dbResult->fetch()) {
             if ($row['key'] == 'debug_ldap_import') {
                 if ($row['value'] == 1) {
@@ -751,8 +750,7 @@ class CentreonLDAP
     private function getInfoUseDnsConnect(): void
     {
         $query = "SELECT `key`, `value` FROM `options` WHERE `key` IN ('ldap_dns_use_ssl', 'ldap_dns_use_tls')";
-        $dbResult = $this->db->prepare($query);
-        $dbResult->execute();
+        $dbResult = $this->db->query($query);
         $infos = [];
         while ($row = $dbResult->fetch()) {
             if ($row['key'] == 'ldap_dns_use_ssl') {

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -796,7 +796,7 @@ class CentreonLDAP
      *
      * @param string $msg
      */
-    private function debug($msg): void
+    private function debug($msg)
     {
         if ($this->debugImport) {
             error_log("[" . date("d/m/Y H:i") . "] " . $msg . "\n", 3, $this->debugPath . "ldapsearch.log");

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -799,8 +799,7 @@ class CentreonLDAP
     private function debug($msg): void
     {
         if ($this->debugImport) {
-            $msg = $this->db->escape($msg);
-            error_log("[" . date("d/m/Y H:i") . "] $msg" . PHP_EOL, 3, $this->debugPath . "ldapsearch.log");
+            error_log("[" . date("d/m/Y H:i") . "] " . $msg . "\n", 3, $this->debugPath . "ldapsearch.log");
         }
     }
 

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -796,7 +796,7 @@ class CentreonLDAP
      *
      * @param string $msg
      */
-    private function debug($msg)
+    private function debug($msg): void
     {
         if ($this->debugImport) {
             error_log("[" . date("d/m/Y H:i") . "] " . $msg . "\n", 3, $this->debugPath . "ldapsearch.log");

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -71,6 +71,7 @@ class CentreonLDAP
             "AND ar_id = :ar_id"
         );
         $dbResult->bindValue(':ar_id', $arId, \PDO::PARAM_INT);
+        $dbResult->execute();
         $row = $dbResult->fetch();
         $dbResult->closeCursor();
         if (isset($row['ari_value'])) {
@@ -119,6 +120,7 @@ class CentreonLDAP
                 AND ar_id = :ar_id"
             );
             $dbResult->bindValue(':ar_id', $arId, \PDO::PARAM_INT);
+            $dbResult->execute();
             $row = $dbResult->fetch();
             $dbResult->closeCursor();
             if ($row && trim($row['ari_value']) != '') {
@@ -143,6 +145,7 @@ class CentreonLDAP
                 ORDER BY host_order"
             );
             $dbResult->bindValue(':ar_id', $arId, \PDO::PARAM_INT);
+            $dbResult->execute();
             while ($row = $dbResult->fetch()) {
                 $ldap = array();
                 $ldap['host'] = $row['host_address'];
@@ -180,6 +183,7 @@ class CentreonLDAP
 
         $finalLdapHostParameters = [];
 
+        $resLdapHostParameters->execute();
         while ($rowLdapHostParameters = $resLdapHostParameters->fetch()) {
             $finalLdapHostParameters = $rowLdapHostParameters;
         }

--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -91,6 +91,29 @@ class CentreonUtils
     }
 
     /**
+     * used to sanitize key and value in array
+     * @param array<mixed> $inputArray
+     * @return array<mixed>
+     */
+    public function sanitizeInputArrayNew(array $inputArray): array
+    {
+        $sanitizedArray = [];
+        foreach ($inputArray as $key => $value) {
+            if ($key === 'address') {
+                $key = filter_var($key, FILTER_SANITIZE_STRING);
+                $value = filter_var($value, FILTER_SANITIZE_STRING);
+            } else {
+                $key = filter_var($key, FILTER_VALIDATE_INT);
+                $value = filter_var($value, FILTER_VALIDATE_INT);
+            }
+            if (false !== $key && false !== $value) {
+                $sanitizedArray[$key] = $value;
+            }
+        }
+        return $sanitizedArray;
+    }
+
+    /**
      * Converts Object into Array
      *
      * @param mixed $arrObjData

--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -91,29 +91,6 @@ class CentreonUtils
     }
 
     /**
-     * used to sanitize key and value in array
-     * @param array<mixed> $inputArray
-     * @return array<mixed>
-     */
-    public function sanitizeInputArrayNew(array $inputArray): array
-    {
-        $sanitizedArray = [];
-        foreach ($inputArray as $key => $value) {
-            if ($key === 'address') {
-                $key = filter_var($key, FILTER_SANITIZE_STRING);
-                $value = filter_var($value, FILTER_SANITIZE_STRING);
-            } else {
-                $key = filter_var($key, FILTER_VALIDATE_INT);
-                $value = filter_var($value, FILTER_VALIDATE_INT);
-            }
-            if (false !== $key && false !== $value) {
-                $sanitizedArray[$key] = $value;
-            }
-        }
-        return $sanitizedArray;
-    }
-
-    /**
      * Converts Object into Array
      *
      * @param mixed $arrObjData

--- a/www/include/Administration/parameters/ldap/form.php
+++ b/www/include/Administration/parameters/ldap/form.php
@@ -133,7 +133,7 @@ $form->addRule('ldap_sync_interval', _("An integer with a minimum value of 1 is 
 /**
  * list of contact template available
  */
-$res = $pearDB->prepare(
+$res = $pearDB->query(
     "SELECT contact_id, contact_name FROM contact WHERE contact_register = '0'"
 );
 $res->execute();

--- a/www/include/Administration/parameters/ldap/form.php
+++ b/www/include/Administration/parameters/ldap/form.php
@@ -315,8 +315,8 @@ if ($arId) {
     $nbOfInitialRows = $row['nb'];
 
     $res = $pearDB->prepare(
-        "SELECT MAX(ldap_host_id) as cnt 
-        FROM auth_ressource_host 
+        "SELECT MAX(ldap_host_id) as cnt
+        FROM auth_ressource_host
         WHERE auth_ressource_id = :arId"
     );
     $res->bindValue(':arId', (int)$arId, \PDO::PARAM_INT);
@@ -338,6 +338,7 @@ if ($form->validate()) {
     // sanitize name and description
     $values['ar_name'] = filter_var($values['ar_name'], FILTER_SANITIZE_STRING);
     $values['ar_description'] = filter_var($values['ar_description'], FILTER_SANITIZE_STRING);
+    $values['ar_id'] = $arId;
 
     // Check if sanitized name and description are not empty
     if (

--- a/www/include/Administration/parameters/ldap/form.php
+++ b/www/include/Administration/parameters/ldap/form.php
@@ -133,10 +133,11 @@ $form->addRule('ldap_sync_interval', _("An integer with a minimum value of 1 is 
 /**
  * list of contact template available
  */
-$res = $pearDB->query(
+$res = $pearDB->prepare(
     "SELECT contact_id, contact_name FROM contact WHERE contact_register = '0'"
 );
-$LdapContactTplList = array();
+$res->execute();
+$LdapContactTplList = [];
 while ($row = $res->fetch()) {
     $LdapContactTplList[$row['contact_id']] = $row['contact_name'];
 }

--- a/www/include/Administration/parameters/ldap/ldap.php
+++ b/www/include/Administration/parameters/ldap/ldap.php
@@ -38,12 +38,32 @@ require_once _CENTREON_PATH_ . 'www/class/centreonLDAP.class.php';
 require_once _CENTREON_PATH_ . 'www/class/CentreonLDAPAdmin.class.php';
 $tpl = new Smarty();
 
+/**
+ * used to sanitize key and value in array
+ * @param array<mixed> $inputArray
+ * @return array<mixed>
+ */
+function sanitizeInputArray(array $inputArray): array
+{
+    $sanitizedArray = [];
+    foreach ($inputArray as $key => $value) {
+        $key = filter_var($key, FILTER_VALIDATE_INT);
+        $value = filter_var($value, FILTER_VALIDATE_INT);
+        if (false !== $key && false !== $value) {
+            $sanitizedArray[$key] = $value;
+        }
+    }
+    return $sanitizedArray;
+}
+
 if (isset($_REQUEST['ar_id']) || isset($_REQUEST['new'])) {
+    $_REQUEST['ar_id']  = filter_var($_REQUEST['ar_id'], FILTER_VALIDATE_INT);
+    $_REQUEST['new']    = filter_var($_REQUEST['new'], FILTER_VALIDATE_INT);
     include _CENTREON_PATH_ . 'www/include/Administration/parameters/ldap/form.php';
 } else {
-    $ldapAction = $_REQUEST['a'] ?? null;
+    $ldapAction = filter_var($_REQUEST['a'] ?? null, FILTER_SANITIZE_STRING);
     if (!is_null($ldapAction) && isset($_REQUEST['select']) && is_array($_REQUEST['select'])) {
-        $select = $_REQUEST['select'];
+        $select = sanitizeInputArray($_REQUEST['select']);
         $ldapConf = new CentreonLdapAdmin($pearDB);
         switch ($ldapAction) {
             case "d":

--- a/www/include/Administration/parameters/ldap/ldap.php
+++ b/www/include/Administration/parameters/ldap/ldap.php
@@ -57,8 +57,8 @@ function sanitizeInputArray(array $inputArray): array
 }
 
 if (isset($_REQUEST['ar_id']) || isset($_REQUEST['new'])) {
-    $_REQUEST['ar_id']  = filter_var($_REQUEST['ar_id'], FILTER_VALIDATE_INT);
-    $_REQUEST['new']    = filter_var($_REQUEST['new'], FILTER_VALIDATE_INT);
+    $_REQUEST['ar_id']  = filter_var($_REQUEST['ar_id'] ?? null, FILTER_VALIDATE_INT);
+    $_REQUEST['new']    = filter_var($_REQUEST['new'] ?? null, FILTER_VALIDATE_INT);
     include _CENTREON_PATH_ . 'www/include/Administration/parameters/ldap/form.php';
 } else {
     $ldapAction = filter_var($_REQUEST['a'] ?? null, FILTER_SANITIZE_STRING);

--- a/www/include/Administration/parameters/ldap/list.php
+++ b/www/include/Administration/parameters/ldap/list.php
@@ -72,8 +72,6 @@ $statement = $pearDB->prepare("UPDATE options SET `value` = :enableLdap WHERE `k
 $statement->bindValue(':enableLdap', $enableLdap);
 $statement->execute();
 
-
-
 include "./include/common/checkPagination.php";
 $list = $ldapConf->getLdapConfigurationList($searchLdap, ($num * $limit), $limit);
 $tpl = initSmartyTpl($path . 'ldap/', $tpl);

--- a/www/include/Administration/parameters/ldap/list.php
+++ b/www/include/Administration/parameters/ldap/list.php
@@ -69,7 +69,7 @@ foreach ($list as $k => $v) {
 }
 
 $statement = $pearDB->prepare("UPDATE options SET `value` = :enableLdap WHERE `key` = 'ldap_auth_enable'");
-$statement->bindValue(':enableLdap', $enableLdap);
+$statement->bindValue(':enableLdap', $enableLdap, \PDO::PARAM_INT);
 $statement->execute();
 
 include "./include/common/checkPagination.php";

--- a/www/include/Administration/parameters/ldap/list.php
+++ b/www/include/Administration/parameters/ldap/list.php
@@ -67,7 +67,12 @@ foreach ($list as $k => $v) {
         $enableLdap = 1;
     }
 }
-$pearDB->query("UPDATE options SET `value` = " . $enableLdap . " WHERE `key` = 'ldap_auth_enable'");
+
+$statement = $pearDB->prepare("UPDATE options SET `value` = :enableLdap WHERE `key` = 'ldap_auth_enable'");
+$statement->bindValue(':enableLdap', $enableLdap);
+$statement->execute();
+
+
 
 include "./include/common/checkPagination.php";
 $list = $ldapConf->getLdapConfigurationList($searchLdap, ($num * $limit), $limit);


### PR DESCRIPTION
## Description

sanitize ldap parameters and use prepare statements

**Fixes** # MON-12481/ MON-12509 / MON-12510 / MON-12514

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

see [how to test section](https://centreon.atlassian.net/browse/MON-12481)