### PR TITLE
fix(router): fix router regexp

### DIFF
--- a/src/Core/Application/Security/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
+++ b/src/Core/Application/Security/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
@@ -40,6 +40,7 @@ use Core\Domain\Security\ProviderConfiguration\OpenId\Model\OpenIdConfiguration;
 use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
 use Core\Application\Security\ProviderConfiguration\OpenId\Repository\ReadOpenIdConfigurationRepositoryInterface;
 use Centreon\Domain\Authentication\Exception\AuthenticationException as LegacyAuthenticationException;
+use Core\Domain\Security\Authentication\SSOAuthenticationException;
 use Core\Domain\Security\ProviderConfiguration\OpenId\Exceptions\OpenIdConfigurationException;
 
 class LoginOpenIdSession
@@ -135,7 +136,7 @@ class LoginOpenIdSession
                     );
                 }
             }
-        } catch (AuthenticationException | NotFoundException | OpenIdConfigurationException $e) {
+        } catch (SSOAuthenticationException | NotFoundException | OpenIdConfigurationException $e) {
             $presenter->present($this->createResponse(null, $e->getMessage()));
             return;
         } catch (\Exception $e) {

--- a/src/Core/Infrastructure/Common/Api/HttpUrlTrait.php
+++ b/src/Core/Infrastructure/Common/Api/HttpUrlTrait.php
@@ -70,7 +70,7 @@ trait HttpUrlTrait
         if (
             isset($_SERVER['REQUEST_URI'])
             && preg_match(
-                '/^(.+)\/(' . implode('|', $routeSuffixPatterns) . ')/',
+                '/^(.+?)\/(' . implode('|', $routeSuffixPatterns) . ')/',
                 $_SERVER['REQUEST_URI'],
                 $matches
             )


### PR DESCRIPTION
## Description

This PR intends to fix router regexp where BaseUri was wrongly computed

**Fixes** # MON-6493

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
