### PR TITLE
fix(security): delete only expired tokens without refresh token

### DIFF
--- a/src/Core/Infrastructure/Security/Repository/DbWriteTokenRepository.php
+++ b/src/Core/Infrastructure/Security/Repository/DbWriteTokenRepository.php
@@ -57,11 +57,11 @@ class DbWriteTokenRepository extends AbstractRepositoryDRB implements WriteToken
 
         $this->db->query(
             $this->translateDbName(
-                "DELETE st FROM `centreon`.security_token st
+                "DELETE st FROM `:db`.security_token st
                 WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
                 AND EXISTS (
                     SELECT 1
-                    FROM `centreon`.security_authentication_tokens sat
+                    FROM `:db`.security_authentication_tokens sat
                     WHERE sat.provider_token_refresh_id = st.id
                     LIMIT 1
                 )"
@@ -78,11 +78,11 @@ class DbWriteTokenRepository extends AbstractRepositoryDRB implements WriteToken
 
         $this->db->query(
             $this->translateDbName(
-                "DELETE st FROM `centreon`.security_token st
+                "DELETE st FROM `:db`.security_token st
                 WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
                 AND NOT EXISTS (
                     SELECT 1
-                    FROM `centreon`.security_authentication_tokens sat
+                    FROM `:db`.security_authentication_tokens sat
                     WHERE sat.provider_token_id = st.id
                     AND sat.provider_token_refresh_id IS NOT NULL
                     LIMIT 1


### PR DESCRIPTION
## Description

delete only expired tokens without refresh token
This avoid unexpected disconnection with openid provider

**Fixes** MON-12699

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)