### PR TITLE
fix(install/upgrade): do not register websso event subscriber on fresh install and upgrade

### DIFF
--- a/src/EventSubscriber/WebSSOEventSubscriber.php
+++ b/src/EventSubscriber/WebSSOEventSubscriber.php
@@ -80,19 +80,19 @@ class WebSSOEventSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        $event = [];
+        $events = [];
         //Register this event only if its not an upgrade or fresh install
         if (
             file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')
             && ! is_dir(_CENTREON_PATH_ . DIRECTORY_SEPARATOR . 'www'  . DIRECTORY_SEPARATOR . 'install')
         ) {
-            $event = [
+            $events = [
                 KernelEvents::REQUEST => [
                     ['loginWebSSOUser', 34]
                 ],
             ];
         }
-        return $event;
+        return $events;
     }
 
     /**

--- a/src/EventSubscriber/WebSSOEventSubscriber.php
+++ b/src/EventSubscriber/WebSSOEventSubscriber.php
@@ -80,11 +80,19 @@ class WebSSOEventSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return [
-            KernelEvents::REQUEST => [
-                ['loginWebSSOUser', 34]
-            ],
-        ];
+        $event = [];
+        //Register this event only if its not an upgrade or fresh install
+        if (
+            file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')
+            && ! is_dir(_CENTREON_PATH_ . DIRECTORY_SEPARATOR . 'www'  . DIRECTORY_SEPARATOR . 'install'))
+        {
+            $event = [
+                KernelEvents::REQUEST => [
+                    ['loginWebSSOUser', 34]
+                ],
+            ];
+        }
+        return $event;
     }
 
     /**

--- a/src/EventSubscriber/WebSSOEventSubscriber.php
+++ b/src/EventSubscriber/WebSSOEventSubscriber.php
@@ -84,8 +84,8 @@ class WebSSOEventSubscriber implements EventSubscriberInterface
         //Register this event only if its not an upgrade or fresh install
         if (
             file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')
-            && ! is_dir(_CENTREON_PATH_ . DIRECTORY_SEPARATOR . 'www'  . DIRECTORY_SEPARATOR . 'install'))
-        {
+            && ! is_dir(_CENTREON_PATH_ . DIRECTORY_SEPARATOR . 'www'  . DIRECTORY_SEPARATOR . 'install')
+        ) {
             $event = [
                 KernelEvents::REQUEST => [
                     ['loginWebSSOUser', 34]


### PR DESCRIPTION
## Description

This PR intends to fix an issue were fresh install and upgrade were broken due to this commit e28153181f301fee415d05fca7bb2a095de6f218

**Fixes** # MON-12856

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Fresh install and upgrade should be successful.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
