### PR TITLE
fix(upgrade): fix alter table error on upgrade from <= 20.10 to 22.04

### DIFF
--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2407,8 +2407,7 @@ CREATE TABLE `security_token` (
   `expiration_date` bigint UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`id`),
   INDEX `token_index` (`token`),
-  INDEX `expiration_index` (`expiration_date`),
-  UNIQUE KEY `unique_token` (`token`)
+  INDEX `expiration_index` (`expiration_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `security_authentication_tokens` (

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -143,7 +143,7 @@ try {
         'SELECT CONSTRAINT_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE
          WHERE TABLE_NAME="security_token" AND CONSTRAINT_NAME="unique_token"'
     );
-    if($constraintExistStatement->fetch() !== false) {
+    if ($constraintExistStatement->fetch() !== false) {
         $errorMessage = "Unable to remove unique_index from security_token";
         $pearDB->query("ALTER TABLE `security_token` DROP INDEX `unique_token`");
     }

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -72,7 +72,7 @@ try {
     $pearDB->beginTransaction();
 
     $errorMessage = "Unable to select existing passwords from 'contact' table";
-    if ($pearDB->isColumnExist('contact', 'contact_passord') === 1) {
+    if ($pearDB->isColumnExist('contact', 'contact_passwd') === 1) {
         $getPasswordResult = $pearDB->query(
             "SELECT `contact_id`, `contact_passwd` FROM `contact` WHERE `contact_passwd` IS NOT NULL"
         );

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -138,8 +138,15 @@ try {
         $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
     }
 
-    $errorMessage= "Unable to remove unique_index from security_token";
-    $pearDB->query("ALTER TABLE `security_token` DROP INDEX `unique_token`");
+    $errorMessage = "Unable to find constraint unique_index from security_token";
+    $constraintExistStatement = $pearDB->query(
+        'SELECT CONSTRAINT_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+         WHERE TABLE_NAME="security_token" AND CONSTRAINT_NAME="unique_token"'
+    );
+    if($constraintExistStatement->fetch() !== false) {
+        $errorMessage = "Unable to remove unique_index from security_token";
+        $pearDB->query("ALTER TABLE `security_token` DROP INDEX `unique_token`");
+    }
 
     $errorMessage = "Unable to alter table security_token";
     $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");


### PR DESCRIPTION
## Description

This PR intends to  fix alter table error on upgrade <= 20.10 to 22.04

On Centreon Web 20.10 and prior the version of MariaDB is 10.3, the query `$pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");` can't be executed as an unique key index is present on this column and couldn't be more than 3072 bytes. 
This PR remove the unique index

**Fixes** # MON-12897

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
