### PR TITLE
fix:  graph tiles size constant in rs host graph panel

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/Graphs.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'grid',
     gridTemplateColumns: `repeat(auto-fill, minmax(${theme.spacing(
       40,
-    )}px, auto))`,
+    )}, auto))`,
     rowGap: '8px',
   },
 }));

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/index.tsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   graphContainer: {
     display: 'grid',
     gridTemplateRows: '1fr',
+    height: '93%',
     padding: theme.spacing(2, 1, 1),
   },
 }));


### PR DESCRIPTION
update graph tiles size to be equal 
some screens : 
**before** : 
![avant0](https://user-images.githubusercontent.com/97687698/162965273-0439de93-5408-43de-bf3a-0e4a4396fa07.png)

**after**:
![graphuu](https://user-images.githubusercontent.com/97687698/162965340-f016337b-249a-4d8d-93cd-60a73e7468ff.png)

