### PR TITLE
fix(phpstan): ignore errors from pest globals

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,14 @@ parameters:
     - %currentWorkingDirectory%/tests/php/Centreon
     - %currentWorkingDirectory%/tests/php/Security
     - %currentWorkingDirectory%/tests/php/Utility
+  ignoreErrors:
+    -
+      message: '#^Undefined variable: \$this$#'
+      path: tests/php/
+    -
+      message: '#^Call to an undefined method Pest#'
+      path: tests/php/
+  reportUnmatchedIgnoredErrors: false
 services:
   errorFormatter.absolute:
     class: Centreon\PHPStan\AbsolutePathErrorFormatter


### PR DESCRIPTION
## Description

ignore errors from pest globals

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)