### PR TITLE
fix(perlcore): test conf.pm file present

### DIFF
--- a/lib/perl/centreon/script.pm
+++ b/lib/perl/centreon/script.pm
@@ -142,8 +142,10 @@ sub parse_options {
     die "Command line error" if !GetOptions(%{$self->{options}});
     pod2usage(-exitval => 1, -input => $FindBin::Bin . "/" . $FindBin::Script) if $self->{help};
     if ($self->{noconfig} == 0) {
-        require $self->{config_file};
-        $self->{centreon_config} = $centreon_config;
+        if (-e "$self->{config_file}") {
+            require $self->{config_file};
+            $self->{centreon_config} = $centreon_config;
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Because there is no web install for Poller, package installation creates an empty “/etc/centreon/conf.pm" file.
Because it’s empty, and because it’s required by centreontrapd service (through sysconfig file), service won’t start.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Install a Poller,
- Start centreontrapd service.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
