### PR TITLE
fix(UI): Fix pages topology

### DIFF
--- a/www/front_src/src/route-components/legacyRoute/index.tsx
+++ b/www/front_src/src/route-components/legacyRoute/index.tsx
@@ -14,10 +14,11 @@ const LegacyRoute = (): JSX.Element => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  React.useEffect(() => {
-    mainContainerRef.current =
-      window.document.getElementById('fullscreen-wrapper');
-  }, []);
+  const handleHref = (event): void => {
+    const { href } = event.detail;
+
+    window.history.pushState(null, href, href);
+  };
 
   const load = (): void => {
     setLoading(false);
@@ -51,6 +52,17 @@ const LegacyRoute = (): JSX.Element => {
       );
     });
   };
+
+  React.useEffect(() => {
+    mainContainerRef.current =
+      window.document.getElementById('fullscreen-wrapper');
+
+    window.addEventListener('react.href.update', handleHref, false);
+
+    return () => {
+      window.removeEventListener('react.href.update', handleHref);
+    };
+  }, []);
 
   const { search, hash } = location;
 

--- a/www/include/core/footer/footerPart.php
+++ b/www/include/core/footer/footerPart.php
@@ -267,6 +267,39 @@ foreach ($jsdata as $k => $val) {
     }
     ?>
 
+    // send an event to parent for change in iframe URL
+    function parentHrefUpdate(href) {
+        let parentHref = window.parent.location.href;
+        href = href.replace('main.get.php', 'main.php');
+
+        if (parentHref.localeCompare(href) === 0) {
+            return;
+        }
+
+        href = '/' + href.split(window.location.host + '/')[1];
+
+        if (parentHref.localeCompare(href) === 0) {
+            return;
+        }
+
+        var event = new CustomEvent('react.href.update', {
+            detail: {
+                href: href
+            }
+        });
+        window.parent.dispatchEvent(event);
+    }
+
+    // send event when url changed
+    jQuery(document).ready(function() {
+        parentHrefUpdate(location.href);
+    });
+
+    // send event when hash changed
+    jQuery(window).bind('hashchange', function() {
+        parentHrefUpdate(location.href);
+    });
+
     jQuery('body').delegate(
         'a',
         'click',


### PR DESCRIPTION
## Description

This fixes page topology in URL when navigating from a legacy page to another legacy page.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the 'pollers list' page
- Click on the "Export configuration" button
- -> The URL contains the correct page topology

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
