### PR TITLE
add color dark mode to tactical widget

### DIFF
--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -102,4 +102,9 @@
     --up-to-date-color:var(--option-color);
     --update-secu-background-color:var(--color-torch-red);
     --ui-icon-fill-color: var(--color-primary-light);
+    --list-ack-background-color:var(--color-raw-umber);
+    --list-ack-hover-background-color:var(--color-raw-umber);
+    --list-downtime-background-color:var(--color-persian-indigo);
+    --list-downtime-hover-background-color:var(--color-persian-indigo);
+    --list-two-hover-background-color:var(--list-two-background-color);
 }

--- a/www/Themes/Generic-theme/Variables-css/color-variables.css
+++ b/www/Themes/Generic-theme/Variables-css/color-variables.css
@@ -156,5 +156,9 @@
     --color-astral-rgb: rgb(51, 122, 183);
     --color-pistachio-rgba: rgba(158, 199, 0, 0.49);
     --color-gallery-rgba: rgba(239,239,239, 0.8);
+    --color-beige:#F7F4E5;
+    --color-raw-umber:#635A15;
+    --color-Magnolia:#F9E7FF;
+    --color-persian-indigo:#4E1358;
     /******************/
 }


### PR DESCRIPTION
## Description

adding color of dark mode to widget tactical overview

**Fixes** #MON-12624

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
