### PR TITLE
fix(upgrade): use fetchAll in select openid query

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -189,68 +189,87 @@ function insertOpenIdConfiguration(CentreonDB $pearDB): void
     $statement = $pearDB->query("SELECT * FROM options WHERE `key` LIKE 'openid_%'");
     $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
     if (!empty($result)) {
-        foreach ($result as $key => $value) {
-            switch ($key) {
+        foreach ($result as $configLine) {
+            switch ($configLine['key']) {
                 case 'openid_connect_enable':
-                    $isActive = $value === '1';
+                    $isActive = $configLine['value'] === '1';
                     break;
                 case 'openid_connect_mode':
-                    $isForced = $value === '0'; //'0' OpenId Connect Only, '1' Mixed
+                    $isForced = $configLine['value'] === '0'; //'0' OpenId Connect Only, '1' Mixed
                     break;
                 case 'openid_connect_trusted_clients':
-                    $customConfiguration['trusted_client_addresses'] = !empty($value) ? explode(',', $value) : [];
+                    $customConfiguration['trusted_client_addresses'] = !empty($configLine['value'])
+                        ? explode(',', $configLine['value'])
+                        : [];
                     break;
                 case 'openid_connect_blacklist_clients':
-                    $customConfiguration['blacklist_client_addresses'] = !empty($value) ? explode(',', $value) : [];
+                    $customConfiguration['blacklist_client_addresses'] = !empty($configLine['value'])
+                        ? explode(',', $configLine['value'])
+                        : [];
                     break;
                 case 'openid_connect_base_url':
-                    $customConfiguration['base_url'] = !empty($value) ? $value : null;
+                    $customConfiguration['base_url'] = !empty($configLine['value'])
+                        ? $configLine['value']
+                        : null;
                     break;
                 case 'openid_connect_authorization_endpoint':
-                    $customConfiguration['authorization_endpoint'] = !empty($value) ? $value : null;
+                    $customConfiguration['authorization_endpoint'] = !empty($configLine['value'])
+                        ? $configLine['value']
+                        : null;
                     break;
                 case 'openid_connect_token_endpoint':
-                    $customConfiguration['token_endpoint'] = !empty($value) ? $value : null;
+                    $customConfiguration['token_endpoint'] = !empty($configLine['value'])
+                        ? $configLine['value']
+                        : null;
                     break;
                 case 'openid_connect_introspection_endpoint':
-                    $customConfiguration['introspection_token_endpoint'] = !empty($value) ? $value : null;
+                    $customConfiguration['introspection_token_endpoint'] = !empty($configLine['value'])
+                        ? $configLine['value']
+                        : null;
                     break;
                 case 'openid_connect_userinfo_endpoint':
-                    $customConfiguration['userinfo_endpoint'] = !empty($value) ? $value : null;
+                    $customConfiguration['userinfo_endpoint'] = !empty($configLine['value'])
+                        ? $configLine['value']
+                        : null;
                     break;
                 case 'openid_connect_end_session_endpoint':
-                    $customConfiguration['endsession_endpoint'] = !empty($value) ? $value : null;
+                    $customConfiguration['endsession_endpoint'] = !empty($configLine['value'])
+                        ? $configLine['value']
+                        : null;
                     break;
                 case 'openid_connect_scope':
-                    $customConfiguration['connection_scopes'] = !empty($value) ? explode(' ', $value) : [];
+                    $customConfiguration['connection_scopes'] = !empty($configLine['value'])
+                        ? explode(' ', $configLine['value'])
+                        : [];
                     break;
                 case 'openid_connect_login_claim':
-                    $customConfiguration['login_claim'] = !empty($value) ? $value : null;
+                    $customConfiguration['login_claim'] = !empty($configLine['value']) ? $configLine['value'] : null;
                     break;
                 case 'openid_connect_client_id':
-                    $customConfiguration['client_id'] = !empty($value) ? $value : null;
+                    $customConfiguration['client_id'] = !empty($configLine['value']) ? $configLine['value'] : null;
                     break;
                 case 'openid_connect_client_secret':
-                    $customConfiguration['client_secret'] = !empty($value) ? $value : null;
+                    $customConfiguration['client_secret'] = !empty($configLine['value']) ? $configLine['value'] : null;
                     break;
                 case 'openid_connect_client_basic_auth':
-                    $customConfiguration['authentication_type'] = $value === '1'
+                    $customConfiguration['authentication_type'] = $configLine['value'] === '1'
                         ? 'client_secret_basic'
                         : 'client_secret_post';
                     break;
                 case 'openid_connect_verify_peer':
-                    $customConfiguration['verify_peer'] = $value === '1' ? false : true; // '1' is Verify Peer disable
+                    // '1' is Verify Peer disable
+                    $customConfiguration['verify_peer'] = $configLine['value'] === '1' ? false : true;
                     break;
             }
         }
         $pearDB->query("DELETE FROM options WHERE `key` LIKE 'open_id%'");
     }
-    $statement2 = $pearDB->prepare(
+    $insertStatement = $pearDB->prepare(
         "INSERT INTO provider_configuration (`type`,`name`,`custom_configuration`,`is_active`,`is_forced`)
         VALUES ('openid','openid', :customConfiguration, :isActive, :isForced)"
     );
-    $statement2->bindValue(':customConfiguration', json_encode($customConfiguration), \PDO::PARAM_STR);
-    $statement2->bindValue(':isActive', $isActive ? '1' : '0', \PDO::PARAM_STR);
-    $statement2->bindValue(':isForced', $isForced ? '1' : '0', \PDO::PARAM_STR);
-    $statement2->execute();
+    $insertStatement->bindValue(':customConfiguration', json_encode($customConfiguration), \PDO::PARAM_STR);
+    $insertStatement->bindValue(':isActive', $isActive ? '1' : '0', \PDO::PARAM_STR);
+    $insertStatement->bindValue(':isForced', $isForced ? '1' : '0', \PDO::PARAM_STR);
+    $insertStatement->execute();
 }

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -170,84 +170,92 @@ try {
  */
 function insertOpenIdConfiguration(CentreonDB $pearDB): void
 {
+    $customConfiguration = [
+        "trusted_client_addresses" => [],
+        "blacklist_client_addresses" => [],
+        "base_url" => null,
+        "authorization_endpoint" => null,
+        "token_endpoint" => null,
+        "introspection_token_endpoint" => null,
+        "userinfo_endpoint" => null,
+        "endsession_endpoint" => null,
+        "connection_scopes" => [],
+        "login_claim" => null,
+        "client_id" => null,
+        "client_secret" => null,
+        "authentication_type" => "client_secret_post",
+        "verify_peer" => true
+    ];
+    $isActive = false;
+    $isForced = false;
     $pearDB->beginTransaction();
     // Move OpenID Connect information to openid provider configuration.
     $statement = $pearDB->query("SELECT * FROM options WHERE `key` LIKE 'openid_%'");
-    if (($result = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
-        $isActive = $result['openid_connect_enable'] === '1';
-        $isForced = $result['openid_connect_mode'] === '0'; //'0' OpenId Connect Only, '1' Mixed
-        $customConfiguration = [
-            "trusted_client_addresses" => !empty($result['openid_connect_trusted_clients'])
-                ? explode(',', $result['openid_connect_trusted_clients'])
-                : [],
-            "blacklist_client_addresses" => !empty($result['openid_connect_blacklist_clients'])
-                ? explode(',', $result['openid_connect_blacklist_clients'])
-                : [],
-            "base_url" => !empty($result['openid_connect_base_url']) ? $result['openid_connect_base_url'] : null,
-            "authorization_endpoint" => !empty($result['openid_connect_authorization_endpoint'])
-                ? $result['openid_connect_authorization_endpoint']
-                : null,
-            "token_endpoint" => !empty($result['openid_connect_token_endpoint'])
-                ? $result['openid_connect_token_endpoint']
-                : null,
-            "introspection_token_endpoint" => !empty($result['openid_connect_introspection_endpoint'])
-                ? $result['openid_connect_introspection_endpoint']
-                : null,
-            "userinfo_endpoint" => !empty($result['openid_connect_userinfo_endpoint'])
-                ? $result['openid_connect_userinfo_endpoint']
-                : null,
-            "endsession_endpoint" => !empty($result['openid_connect_end_session_endpoint'])
-                ? $result['openid_connect_end_session_endpoint']
-                : null,
-            "connection_scopes" => explode(" ", $result['openid_connect_scope']),
-            "login_claim" => !empty($result['openid_connect_login_claim'])
-                ? $result['openid_connect_login_claim']
-                : null,
-            "client_id" => !empty($result['openid_connect_client_id'])
-                ? $result['openid_connect_client_id']
-                : null,
-            "client_secret" => !empty($result['openid_connect_client_secret'])
-                ? $result['openid_connect_client_secret']
-                : null,
-            "authentication_type" => $result['openid_connect_client_basic_auth'] === '1'
-                ? 'client_secret_basic'
-                : 'client_secret_post',
-            "verify_peer" => $result['openid_connect_verify_peer'] === '1' ? false : true // '1' is Verify Peer disable
-        ];
-
-        $statement2 = $pearDB->prepare(
-            "INSERT INTO provider_configuration (`type`,`name`,`custom_configuration`,`is_active`,`is_forced`)
-            VALUES ('openid','openid', :customConfiguration, :isActive, :isForced)"
-        );
-        $statement2->bindValue(':customConfiguration', json_encode($customConfiguration), \PDO::PARAM_STR);
-        $statement2->bindValue(':isActive', $isActive ? '1' : '0', \PDO::PARAM_STR);
-        $statement2->bindValue(':isForced', $isForced ? '1' : '0', \PDO::PARAM_STR);
-        $statement2->execute();
-
+    $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+    if (!empty($result)) {
+        foreach ($result as $key => $value) {
+            switch ($key) {
+                case 'openid_connect_enable':
+                    $isActive = $value === '1';
+                    break;
+                case 'openid_connect_mode':
+                    $isForced = $value === '0'; //'0' OpenId Connect Only, '1' Mixed
+                    break;
+                case 'openid_connect_trusted_clients':
+                    $customConfiguration['trusted_client_addresses'] = !empty($value) ? explode(',', $value) : [];
+                    break;
+                case 'openid_connect_blacklist_clients':
+                    $customConfiguration['blacklist_client_addresses'] = !empty($value) ? explode(',', $value) : [];
+                    break;
+                case 'openid_connect_base_url':
+                    $customConfiguration['base_url'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_authorization_endpoint':
+                    $customConfiguration['authorization_endpoint'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_token_endpoint':
+                    $customConfiguration['token_endpoint'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_introspection_endpoint':
+                    $customConfiguration['introspection_token_endpoint'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_userinfo_endpoint':
+                    $customConfiguration['userinfo_endpoint'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_end_session_endpoint':
+                    $customConfiguration['endsession_endpoint'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_scope':
+                    $customConfiguration['connection_scopes'] = !empty($value) ? explode(' ', $value) : [];
+                    break;
+                case 'openid_connect_login_claim':
+                    $customConfiguration['login_claim'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_client_id':
+                    $customConfiguration['client_id'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_client_secret':
+                    $customConfiguration['client_secret'] = !empty($value) ? $value : null;
+                    break;
+                case 'openid_connect_client_basic_auth':
+                    $customConfiguration['authentication_type'] = $value === '1'
+                        ? 'client_secret_basic'
+                        : 'client_secret_post';
+                    break;
+                case 'openid_connect_verify_peer':
+                    $customConfiguration['verify_peer'] = $value === '1' ? false : true; // '1' is Verify Peer disable
+                    break;
+            }
+        }
         $pearDB->query("DELETE FROM options WHERE `key` LIKE 'open_id%'");
-    } else {
-        $customConfiguration = [
-            "trusted_client_addresses" => [],
-            "blacklist_client_addresses" => [],
-            "base_url" => null,
-            "authorization_endpoint" => null,
-            "token_endpoint" => null,
-            "introspection_token_endpoint" => null,
-            "userinfo_endpoint" => null,
-            "endsession_endpoint" => null,
-            "connection_scopes" => [],
-            "login_claim" => null,
-            "client_id" => null,
-            "client_secret" => null,
-            "authentication_type" => "client_secret_post",
-            "verify_peer" => true
-        ];
-        $statement = $pearDB->prepare(
-            "INSERT INTO provider_configuration (`type`,`name`,`custom_configuration`,`is_active`,`is_forced`)
-            VALUES ('openid','openid', :customConfiguration, false, false)"
-        );
-        $statement->bindValue(':customConfiguration', json_encode($customConfiguration), \PDO::PARAM_STR);
-        $statement->execute();
     }
+    $statement2 = $pearDB->prepare(
+        "INSERT INTO provider_configuration (`type`,`name`,`custom_configuration`,`is_active`,`is_forced`)
+        VALUES ('openid','openid', :customConfiguration, :isActive, :isForced)"
+    );
+    $statement2->bindValue(':customConfiguration', json_encode($customConfiguration), \PDO::PARAM_STR);
+    $statement2->bindValue(':isActive', $isActive ? '1' : '0', \PDO::PARAM_STR);
+    $statement2->bindValue(':isForced', $isForced ? '1' : '0', \PDO::PARAM_STR);
+    $statement2->execute();
     $pearDB->commit();
 }

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -109,7 +109,6 @@ try {
 
     $errorMessage = "Unable to drop column 'contact_passwd' from 'contact' table";
     $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
-    $pearDB->commit();
 
     // Add JS Effect to contact
     $errorMessage = 'Impossible to add "contact_js_effects" column to "contact" table';

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -253,5 +253,4 @@ function insertOpenIdConfiguration(CentreonDB $pearDB): void
     $statement2->bindValue(':isActive', $isActive ? '1' : '0', \PDO::PARAM_STR);
     $statement2->bindValue(':isForced', $isForced ? '1' : '0', \PDO::PARAM_STR);
     $statement2->execute();
-    $pearDB->commit();
 }

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -104,11 +104,12 @@ try {
         $statement->bindValue(':creationDate', time(), \PDO::PARAM_INT);
         $statement->execute();
     }
-
-    $pearDB->commit();
+    $errorMessage = "Impossible to add default OpenID provider configuration";
+    insertOpenIdConfiguration($pearDB);
 
     $errorMessage = "Unable to drop column 'contact_passwd' from 'contact' table";
     $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
+    $pearDB->commit();
 
     // Add JS Effect to contact
     $errorMessage = 'Impossible to add "contact_js_effects" column to "contact" table';
@@ -142,9 +143,6 @@ try {
         ADD `blocking_time` BIGINT(20) UNSIGNED DEFAULT NULL"
     );
 
-    $errorMessage = "Impossible to add default OpenID provider configuration";
-    insertOpenIdConfiguration($pearDB);
-
     $errorMessage = "Unable to alter table security_token";
     $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
 } catch (\Exception $e) {
@@ -164,7 +162,7 @@ try {
 }
 
 /**
- * insert OpenId Configuration
+ * insert OpenId Configuration Default configuration.
  *
  * @param CentreonDB $pearDB
  */
@@ -188,8 +186,6 @@ function insertOpenIdConfiguration(CentreonDB $pearDB): void
     ];
     $isActive = false;
     $isForced = false;
-    $pearDB->beginTransaction();
-    // Move OpenID Connect information to openid provider configuration.
     $statement = $pearDB->query("SELECT * FROM options WHERE `key` LIKE 'openid_%'");
     $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
     if (!empty($result)) {


### PR DESCRIPTION
## Description

This PR intends to use fetchAll in select openid query to move existing configuration in provider_configuration table.
**Fixes** # MON-6491

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
