### PR TITLE
fix(recurrentDowntimes): correctly display error message when needed

### DIFF
--- a/www/include/monitoring/recurrentDowntime/formDowntime.html
+++ b/www/include/monitoring/recurrentDowntime/formDowntime.html
@@ -183,7 +183,7 @@ function validPeriods()
 </script>
         {/literal}
 
-<div id="msg_err" style="color: red; text-align: center; font-weight: bold; margin: 4px; {if !$msg_err_norelation }display: none;{/if}">{$msg_err_norelation}</div>
+<div id="msg_err" style="color: red; text-align: center; font-weight: bold; margin: 4px; {if !$msg_err }display: none;{/if}">{$msg_err}</div>
 
 {if isset($form.msgacl) }
 <div style="color: red; text-align: center; font-weight: bold; margin: 4px" >


### PR DESCRIPTION
This PR intends to fix an issue where on Recurrent Downtime page where an error message was always displayed with no reason.

The error message will now be displayed when needed (if no relation is added between resources and downtime)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
