### PR TITLE
enh (export/conf): Add icon_id property to exported host and service files

### DIFF
--- a/www/class/config-generate/abstract/host.class.php
+++ b/www/class/config-generate/abstract/host.class.php
@@ -119,6 +119,7 @@ abstract class AbstractHost extends AbstractObject
         'notes_url',
         'action_url',
         'icon_image',
+        'icon_id',
         'icon_image_alt',
         'statusmap_image',
         'timezone',
@@ -180,6 +181,7 @@ abstract class AbstractHost extends AbstractObject
         $media = Media::getInstance($this->dependencyInjector);
         if (!isset($host['icon_image'])) {
             $host['icon_image'] = $media->getMediaPathFromId($host['icon_image_id']);
+            $host['icon_id'] = $host['icon_image_id'];
         }
         if (!isset($host['statusmap_image'])) {
             $host['statusmap_image'] = $media->getMediaPathFromId($host['statusmap_image_id']);

--- a/www/class/config-generate/abstract/service.class.php
+++ b/www/class/config-generate/abstract/service.class.php
@@ -112,6 +112,7 @@ abstract class AbstractService extends AbstractObject
         'notes_url',
         'action_url',
         'icon_image',
+        'icon_id',
         'icon_image_alt',
         'acknowledgement_timeout'
     );
@@ -145,6 +146,7 @@ abstract class AbstractService extends AbstractObject
         $media = Media::getInstance($this->dependencyInjector);
         if (!isset($service['icon_image'])) {
             $service['icon_image'] = $media->getMediaPathFromId($service['icon_image_id']);
+            $service['icon_id'] = $service['icon_image_id'];
         }
     }
 


### PR DESCRIPTION
## Description

For the new resource status table, we add icon_id property to exported host and service files

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
