### PR TITLE
fix(config): do not shared same instance of statement collector

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,6 +59,9 @@ services:
     Pimple\Container:
         factory: ['Centreon\LegacyContainer', 'getInstance']
 
+    Centreon\Infrastructure\CentreonLegacyDB\StatementCollector:
+        shared: false
+
     Core\Infrastructure\Common\Api\Router:
         decorates: router
         arguments: ['@.inner']


### PR DESCRIPTION
## Description

do not shared same instance of statement collector between services to avoid side effects with unexpected bind values

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)