### PR TITLE
enh(connectors): add the --log-file option for fresh installs

### DIFF
--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -235,8 +235,8 @@ INSERT INTO `giv_graphs_template` (`graph_id`, `name`, `vertical_label`, `width`
 -- Contenu de la table Connector
 --
 INSERT INTO `connector` (`id`, `name`, `description`, `command_line`, `enabled`, `created`, `modified`) VALUES
-(1, 'Perl Connector', '', 'centreon_connector_perl --log-file=/var/log/centreon-engine/connector-perl.log', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
-(2, 'SSH Connector', '', 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP());
+(1, 'Perl Connector', '', 'centreon_connector_perl --log-file=@monitoring_varlog@/connector-perl.log', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(2, 'SSH Connector', '', 'centreon_connector_ssh --log-file=@monitoring_varlog@/connector-ssh.log', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP());
 
 
 --

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -235,8 +235,8 @@ INSERT INTO `giv_graphs_template` (`graph_id`, `name`, `vertical_label`, `width`
 -- Contenu de la table Connector
 --
 INSERT INTO `connector` (`id`, `name`, `description`, `command_line`, `enabled`, `created`, `modified`) VALUES
-(1, 'Perl Connector', '', 'centreon_connector_perl', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
-(2, 'SSH Connector', '', 'centreon_connector_ssh', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP());
+(1, 'Perl Connector', '', 'centreon_connector_perl --log-file=/var/log/centreon-engine/connector-perl.log', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(2, 'SSH Connector', '', 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log', 1, UNIX_TIMESTAMP(), UNIX_TIMESTAMP());
 
 
 --


### PR DESCRIPTION
## Description

Until now, connectors logging was disabled, and nearly no one knew it was possible.
I'm changing this starting 22.04 for fresh installs only.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

It should not break anything but I wouldn't backport it to previous versions. I'm also pushing a PR in centreon-collect to adapt the logrotate rules.

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
