### PR TITLE
fix(install): allow centreon sql user to create view

### DIFF
--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -96,6 +96,7 @@ $mandatoryPrivileges = [
     'LOCK TABLES',
     'CREATE TEMPORARY TABLES',
     'EVENT',
+    'CREATE VIEW',
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
 $query = "GRANT " . $privilegesQuery . " ON `%s`.* TO " . $parameters['db_user'] . "@" . $host;


### PR DESCRIPTION
## Description

allow centreon sql user to create view
otherwise, MBI installation does not work

**Fixes** MON-11203

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)