### PR TITLE
enh(openid): re add old log mechanism

### DIFF
--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -509,7 +509,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function getUsernameFromLoginClaim(): string
     {
-        $loginClaim = !empty($this->configuration->getLoginClaim())
+        $loginClaim = ! empty($this->configuration->getLoginClaim())
             ? $this->configuration->getLoginClaim()
             : OpenIdConfiguration::DEFAULT_LOGIN_GLAIM;
         if (

--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -262,6 +262,10 @@ class OpenIdProvider implements OpenIdProviderInterface
         $statusCode = $response->getStatusCode();
         if ($statusCode !== Response::HTTP_OK) {
             $this->logErrorForInvalidStatusCode($statusCode, Response::HTTP_OK);
+            $this->logExceptionInLoginLogFile(
+                "Unable to get Rfresh Token Information: %s, message: %s",
+                SSOAuthenticationException::requestForRefreshTokenFail()
+            );
             throw SSOAuthenticationException::requestForRefreshTokenFail();
         }
         $content = json_decode($response->getContent(false), true);
@@ -332,6 +336,10 @@ class OpenIdProvider implements OpenIdProviderInterface
         $statusCode = $response->getStatusCode();
         if ($statusCode !== Response::HTTP_OK) {
             $this->logErrorForInvalidStatusCode($statusCode, Response::HTTP_OK);
+            $this->logExceptionInLoginLogFile(
+                "Unable to get Token Access Information: %s, message: %s",
+                SSOAuthenticationException::requestForConnectionTokenFail()
+            );
             throw SSOAuthenticationException::requestForConnectionTokenFail();
         }
         $content = json_decode($response->getContent(false), true);
@@ -406,6 +414,10 @@ class OpenIdProvider implements OpenIdProviderInterface
         $statusCode = $response->getStatusCode();
         if ($statusCode !== Response::HTTP_OK) {
             $this->logErrorForInvalidStatusCode($statusCode, Response::HTTP_OK);
+            $this->logExceptionInLoginLogFile(
+                "Unable to get Introspection Information: %s, message: %s",
+                SSOAuthenticationException::requestForIntrospectionTokenFail()
+            );
             throw SSOAuthenticationException::requestForIntrospectionTokenFail();
         }
         $content = json_decode($response->getContent(false), true);
@@ -446,6 +458,10 @@ class OpenIdProvider implements OpenIdProviderInterface
         $statusCode = $response->getStatusCode();
         if ($statusCode !== Response::HTTP_OK) {
             $this->logErrorForInvalidStatusCode($statusCode, Response::HTTP_OK);
+            $this->logExceptionInLoginLogFile(
+                "Unable to get User Information: %s, message: %s",
+                SSOAuthenticationException::requestForUserInformationFail()
+            );
             throw SSOAuthenticationException::requestForUserInformationFail();
         }
         $content = json_decode($response->getContent(false), true);

--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -405,12 +405,12 @@ class OpenIdProvider implements OpenIdProviderInterface
             throw SSOAuthenticationException::requestForIntrospectionTokenFail();
         }
         $content = json_decode($response->getContent(false), true);
-        $this->logAuthenticationInfoInLoginLogFile('Token Introspection Information: ', $content);
         if (empty($content) || array_key_exists('error', $content)) {
             $this->logErrorInLoginLogFile('Introspection Token Info: ', $content);
             $this->logErrorFromExternalProvider($content);
             throw SSOAuthenticationException::errorFromExternalProvider(OpenIdConfiguration::NAME);
         }
+        $this->logAuthenticationInfoInLoginLogFile('Token Introspection Information: ', $content);
         $this->info('Introspection token information found');
         $this->userInformations = $content;
     }

--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -597,7 +597,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      * Log error in login.log file
      *
      * @param string $message
-     * @param array $content
+     * @param array<string,string> $content
      */
     private function logErrorInLoginLogFile(string $message, array $content): void
     {
@@ -613,7 +613,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      * Log Authentication informations in login.log file
      *
      * @param string $message
-     * @param array $content
+     * @param array<string,string> $content
      */
     private function logAuthenticationInfoInLoginLogFile(string $message, array $content): void
     {

--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -285,7 +285,6 @@ class OpenIdProvider implements OpenIdProviderInterface
             [
                 'provider_token' => $resultForDebug['access_token'],
                 'refresh_token' => $resultForDebug['refresh_token'],
-                'id_token' => $resultForDebug['id_token']
             ]
         );
         $creationDate = new \DateTime();

--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -263,7 +263,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         if ($statusCode !== Response::HTTP_OK) {
             $this->logErrorForInvalidStatusCode($statusCode, Response::HTTP_OK);
             $this->logExceptionInLoginLogFile(
-                "Unable to get Rfresh Token Information: %s, message: %s",
+                "Unable to get Refresh Token Information: %s, message: %s",
                 SSOAuthenticationException::requestForRefreshTokenFail()
             );
             throw SSOAuthenticationException::requestForRefreshTokenFail();


### PR DESCRIPTION
## Description

This PR intends to reimplement old log in login.log for openid connection

**Fixes** # MON-6493

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
