### PR TITLE
enh(api): return service state in host listing

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Service.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Service.yml
@@ -150,6 +150,7 @@ Centreon\Domain\Monitoring\Service:
         state:
             type: int
             groups:
+                - 'service_min'
                 - 'service_main'
                 - 'service_full'
         stateType:


### PR DESCRIPTION
## Description

return service state in host listing when `show_service` argument is set

**Fixes** MON-13009 #10788

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)