### PR TITLE
feat(api): add endpoint to get contact templates

### DIFF
--- a/config/routes/Centreon/configuration/contact_template.yaml
+++ b/config/routes/Centreon/configuration/contact_template.yaml
@@ -1,5 +1,5 @@
 configuration_contact_template_find_all:
   methods: GET
-  path: /configuration/contact/template
+  path: /configuration/contacts/templates
   controller: 'Core\Contact\Infrastructure\Api\FindContactTemplates\FindContactTemplatesController'
   condition: "request.attributes.get('version') >= 22.04"

--- a/config/routes/Centreon/configuration/contact_template.yaml
+++ b/config/routes/Centreon/configuration/contact_template.yaml
@@ -1,0 +1,5 @@
+configuration_contact_template_find_all:
+  methods: GET
+  path: /configuration/contact/template
+  controller: 'Core\Contact\Infrastructure\Api\FindContactTemplates\FindContactTemplatesController'
+  condition: "request.attributes.get('version') >= 22.04"

--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -837,7 +837,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/contact-template:
+  /configuration/contact/template:
     get:
       tags:
       - User

--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -837,7 +837,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/contact/template:
+  /configuration/contacts/templates:
     get:
       tags:
       - User

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16719,3 +16719,6 @@ msgstr "Se connecter avec"
 
 msgid "Can't resolve username from login claim using configured regular expression"
 msgstr "Impossible de résoudre le nom d'utilisateur à partir de la déclaration de connexion en utilisant l'expression régulière configurée"
+
+msgid "Impossible to get contact templates from data storage"
+msgstr "Impossible d'obtenir les modèles de contact depuis le stockage de données"

--- a/src/Core/Contact/Application/Repository/ReadContactTemplateRepositoryInterface.php
+++ b/src/Core/Contact/Application/Repository/ReadContactTemplateRepositoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Application\Repository;
+
+use Core\Contact\Domain\Model\ContactTemplate;
+
+interface ReadContactTemplateRepositoryInterface
+{
+    /**
+     * Get all contact templates
+     *
+     * @return array<ContactTemplate>
+     */
+    public function findAll(): array;
+}

--- a/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplates.php
+++ b/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplates.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Application\UseCase\FindContactTemplates;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Contact\Application\Repository\ReadContactTemplateRepositoryInterface;
+
+class FindContactTemplates
+{
+    use LoggerTrait;
+
+    /**
+     * @param ReadContactTemplateRepositoryInterface $repository
+     */
+    public function __construct(private ReadContactTemplateRepositoryInterface $repository)
+    {
+    }
+
+    /**
+     * @param FindContactTemplatesPresenterInterface $presenter
+     */
+    public function __invoke(FindContactTemplatesPresenterInterface $presenter): void
+    {
+        try {
+            $contactTemplates = $this->repository->findAll();
+        } catch (\Throwable $ex) {
+            $this->error('An error occured in data storage while getting contact templates', [
+                'trace' => $ex->getTraceAsString()
+            ]);
+            $presenter->setResponseStatus(new ErrorResponse(
+                'Impossible to get contact templates from data storage'
+            ));
+            return;
+        }
+
+        $presenter->present(new FindContactTemplatesResponse($contactTemplates));
+    }
+}

--- a/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesPresenterInterface.php
+++ b/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesPresenterInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Application\UseCase\FindContactTemplates;
+
+use Core\Application\Common\UseCase\PresenterInterface;
+
+interface FindContactTemplatesPresenterInterface extends PresenterInterface
+{
+}

--- a/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesResponse.php
+++ b/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesResponse.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Application\UseCase\FindContactTemplates;
+
+use Core\Contact\Domain\Model\ContactTemplate;
+
+class FindContactTemplatesResponse
+{
+    /**
+     * @var array<array<string,string|int>>
+     */
+    public array $contactTemplates;
+
+    /**
+     * Undocumented function
+     *
+     * @param array<ContactTemplate> $contactTemplates
+     */
+    public function __construct(array $contactTemplates)
+    {
+        $this->contactTemplates = $this->contactTemplatesToArray($contactTemplates);
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param array<ContactTemplate> $contactTemplates
+     * @return array<array<string,string|int>>
+     */
+    private function contactTemplatesToArray(array $contactTemplates): array
+    {
+        return array_map(
+            fn (ContactTemplate $contactTemplate) => [
+                'id' => $contactTemplate->getId(),
+                'name' => $contactTemplate->getName(),
+            ],
+            $contactTemplates
+        );
+    }
+}

--- a/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesResponse.php
+++ b/src/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesResponse.php
@@ -33,8 +33,6 @@ class FindContactTemplatesResponse
     public array $contactTemplates;
 
     /**
-     * Undocumented function
-     *
      * @param array<ContactTemplate> $contactTemplates
      */
     public function __construct(array $contactTemplates)
@@ -43,8 +41,6 @@ class FindContactTemplatesResponse
     }
 
     /**
-     * Undocumented function
-     *
      * @param array<ContactTemplate> $contactTemplates
      * @return array<array<string,string|int>>
      */

--- a/src/Core/Contact/Domain/Model/ContactTemplate.php
+++ b/src/Core/Contact/Domain/Model/ContactTemplate.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Domain\Model;
+
+class ContactTemplate
+{
+    /**
+     * @param integer $id
+     * @param string $name
+     */
+    public function __construct(
+        private int $id,
+        private string $name
+    ) {
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesController.php
+++ b/src/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesController.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Infrastructure\Api\FindContactTemplates;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Contact\Application\UseCase\FindContactTemplates\{
+    FindContactTemplates,
+    FindContactTemplatesPresenterInterface
+};
+
+class FindContactTemplatesController extends AbstractController
+{
+    /**
+     * @param FindContactTemplates $useCase
+     * @param FindContactTemplatesPresenterInterface $presenter
+     * @return object
+     */
+    public function __invoke(FindContactTemplates $useCase, FindContactTemplatesPresenterInterface $presenter): object
+    {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($presenter);
+        return $presenter->show();
+    }
+}

--- a/src/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesPresenter.php
+++ b/src/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesPresenter.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Infrastructure\Api\FindContactTemplates;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Contact\Application\UseCase\FindContactTemplates\{
+    FindContactTemplatesPresenterInterface
+};
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+
+class FindContactTemplatesPresenter extends AbstractPresenter implements FindContactTemplatesPresenterInterface
+{
+    /**
+     * @param RequestParametersInterface $requestParameters
+     * @param PresenterFormatterInterface $presenterFormatter
+     */
+    public function __construct(
+        private RequestParametersInterface $requestParameters,
+        protected PresenterFormatterInterface $presenterFormatter,
+    ) {
+    }
+
+    /**
+     * @param mixed $presentedData
+     * @return void
+     */
+    public function present(mixed $presentedData): void
+    {
+        parent::present([
+            'result' => $presentedData->contactTemplates,
+            'meta' => $this->requestParameters->toArray()
+        ]);
+    }
+}

--- a/src/Core/Contact/Infrastructure/Repository/DbContactTemplateFactory.php
+++ b/src/Core/Contact/Infrastructure/Repository/DbContactTemplateFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Infrastructure\Repository;
+
+use Core\Contact\Domain\Model\ContactTemplate;
+
+class DbContactTemplateFactory
+{
+    /**
+     * @param array<string,string> $record
+     * @return ContactTemplate
+     */
+    public static function createFromRecord(array $record): ContactTemplate
+    {
+        return new ContactTemplate(
+            (int) $record['contact_id'],
+            $record['contact_name']
+        );
+    }
+}

--- a/src/Core/Contact/Infrastructure/Repository/DbReadContactTemplateRepository.php
+++ b/src/Core/Contact/Infrastructure/Repository/DbReadContactTemplateRepository.php
@@ -38,6 +38,7 @@ class DbReadContactTemplateRepository extends AbstractRepositoryDRB implements R
 
     /**
      * @param DatabaseConnection $db
+     * @param SqlRequestParametersTranslator $sqlRequestTranslator
      */
     public function __construct(DatabaseConnection $db, SqlRequestParametersTranslator $sqlRequestTranslator)
     {

--- a/src/Core/Contact/Infrastructure/Repository/DbReadContactTemplateRepository.php
+++ b/src/Core/Contact/Infrastructure/Repository/DbReadContactTemplateRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Infrastructure\Repository;
+
+use Centreon\Infrastructure\DatabaseConnection;
+use Centreon\Domain\RequestParameters\RequestParameters;
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
+use Core\Contact\Application\Repository\ReadContactTemplateRepositoryInterface;
+
+class DbReadContactTemplateRepository extends AbstractRepositoryDRB implements ReadContactTemplateRepositoryInterface
+{
+    /**
+     * @var SqlRequestParametersTranslator
+     */
+    private SqlRequestParametersTranslator $sqlRequestTranslator;
+
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db, SqlRequestParametersTranslator $sqlRequestTranslator)
+    {
+        $this->db = $db;
+        $this->sqlRequestTranslator = $sqlRequestTranslator;
+        $this->sqlRequestTranslator
+            ->getRequestParameters()
+            ->setConcordanceStrictMode(RequestParameters::CONCORDANCE_MODE_STRICT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findAll(): array
+    {
+        $request = "SELECT SQL_CALC_FOUND_ROWS contact_id, contact_name FROM contact WHERE contact_register = 0";
+
+        // Sort
+        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
+        $request .= $sortRequest !== null ? $sortRequest : ' ORDER BY contact_id ASC';
+
+        // Pagination
+        $request .= $this->sqlRequestTranslator->translatePaginationToSql();
+
+        $statement = $this->db->query($this->translateDbName($request));
+
+        // Set total
+        $result = $this->db->query('SELECT FOUND_ROWS()');
+        if ($result !== false && ($total = $result->fetchColumn()) !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal((int) $total);
+        }
+
+        $contactTemplates = [];
+        while ($statement !== false && is_array($result = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $contactTemplates[] = DbContactTemplateFactory::createFromRecord($result);
+        }
+
+        return $contactTemplates;
+    }
+}

--- a/tests/php/Core/Contact/Application/UseCase/FindContactTemplatesPresenterStub.php
+++ b/tests/php/Core/Contact/Application/UseCase/FindContactTemplatesPresenterStub.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Contact\Application\UseCase;
+
+use Symfony\Component\HttpFoundation\Response;
+use Core\Contact\Application\UseCase\FindContactTemplates\FindContactTemplatesResponse;
+use Core\Contact\Application\UseCase\FindContactTemplates\FindContactTemplatesPresenterInterface;
+use Core\Application\Common\UseCase\{
+    AbstractPresenter
+};
+
+class FindContactTemplatesPresenterStub extends AbstractPresenter implements FindContactTemplatesPresenterInterface
+{
+    /**
+     * @var FindContactTemplatesResponse
+     */
+    public $response;
+
+    /**
+     * @param FindContactTemplatesResponse $response
+     */
+    public function present(mixed $response): void
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response
+     */
+    public function show(): Response
+    {
+        return new Response();
+    }
+}

--- a/tests/php/Core/Contact/Application/UseCase/FindContactTemplatesTest.php
+++ b/tests/php/Core/Contact/Application/UseCase/FindContactTemplatesTest.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Contact\Application\UseCase;
+namespace Tests\Core\Contact\Application\UseCase;
 
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;

--- a/tests/php/Core/Contact/Application/UseCase/FindContactTemplatesTest.php
+++ b/tests/php/Core/Contact/Application/UseCase/FindContactTemplatesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Application\UseCase;
+
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Tests\Core\Contact\Application\UseCase\FindContactTemplatesPresenterStub;
+use Core\Contact\Application\Repository\ReadContactTemplateRepositoryInterface;
+use Core\Contact\Application\UseCase\FindContactTemplates\FindContactTemplates;
+use Core\Contact\Application\UseCase\FindContactTemplates\FindContactTemplatesResponse;
+use Core\Contact\Domain\Model\ContactTemplate;
+
+beforeEach(function () {
+    $this->repository = $this->createMock(ReadContactTemplateRepositoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+});
+
+it('should present an ErrorResponse while an exception occured', function () {
+    $useCase = new FindContactTemplates($this->repository);
+    $this->repository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willThrowException(new \Exception());
+
+    $presenter = new FindContactTemplatesPresenterStub($this->presenterFormatter);
+    $useCase($presenter);
+
+    expect($presenter->getResponseStatus())->toBeInstanceOf(ErrorResponse::class);
+    expect($presenter->getResponseStatus()?->getMessage())->toBe(
+        'Impossible to get contact templates from data storage'
+    );
+});
+
+it('should present a FindContactTemplatesResponse when no error occured', function () {
+    $useCase = new FindContactTemplates($this->repository);
+    $contactTemplate = new ContactTemplate(1, 'contact_template');
+    $this->repository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willReturn([$contactTemplate]);
+
+    $presenter = new FindContactTemplatesPresenterStub($this->presenterFormatter);
+    $useCase($presenter);
+
+    expect($presenter->response)->toBeInstanceOf(FindContactTemplatesResponse::class);
+    expect($presenter->response->contactTemplates[0])->toBe(
+        [
+            'id' => 1,
+            'name' => 'contact_template'
+        ]
+    );
+});

--- a/tests/php/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesControllerTest.php
+++ b/tests/php/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Infrastructure\Security\ProviderConfiguration\WebSSO\Api\FindWebSSOConfiguration;
+
+use Centreon\Domain\Contact\Contact;
+use Core\Contact\Application\UseCase\FindContactTemplates\FindContactTemplates;
+use Core\Contact\Application\UseCase\FindContactTemplates\FindContactTemplatesPresenterInterface;
+use Core\Contact\Infrastructure\Api\FindContactTemplates\FindContactTemplatesController;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+beforeEach(function () {
+    $this->useCase = $this->createMock(FindContactTemplates::class);
+    $this->presenter = $this->createMock(FindContactTemplatesPresenterInterface::class);
+
+    $timezone = new \DateTimeZone('Europe/Paris');
+    $adminContact = (new Contact())
+        ->setId(1)
+        ->setName('admin')
+        ->setAdmin(true)
+        ->setTimezone($timezone);
+    $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+    $authorizationChecker->expects($this->once())
+        ->method('isGranted')
+        ->willReturn(true);
+    $token = $this->createMock(TokenInterface::class);
+    $token->expects($this->any())
+        ->method('getUser')
+        ->willReturn($adminContact);
+    $tokenStorage = $this->createMock(TokenStorageInterface::class);
+    $tokenStorage->expects($this->any())
+        ->method('getToken')
+        ->willReturn($token);
+    $this->container = $this->createMock(ContainerInterface::class);
+    $this->container->expects($this->any())
+        ->method('has')
+        ->willReturn(true);
+    $this->container->expects($this->any())
+        ->method('get')
+        ->withConsecutive(
+            [$this->equalTo('security.authorization_checker')],
+            [$this->equalTo('parameter_bag')]
+        )
+        ->willReturnOnConsecutiveCalls(
+            $authorizationChecker,
+            new class () {
+                public function get(): string
+                {
+                    return __DIR__ . '/../../../../../';
+                }
+            }
+        );
+    $this->request = $this->createMock(Request::class);
+});
+
+it('should call the use case', function () {
+    $controller = new FindContactTemplatesController();
+    $controller->setContainer($this->container);
+
+    $this->useCase
+        ->expects($this->once())
+        ->method('__invoke')
+        ->with(
+            $this->equalTo($this->presenter)
+        );
+
+    $controller($this->useCase, $this->presenter);
+});

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -165,7 +165,7 @@ function insertWebSSOConfiguration(CentreonDB $pearDB): void
     $customConfiguration = [
         "trusted_client_addresses" => [],
         "blacklist_client_addresses" => [],
-        "login_header_attribute" => null,
+        "login_header_attribute" => "HTTP_AUTH_USER",
         "pattern_matching_login" => null,
         "pattern_replace_login" => null
     ];


### PR DESCRIPTION
## Description

In order to prepare auto imports features, we need to implement an endpoint to get the list of contact templates.

**Fixes** # MON-12595

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
