### PR TITLE
enh(api): add InvalidArgumentResponse to manage bad request

### DIFF
--- a/src/Core/Application/Common/UseCase/InvalidArgumentResponse.php
+++ b/src/Core/Application/Common/UseCase/InvalidArgumentResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Common\UseCase;
+
+class InvalidArgumentResponse implements ResponseStatusInterface
+{
+    /**
+     * @param string $message
+     */
+    public function __construct(private string $message)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage(): string
+    {
+        return _($this->message);
+    }
+}

--- a/src/Core/Infrastructure/Common/Presenter/JsonPresenter.php
+++ b/src/Core/Infrastructure/Common/Presenter/JsonPresenter.php
@@ -28,6 +28,7 @@ use Core\Application\Common\UseCase\BodyResponseInterface;
 use Core\Application\Common\UseCase\ResponseStatusInterface;
 use Core\Application\Common\UseCase\CreatedResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\UnauthorizedResponse;
 use Core\Application\Common\UseCase\PaymentRequiredResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
@@ -92,6 +93,13 @@ class JsonPresenter implements PresenterFormatterInterface
                 return new JsonResponse(
                     $this->formatErrorContent($this->data, JsonResponse::HTTP_INTERNAL_SERVER_ERROR),
                     JsonResponse::HTTP_INTERNAL_SERVER_ERROR,
+                    $this->responseHeaders,
+                );
+            case is_a($this->data, InvalidArgumentResponse::class, false):
+                $this->debug('Invalid argument. Generating an error response');
+                return new JsonResponse(
+                    $this->formatErrorContent($this->data, JsonResponse::HTTP_BAD_REQUEST),
+                    JsonResponse::HTTP_BAD_REQUEST,
                     $this->responseHeaders,
                 );
             case is_a($this->data, UnauthorizedResponse::class, false):


### PR DESCRIPTION
## Description

add InvalidArgumentResponse to manage bad request

**Fixes** MON-11203

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)