### PR TITLE
enh(conf/broker) change broker outputs to unified sql on upgrade

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -488,6 +488,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
     $blockIds = "";
     foreach ($typeIds as $key => $typeId) {
         $blockIds .= ! empty($blockIds) ? "," : "";
+        // 1_ = "output"
         $blockIds .= "'1_$typeId'";
     }
 

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -491,17 +491,17 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
 
     $blockIdsList = "";
     foreach ($typeIds as $key => $typeId) {
-        $blockIdsList .= $key > 0 ? "," : "";
+        $blockIdsList .= ! empty($blockIdsList) ? "," : "";
         $blockIdsList .= "'1_$typeId'";
     }
 
     // Retrieve unified_sql type id
-    $dbResult = $pearDB->query("SELECT cb_type_id FROM cb_type WHERE type_shortname IN ('unified_sql')");
+    $dbResult = $pearDB->query("SELECT cb_type_id FROM cb_type WHERE type_shortname = 'unified_sql'");
     $unifiedSqlType = $dbResult->fetch(PDO::FETCH_COLUMN, 0);
     if (empty($unifiedSqlType)) {
         throw new Exception("Cannot find 'unified_sql' in cb_type table");
     }
-    $unifiedSqlTypeId = $unifiedSqlType['cb_type_id'];
+    $unifiedSqlTypeId = (int) $unifiedSqlType['cb_type_id'];
 
     foreach ($configIds as $configId) {
         // Find next config group id

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -472,16 +472,16 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
 {
     // Retrieve all broker config ids
     $dbResult = $pearDB->query("SELECT config_id FROM cfg_centreonbroker WHERE config_name LIKE '%broker%'");
-    $configIds = $dbResult->fetchAll(PDO::FETCH_COLUMN, 0);
+    $configIds = $dbResult->fetchAll(\PDO::FETCH_COLUMN, 0);
     if (empty($configIds)) {
-        throw new Exception("Cannot find config ids in cfg_centreonbroker table");
+        throw new \Exception("Cannot find config ids in cfg_centreonbroker table");
     }
 
     // Determine blockIds for output of type sql and storage
     $dbResult = $pearDB->query("SELECT cb_type_id FROM cb_type WHERE type_shortname IN ('sql', 'storage')");
-    $typeIds = $dbResult->fetchAll(PDO::FETCH_COLUMN, 0);
+    $typeIds = $dbResult->fetchAll(\PDO::FETCH_COLUMN, 0);
     if (empty($typeIds)) {
-        throw new Exception("Cannot find 'sql' and 'storage' in cb_type table");
+        throw new \Exception("Cannot find 'sql' and 'storage' in cb_type table");
     }
 
     $blockIdsList = "";
@@ -492,9 +492,9 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
 
     // Retrieve unified_sql type id
     $dbResult = $pearDB->query("SELECT cb_type_id FROM cb_type WHERE type_shortname = 'unified_sql'");
-    $unifiedSqlType = $dbResult->fetch(PDO::FETCH_COLUMN, 0);
+    $unifiedSqlType = $dbResult->fetch(\PDO::FETCH_COLUMN, 0);
     if (empty($unifiedSqlType)) {
-        throw new Exception("Cannot find 'unified_sql' in cb_type table");
+        throw new \Exception("Cannot find 'unified_sql' in cb_type table");
     }
     $unifiedSqlTypeId = (int) $unifiedSqlType['cb_type_id'];
 
@@ -504,9 +504,9 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             "SELECT MAX(config_group_id) as max_config_group_id FROM cfg_centreonbroker_info
             WHERE config_id = $configId AND config_group = 'output'"
         );
-        $maxConfigGroupId = $dbResult->fetch(PDO::FETCH_COLUMN, 0);
+        $maxConfigGroupId = $dbResult->fetch(\PDO::FETCH_COLUMN, 0);
         if (empty($maxConfigGroupId)) {
-            throw new Exception("Cannot find max config group id in cfg_centreonbroker_info table");
+            throw new \Exception("Cannot find max config group id in cfg_centreonbroker_info table");
         }
         $nextConfigGroupId = (int) $maxConfigGroupId['max_config_group_id'] + 1;
 
@@ -516,9 +516,9 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             WHERE config_id = $configId AND config_key = 'blockId'
             AND config_value IN ($blockIdsList)"
         );
-        $configGroupIds = $dbResult->fetchAll(PDO::FETCH_COLUMN, 0);
+        $configGroupIds = $dbResult->fetchAll(\PDO::FETCH_COLUMN, 0);
         if (empty($configGroupIds)) {
-            throw new Exception("Cannot find config group ids in cfg_centreonbroker_info table");
+            throw new \Exception("Cannot find config group ids in cfg_centreonbroker_info table");
         }
 
         // Build unified sql output config from outputs to replace
@@ -534,7 +534,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             }
         }
         if (empty($unifiedSqlOutput)) {
-            throw new Exception("Cannot find conf for unified sql from cfg_centreonbroker_info table");
+            throw new \Exception("Cannot find conf for unified sql from cfg_centreonbroker_info table");
         }
 
         $unifiedSqlOutput['name']['config_value'] = str_replace(
@@ -573,9 +573,9 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
         foreach ($unifiedSqlOutput as $configKey => $row) {
             foreach ($row as $key => $value) {
                 if (in_array($key, ['config_key', 'config_value', 'config_group'])) {
-                    $stmt->bindValue(':' . $configKey . '_' . $key, $value, PDO::PARAM_STR);
+                    $stmt->bindValue(':' . $configKey . '_' . $key, $value, \PDO::PARAM_STR);
                 } else {
-                    $stmt->bindValue(':' . $configKey . '_' . $key, $value, PDO::PARAM_INT);
+                    $stmt->bindValue(':' . $configKey . '_' . $key, $value, \PDO::PARAM_INT);
                 }
             }
         }
@@ -592,7 +592,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             WHERE config_id = $configId AND config_group_id IN (" . implode(', ', array_keys($bindedValues)) . ")"
         );
         foreach ($bindedValues as $key => $value) {
-            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+            $stmt->bindValue($key, $value, \PDO::PARAM_INT);
         }
         $stmt->execute();
     }

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -115,7 +115,13 @@ try {
     $errorMessage = "Unable to add 'unifed_sql' broker configuration output";
     addNewUnifiedSqlOutput($pearDB);
 
+    $errorMessage = "Unable to migrate broker config to unified_sql";
+    migrateBrokerConfigOutputsToUnifiedSql($pearDB);
+
     $pearDB->commit();
+
+    $errorMessage = "Unable to drop column 'contact_passwd' from 'contact' table";
+    $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
 
     /**
      * Alter Tables
@@ -151,9 +157,6 @@ try {
     $errorMessage = "Unable to alter table security_token";
     $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
 
-    $pearDB->beginTransaction();
-    $errorMessage = "Unable to migrate broker config to unified_sql";
-    migrateBrokerConfigOutputsToUnifiedSql($pearDB);
     $pearDB->commit();
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -559,11 +559,11 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
         $queryRows = [];
         $bindedValues = [];
         $columnNames = null;
-        foreach ($unifiedSqlOutput as $configKey => $row) {
-            $columnNames = $columnNames ?? implode(", ", array_keys($row));
+        foreach ($unifiedSqlOutput as $configKey => $configInput) {
+            $columnNames = $columnNames ?? implode(", ", array_keys($configInput));
 
             $queryKeys = [];
-            foreach ($row as $key => $value) {
+            foreach ($configInput as $key => $value) {
                 $queryKeys[] = ":" . $configKey . '_' . $key;
                 if (in_array($key, ['config_key', 'config_value', 'config_group'])) {
                     $bindedValues[':' . $configKey . '_' . $key] = ['value' => $value, 'type' => \PDO::PARAM_STR];

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -120,9 +120,6 @@ try {
 
     $pearDB->commit();
 
-    $errorMessage = "Unable to drop column 'contact_passwd' from 'contact' table";
-    $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
-
     /**
      * Alter Tables
      */
@@ -156,8 +153,6 @@ try {
 
     $errorMessage = "Unable to alter table security_token";
     $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
-
-    $pearDB->commit();
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {
         $pearDB->rollBack();
@@ -526,7 +521,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             throw new Exception("Cannot find config group ids in cfg_centreonbroker_info table");
         }
 
-        // Build unified sql output config from outputs to replace and insert it
+        // Build unified sql output config from outputs to replace
         $unifiedSqlOutput = [];
         foreach ($configGroupIds as $configGroupId) {
             $dbResult = $pearDB->query(
@@ -586,7 +581,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
         }
         $stmt->execute();
 
-        // Delete former outputs
+        // Delete deprecated outputs
         $bindedValues = [];
         foreach ($configGroupIds as $index => $configGroupId) {
             $bindedValues[':id_' . $index] = $configGroupId;

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -470,7 +470,7 @@ function updateSecurityPolicyConfiguration(CentreonDB $pearDB): void
 /**
  * Migrate broker outputs 'sql' and 'storage' to a unique output 'unified_sql'
  *
- * @param CentreonDb $pearDB
+ * @param CentreonDB $pearDB
  * @return void
  */
 function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
@@ -584,8 +584,6 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
                 }
             }
         }
-        $stmt->queryString;
-
         $stmt->execute();
 
         // Delete former outputs

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -571,7 +571,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
         // Delete former outputs
         $pearDB->query(
             "DELETE FROM cfg_centreonbroker_info
-            WHERE config_id = $configId AND config_group_id IN (" . implode(', ', $configGroupIds) .")"
+            WHERE config_id = $configId AND config_group_id IN (" . implode(', ', $configGroupIds) . ")"
         );
     }
 }

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -466,6 +466,7 @@ function updateSecurityPolicyConfiguration(CentreonDB $pearDB): void
  * Migrate broker outputs 'sql' and 'storage' to a unique output 'unified_sql'
  *
  * @param CentreonDB $pearDB
+ * @throws \Exception
  * @return void
  */
 function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
@@ -548,9 +549,9 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
         // Insert new output
         $queryRows = [];
         $bindedValues = [];
-        $columnsName = null;
+        $columnNames = null;
         foreach ($unifiedSqlOutput as $configKey => $row) {
-            $columnsName = $columnsName ?? implode(", ", array_keys($row));
+            $columnNames = $columnNames ?? implode(", ", array_keys($row));
 
             $queryKeys = [];
             foreach ($row as $key => $value) {
@@ -566,8 +567,8 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             }
         }
 
-        if (! empty($queryRows)) {
-            $query = "INSERT INTO cfg_centreonbroker_info ($columnsName) VALUES ";
+        if (! empty($queryRows) && $columnNames !== null) {
+            $query = "INSERT INTO cfg_centreonbroker_info ($columnNames) VALUES ";
             $query .= implode(', ', $queryRows);
 
             $stmt = $pearDB->prepare($query);


### PR DESCRIPTION
## Description

Migrate broker outputs configs from 'sql' and 'storage' outputs to the new 'unified_sql' output when upgrading to 22.04

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
