### PR TITLE
fix(UI): Login form is blended with background on Firefox

### DIFF
--- a/www/front_src/src/Login/index.tsx
+++ b/www/front_src/src/Login/index.tsx
@@ -33,9 +33,9 @@ const useStyles = makeStyles((theme) => ({
   },
   loginBackground: {
     alignItems: 'center',
-    backdropFilter: 'brightness(1)',
     backgroundColor: 'transparent',
     display: 'flex',
+    filter: 'brightness(1)',
     flexDirection: 'column',
     height: '100vh',
     justifyContent: 'center',


### PR DESCRIPTION
## Description

This fixes the login form paper blended with the background image

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

The login form is correctly displayed

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
