### PR TITLE
fix(upgrade): exclude CBIS user from password policy

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -693,7 +693,7 @@ function createGorgoneUser(CentreonDB $pearDB, string $userAlias, string $hashed
 function excludeUsersFromPasswordPolicy(CentreonDB $pearDB): void
 {
     $usersToExclude = [
-        ':bi' => 'centreonBI',
+        ':bi' => 'CBIS',
         ':map' => 'centreon-map'
     ];
 


### PR DESCRIPTION
## Description

exclude CBIS user from password policy instead of centreonBI

**Fixes** MON-13022

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)