### PR TITLE
enh(conf/host) add findHostByName method

### DIFF
--- a/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+++ b/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
@@ -676,4 +676,16 @@ class HostConfigurationService implements HostConfigurationServiceInterface
             }
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function findHostByName(string $hostName): ?Host
+    {
+        try {
+            return $this->hostConfigurationRepository->findHostByName($hostName);
+        } catch (\Throwable $ex) {
+            throw new HostConfigurationException(_('Error while searching for the host'), 0, $ex);
+        }
+    }
 }

--- a/src/Centreon/Domain/HostConfiguration/Interfaces/HostConfigurationReadRepositoryInterface.php
+++ b/src/Centreon/Domain/HostConfiguration/Interfaces/HostConfigurationReadRepositoryInterface.php
@@ -116,4 +116,13 @@ interface HostConfigurationReadRepositoryInterface
      * @return Host[]
      */
     public function findHostTemplatesByHost(Host $host): array;
+
+    /**
+     * Find a host by its name.
+     *
+     * @param string $hostName Host Id to be found
+     * @return Host|null Returns a host otherwise null
+     * @throws \Throwable
+     */
+    public function findHostByName(string $hostName): ?Host;
 }

--- a/src/Centreon/Domain/HostConfiguration/Interfaces/HostConfigurationServiceInterface.php
+++ b/src/Centreon/Domain/HostConfiguration/Interfaces/HostConfigurationServiceInterface.php
@@ -131,4 +131,13 @@ interface HostConfigurationServiceInterface
      * @return Host[]
      */
     public function findHostTemplatesByHost(Host $host): array;
+
+    /**
+     * Find a host by its name
+     *
+     * @param string $hostName Host name to be found
+     * @return Host|null Returns a host otherwise null
+     * @throws HostConfigurationException
+     */
+    public function findHostByName(string $hostName): ?Host;
 }

--- a/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
@@ -235,26 +235,7 @@ class HostConfigurationRepositoryRDB extends AbstractRepositoryDRB implements Ho
         $statement->execute();
 
         if (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
-            /**
-             * @var Host $host
-             */
-            $host = EntityCreator::createEntityByArray(Host::class, $record, 'host_');
-            /**
-             * @var ExtendedHost $extendedHost
-             */
-            $extendedHost = EntityCreator::createEntityByArray(ExtendedHost::class, $record, 'ehi_');
-            $host->setExtendedHost($extendedHost);
-            /**
-             * @var MonitoringServer $monitoringServer
-             */
-            $monitoringServer = EntityCreator::createEntityByArray(
-                MonitoringServer::class,
-                $record,
-                'monitoring_server_'
-            );
-            $host->setMonitoringServer($monitoringServer);
-
-            return $host;
+            return $this->createHost($record);
         }
         return null;
     }
@@ -997,6 +978,35 @@ class HostConfigurationRepositoryRDB extends AbstractRepositoryDRB implements Ho
     }
 
     /**
+     * @param array<string,mixed> $hostData
+     * @return Host
+     * @throws \Exception
+     */
+    private function createHost(array $hostData): Host
+    {
+        /**
+         * @var Host $host
+         */
+        $host = EntityCreator::createEntityByArray(Host::class, $hostData, 'host_');
+        /**
+         * @var ExtendedHost $extendedHost
+         */
+        $extendedHost = EntityCreator::createEntityByArray(ExtendedHost::class, $hostData, 'ehi_');
+        $host->setExtendedHost($extendedHost);
+        /**
+         * @var MonitoringServer $monitoringServer
+         */
+        $monitoringServer = EntityCreator::createEntityByArray(
+            MonitoringServer::class,
+            $hostData,
+            'monitoring_server_'
+        );
+        $host->setMonitoringServer($monitoringServer);
+
+        return $host;
+    }
+
+    /**
      * @inheritDoc
      */
     public function findHostByName(string $hostName): ?Host
@@ -1021,26 +1031,7 @@ class HostConfigurationRepositoryRDB extends AbstractRepositoryDRB implements Ho
         $statement->execute();
 
         if (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
-            /**
-             * @var Host $host
-             */
-            $host = EntityCreator::createEntityByArray(Host::class, $record, 'host_');
-            /**
-             * @var ExtendedHost $extendedHost
-             */
-            $extendedHost = EntityCreator::createEntityByArray(ExtendedHost::class, $record, 'ehi_');
-            $host->setExtendedHost($extendedHost);
-            /**
-             * @var MonitoringServer $monitoringServer
-             */
-            $monitoringServer = EntityCreator::createEntityByArray(
-                MonitoringServer::class,
-                $record,
-                'monitoring_server_'
-            );
-            $host->setMonitoringServer($monitoringServer);
-
-            return $host;
+            return $this->createHost($record);
         }
         return null;
     }

--- a/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
@@ -995,4 +995,53 @@ class HostConfigurationRepositoryRDB extends AbstractRepositoryDRB implements Ho
 
         $this->linkSeverityToHost($host);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function findHostByName(string $hostName): ?Host
+    {
+        $request = $this->translateDbName(
+            'SELECT host.host_id, host.host_name, host.host_alias, host.display_name AS host_display_name,
+            host.host_address AS host_ip_address, host.host_comment, host.geo_coords AS host_geo_coords,
+            host.host_activate AS host_is_activated, nagios.id AS monitoring_server_id,
+            nagios.name AS monitoring_server_name, ext.*
+            FROM `:db`.host host
+            LEFT JOIN `:db`.extended_host_information ext
+                ON ext.host_host_id = host.host_id
+            INNER JOIN `:db`.ns_host_relation host_server
+                ON host_server.host_host_id = host.host_id
+            INNER JOIN `:db`.nagios_server nagios
+                ON nagios.id = host_server.nagios_server_id
+            WHERE host.host_name = :host_name
+            AND host.host_register = \'1\''
+        );
+        $statement = $this->db->prepare($request);
+        $statement->bindValue(':host_name', $hostName, \PDO::PARAM_STR);
+        $statement->execute();
+
+        if (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            /**
+             * @var Host $host
+             */
+            $host = EntityCreator::createEntityByArray(Host::class, $record, 'host_');
+            /**
+             * @var ExtendedHost $extendedHost
+             */
+            $extendedHost = EntityCreator::createEntityByArray(ExtendedHost::class, $record, 'ehi_');
+            $host->setExtendedHost($extendedHost);
+            /**
+             * @var MonitoringServer $monitoringServer
+             */
+            $monitoringServer = EntityCreator::createEntityByArray(
+                MonitoringServer::class,
+                $record,
+                'monitoring_server_'
+            );
+            $host->setMonitoringServer($monitoringServer);
+
+            return $host;
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
## Description

New method findHostByName, is part of the autodisco feature to handle host created manually in host discovery (https://github.com/centreon/centreon-autodiscovery/pull/598)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
