### PR TITLE
chore(snyk): exclude e2e tests

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore: {}
 
 exclude:
    code:
-     - "tests/**/.php"
+     - "tests/**/*"
      - "**/index.test.tsx"
      - tests/php/**/*
      - www/install/step_upgrade/**/*

--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore: {}
 
 exclude:
    code:
-     - "tests/**/*"
+     - "test?/**/*"
      - "**/index.test.tsx"
      - tests/php/**/*
      - www/install/step_upgrade/**/*

--- a/tests/e2e/cypress/tsconfig.json
+++ b/tests/e2e/cypress/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "baseUrl": "..",
     "esModuleInterop": true,
-    "types": ["cypress", "node"],
+    "types": ["cypress", "node"]
   },
   "include": [
     "**/*.ts"
-  ],
+  ]
 }


### PR DESCRIPTION
## Description

Exclude tests/e2e forlders
Remove trailling coma which break snyk's scans
![image](https://user-images.githubusercontent.com/34628915/162768915-e69cd6dc-d288-482d-a94a-29821c189067.png)


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)
