### PR TITLE
fix(upgrade): add default openid configuration if no configuration was found

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -195,6 +195,15 @@ try {
 
         $errorMessage = "Impossible to remove open_id options form options table";
         $pearDB->query("DELETE FROM options WHERE `key` LIKE 'open_id%'");
+    } else {
+        $customConfiguration = '{"trusted_client_addresses":[],"blacklist_client_addresses":[],"base_url":null,'
+            . '"authorization_endpoint":null,"token_endpoint":null,"introspection_token_endpoint":null,'
+            . '"userinfo_endpoint":null,"endsession_endpoint":null,"connection_scopes":[],"login_claim":null,'
+            . '"client_id":null,"client_secret":null,"authentication_type":"client_secret_post","verify_peer":true}';
+        $pearDB->query(
+            "INSERT INTO provider_configuration (`type`,`name`,`custom_configuration`,`is_active`,`is_forced`)
+            VALUES ('openid','openid', '" . $customConfiguration . "', false, false)"
+        );
     }
     $pearDB->commit();
 

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -177,8 +177,12 @@ function insertOpenIdConfiguration(CentreonDB $pearDB): void
         $isActive = $result['openid_connect_enable'] === '1';
         $isForced = $result['openid_connect_mode'] === '0'; //'0' OpenId Connect Only, '1' Mixed
         $customConfiguration = [
-            "trusted_client_addresses" => explode(',', $result['openid_connect_trusted_clients']),
-            "blacklist_client_addresses" => explode(',', $result['openid_connect_blacklist_clients']),
+            "trusted_client_addresses" => !empty($result['openid_connect_trusted_clients'])
+                ? explode(',', $result['openid_connect_trusted_clients'])
+                : [],
+            "blacklist_client_addresses" => !empty($result['openid_connect_blacklist_clients'])
+                ? explode(',', $result['openid_connect_blacklist_clients'])
+                : [],
             "base_url" => !empty($result['openid_connect_base_url']) ? $result['openid_connect_base_url'] : null,
             "authorization_endpoint" => !empty($result['openid_connect_authorization_endpoint'])
                 ? $result['openid_connect_authorization_endpoint']


### PR DESCRIPTION
## Description
This PR intends to add default openid configuration if no configuration was found in options table
**Fixes** # MON-6491

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
