### PR TITLE
fix(UI): Issue with openid connect

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15061,3 +15061,6 @@ msgstr ""
 
 # msgid "At least one of the two following fields must be filled"
 # msgstr ""
+
+# msgid "Press Enter to accept"
+# msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15058,3 +15058,6 @@ msgstr ""
 
 # msgid "Discard"
 # msgstr ""
+
+# msgid "At least one of the two following fields must be filled"
+# msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16751,3 +16751,6 @@ msgstr "Il y a des erreurs dans le formulaire. Voulez-vous quitter le formulaire
 
 msgid "Discard"
 msgstr "Annuler"
+
+msgid "At least one of the two following fields must be filled"
+msgstr "Au moins l'un des deux champs suivants doit être rempli"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16754,3 +16754,6 @@ msgstr "Annuler"
 
 msgid "At least one of the two following fields must be filled"
 msgstr "Au moins l'un des deux champs suivants doit être rempli"
+
+msgid "Press Enter to accept"
+msgstr "Appuyer sur Entrée pour accepter"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15512,3 +15512,6 @@ msgstr ""
 
 # msgid "At least one of the two following fields must be filled"
 # msgstr ""
+
+# msgid "Press Enter to accept"
+# msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15509,3 +15509,6 @@ msgstr ""
 
 # msgid "Discard"
 # msgstr ""
+
+# msgid "At least one of the two following fields must be filled"
+# msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15500,3 +15500,6 @@ msgstr ""
 
 # msgid "At least one of the two following fields must be filled"
 # msgstr ""
+
+# msgid "Press Enter to accept"
+# msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15497,3 +15497,6 @@ msgstr ""
 
 # msgid "Discard"
 # msgstr ""
+
+# msgid "At least one of the two following fields must be filled"
+# msgstr ""

--- a/src/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
+++ b/src/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
@@ -27,7 +27,10 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Centreon\Domain\Log\LoggerTrait;
-use Core\Domain\Security\ProviderConfiguration\OpenId\Model\OpenIdConfigurationFactory;
+use Core\Domain\Security\ProviderConfiguration\OpenId\{
+    Model\OpenIdConfigurationFactory,
+    Exceptions\OpenIdConfigurationException
+};
 use Core\Application\Security\ProviderConfiguration\OpenId\Repository\WriteOpenIdConfigurationRepositoryInterface;
 
 class UpdateOpenIdConfiguration
@@ -53,7 +56,7 @@ class UpdateOpenIdConfiguration
         $this->info('Updating OpenID Configuration');
         try {
             $configuration = OpenIdConfigurationFactory::createFromRequest($request);
-        } catch (AssertionException $ex) {
+        } catch (AssertionException | OpenIdConfigurationException $ex) {
             $this->error('Unable to create OpenID Configuration because one or many parameters are invalid');
             $presenter->setResponseStatus(new ErrorResponse($ex->getMessage()));
             return;

--- a/src/Core/Domain/Security/ProviderConfiguration/OpenId/Model/OpenIdConfigurationFactory.php
+++ b/src/Core/Domain/Security/ProviderConfiguration/OpenId/Model/OpenIdConfigurationFactory.php
@@ -26,6 +26,7 @@ namespace Core\Domain\Security\ProviderConfiguration\OpenId\Model;
 use Core\Application\Security\ProviderConfiguration\OpenId\UseCase\UpdateOpenIdConfiguration\{
     UpdateOpenIdConfigurationRequest
 };
+use Core\Domain\Security\ProviderConfiguration\OpenId\Exceptions\OpenIdConfigurationException;
 
 class OpenIdConfigurationFactory
 {
@@ -35,6 +36,11 @@ class OpenIdConfigurationFactory
      */
     public static function createFromRequest(UpdateOpenIdConfigurationRequest $request): OpenIdConfiguration
     {
+        if ($request->userInformationEndpoint === null && $request->introspectionTokenEndpoint === null)
+        {
+            throw OpenIdConfigurationException::missingInformationEndpoint();
+        }
+
         return new OpenIdConfiguration(
             $request->isActive,
             $request->isForced,

--- a/src/Core/Domain/Security/ProviderConfiguration/OpenId/Model/OpenIdConfigurationFactory.php
+++ b/src/Core/Domain/Security/ProviderConfiguration/OpenId/Model/OpenIdConfigurationFactory.php
@@ -36,8 +36,7 @@ class OpenIdConfigurationFactory
      */
     public static function createFromRequest(UpdateOpenIdConfigurationRequest $request): OpenIdConfiguration
     {
-        if ($request->userInformationEndpoint === null && $request->introspectionTokenEndpoint === null)
-        {
+        if ($request->userInformationEndpoint === null && $request->introspectionTokenEndpoint === null) {
             throw OpenIdConfigurationException::missingInformationEndpoint();
         }
 

--- a/tests/php/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/tests/php/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -133,7 +133,8 @@ class UpdateOpenIdConfigurationTest extends TestCase
     }
 
     /**
-     * Test that the useCase is correctly executed with correct parameters
+     * Test that the useCase present an erro response when introspection and user information
+     * endpoints are both null.
      */
     public function testUseCaseWithMissingUserInformationEndpoints(): void
     {

--- a/tests/php/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/tests/php/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -133,7 +133,7 @@ class UpdateOpenIdConfigurationTest extends TestCase
     }
 
     /**
-     * Test that the useCase present an erro response when introspection and user information
+     * Test that the useCase present an error response when introspection and user information
      * endpoints are both null.
      */
     public function testUseCaseWithMissingUserInformationEndpoints(): void

--- a/tests/php/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/tests/php/Core/Application/Security/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -32,7 +32,10 @@ use Core\Application\Security\ProviderConfiguration\OpenId\UseCase\UpdateOpenIdC
     UpdateOpenIdConfigurationPresenterInterface,
     UpdateOpenIdConfigurationRequest
 };
-use Core\Domain\Security\ProviderConfiguration\OpenId\Model\OpenIdConfigurationFactory;
+use Core\Domain\Security\ProviderConfiguration\OpenId\{
+    Model\OpenIdConfigurationFactory,
+    Exceptions\OpenIdConfigurationException
+};
 
 class UpdateOpenIdConfigurationTest extends TestCase
 {
@@ -95,8 +98,6 @@ class UpdateOpenIdConfigurationTest extends TestCase
 
     /**
      * Test that the useCase is correctly executed with correct parameters
-     *
-     * @return void
      */
     public function testUseCaseWithInvalidParameters(): void
     {
@@ -124,6 +125,41 @@ class UpdateOpenIdConfigurationTest extends TestCase
             ->with(new ErrorResponse(
                 '[OpenIdConfiguration::trustedClientAddresses] The value "abcd_.@" '
                 . 'was expected to be a valid ip address or domain name'
+            ));
+
+        $useCase = new UpdateOpenIdConfiguration($this->repository);
+
+        $useCase($this->presenter, $request);
+    }
+
+    /**
+     * Test that the useCase is correctly executed with correct parameters
+     */
+    public function testUseCaseWithMissingUserInformationEndpoints(): void
+    {
+        $request = new UpdateOpenIdConfigurationRequest();
+        $request->isActive = true;
+        $request->isForced = true;
+        $request->trustedClientAddresses = ["abcd_.@"];
+        $request->blacklistClientAddresses = [];
+        $request->baseUrl = 'http://127.0.0.1/auth/openid-connect';
+        $request->authorizationEndpoint = '/authorization';
+        $request->tokenEndpoint = '/token';
+        $request->introspectionTokenEndpoint = null;
+        $request->userInformationEndpoint = null;
+        $request->endSessionEndpoint = '/logout';
+        $request->connectionScopes = [];
+        $request->loginClaim = 'preferred_username';
+        $request->clientId = 'MyCl1ientId';
+        $request->clientSecret = 'MyCl1ientSuperSecr3tKey';
+        $request->authenticationType = 'client_secret_post';
+        $request->verifyPeer = false;
+
+        $this->presenter
+            ->expects($this->once())
+            ->method('setResponseStatus')
+            ->with(new ErrorResponse(
+                OpenIdConfigurationException::missingInformationEndpoint()->getMessage()
             ));
 
         $useCase = new UpdateOpenIdConfiguration($this->repository);

--- a/www/front_src/src/Authentication/FormInputs/Multiple.tsx
+++ b/www/front_src/src/Authentication/FormInputs/Multiple.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { FormikValues, useFormikContext } from 'formik';
-import { equals, isNil, map, prop, type } from 'ramda';
+import { equals, isEmpty, isNil, map, prop, type } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { FormHelperText, Stack } from '@mui/material';
@@ -12,10 +12,14 @@ import {
   useMemoComponent,
 } from '@centreon/ui';
 
+import { labelPressEnterToAccept } from '../translatedLabels';
+
 import { InputProps } from './models';
 
 const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
   const { t } = useTranslation();
+
+  const [inputText, setInputText] = React.useState('');
 
   const { values, setFieldValue, errors } = useFormikContext<FormikValues>();
 
@@ -63,7 +67,7 @@ const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
           isOptionEqualToValue={(option, selectedValue): boolean =>
             equals(option, selectedValue)
           }
-          label={t(label)}
+          label={`${t(label)} (${t(labelPressEnterToAccept)})`}
           open={false}
           options={[]}
           popupIcon={null}

--- a/www/front_src/src/Authentication/FormInputs/Multiple.tsx
+++ b/www/front_src/src/Authentication/FormInputs/Multiple.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { FormikValues, useFormikContext } from 'formik';
-import { equals, isEmpty, isNil, map, prop, type } from 'ramda';
+import { equals, isNil, map, prop, type } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import { FormHelperText, Stack } from '@mui/material';
@@ -18,8 +18,6 @@ import { InputProps } from './models';
 
 const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
   const { t } = useTranslation();
-
-  const [inputText, setInputText] = React.useState('');
 
   const { values, setFieldValue, errors } = useFormikContext<FormikValues>();
 

--- a/www/front_src/src/Authentication/FormInputs/Multiple.tsx
+++ b/www/front_src/src/Authentication/FormInputs/Multiple.tsx
@@ -19,6 +19,8 @@ import { InputProps } from './models';
 const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
   const { t } = useTranslation();
 
+  const [inputText, setInputText] = React.useState('');
+
   const { values, setFieldValue, errors } = useFormikContext<FormikValues>();
 
   const change = (_, newValues): void => {
@@ -48,6 +50,8 @@ const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
     return error || undefined;
   };
 
+  const textChange = (event): void => setInputText(event.target.value);
+
   const normalizedValues = selectedValues.map((value) => ({
     id: value,
     name: value,
@@ -55,23 +59,25 @@ const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
 
   const inputErrors = getError();
 
+  const additionalLabel = inputText ? ` (${labelPressEnterToAccept})` : '';
+
   return useMemoComponent({
     Component: (
       <div>
         <MultiAutocompleteField
-          clearOnBlur
           freeSolo
-          handleHomeEndKeys
+          inputValue={inputText}
           isOptionEqualToValue={(option, selectedValue): boolean =>
             equals(option, selectedValue)
           }
-          label={`${t(label)} (${t(labelPressEnterToAccept)})`}
+          label={`${t(label)}${additionalLabel}`}
           open={false}
           options={[]}
           popupIcon={null}
           required={required}
           value={normalizedValues}
           onChange={change}
+          onTextChange={textChange}
         />
         {inputErrors && (
           <Stack>
@@ -84,7 +90,7 @@ const Multiple = ({ fieldName, label, required }: InputProps): JSX.Element => {
         )}
       </div>
     ),
-    memoProps: [normalizedValues, inputErrors],
+    memoProps: [normalizedValues, inputErrors, additionalLabel],
   });
 };
 

--- a/www/front_src/src/Authentication/FormInputs/Text.tsx
+++ b/www/front_src/src/Authentication/FormInputs/Text.tsx
@@ -52,6 +52,7 @@ const Text = ({
   return useMemoComponent({
     Component: (
       <TextField
+        fullWidth
         EndAdornment={passwordEndAdornment}
         ariaLabel={t(label)}
         error={error as string | undefined}

--- a/www/front_src/src/Authentication/FormInputs/index.tsx
+++ b/www/front_src/src/Authentication/FormInputs/index.tsx
@@ -38,10 +38,14 @@ export const getInput = cond<InputType, (props: InputProps) => JSX.Element>([
 ]);
 
 const useStyles = makeStyles((theme) => ({
+  additionalLabel: {
+    marginBottom: theme.spacing(0.5),
+  },
   category: {
     marginBottom: theme.spacing(2),
     marginTop: theme.spacing(2),
   },
+  inputWrapper: { width: '100%' },
   inputs: {
     display: 'flex',
     flexDirection: 'column',
@@ -110,6 +114,7 @@ const Inputs = ({ inputs, categories }: Props): JSX.Element => {
                   change,
                   getChecked,
                   required,
+                  additionalLabel,
                 }) => {
                   const Input = getInput(type);
 
@@ -124,7 +129,19 @@ const Inputs = ({ inputs, categories }: Props): JSX.Element => {
                     type,
                   };
 
-                  return <Input key={label} {...props} />;
+                  return (
+                    <div className={classes.inputWrapper} key={label}>
+                      {additionalLabel && (
+                        <Typography
+                          className={classes.additionalLabel}
+                          variant="body1"
+                        >
+                          {t(additionalLabel)}
+                        </Typography>
+                      )}
+                      <Input {...props} />
+                    </div>
+                  );
                 },
               )}
             </div>

--- a/www/front_src/src/Authentication/FormInputs/models.ts
+++ b/www/front_src/src/Authentication/FormInputs/models.ts
@@ -7,6 +7,7 @@ export enum InputType {
 }
 
 export interface InputProps {
+  additionalLabel?: string;
   category: string;
   change?: ({ setFieldValue, value }) => void;
   fieldName: string;

--- a/www/front_src/src/Authentication/Openid/Form/index.tsx
+++ b/www/front_src/src/Authentication/Openid/Form/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Formik, FormikErrors, FormikValues } from 'formik';
+import { Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { isEmpty, isNil, pick, pipe, values, or, all, not } from 'ramda';
 

--- a/www/front_src/src/Authentication/Openid/Form/inputs.ts
+++ b/www/front_src/src/Authentication/Openid/Form/inputs.ts
@@ -1,6 +1,7 @@
 import { equals } from 'ramda';
 
 import {
+  labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled,
   labelAuthenticationMode,
   labelAuthorizationEndpoint,
   labelBaseUrl,
@@ -88,22 +89,17 @@ export const inputs: Array<InputProps> = [
   },
   {
     category: labelIdentityProvider,
-    fieldName: 'introspectionTokenEndpoint',
-    label: labelIntrospectionTokenEndpoint,
+    fieldName: 'clientId',
+    label: labelClientID,
     required: true,
     type: InputType.Text,
   },
   {
     category: labelIdentityProvider,
-    fieldName: 'userInformationEndpoint',
-    label: labelUserInformationEndpoint,
-    type: InputType.Text,
-  },
-  {
-    category: labelIdentityProvider,
-    fieldName: 'endSessionEndpoint',
-    label: labelEndSessionEndpoint,
-    type: InputType.Text,
+    fieldName: 'clientSecret',
+    label: labelClientSecret,
+    required: true,
+    type: InputType.Password,
   },
   {
     category: labelIdentityProvider,
@@ -119,17 +115,22 @@ export const inputs: Array<InputProps> = [
   },
   {
     category: labelIdentityProvider,
-    fieldName: 'clientId',
-    label: labelClientID,
-    required: true,
+    fieldName: 'endSessionEndpoint',
+    label: labelEndSessionEndpoint,
+    type: InputType.Text,
+  },
+  {
+    additionalLabel: labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled,
+    category: labelIdentityProvider,
+    fieldName: 'introspectionTokenEndpoint',
+    label: labelIntrospectionTokenEndpoint,
     type: InputType.Text,
   },
   {
     category: labelIdentityProvider,
-    fieldName: 'clientSecret',
-    label: labelClientSecret,
-    required: true,
-    type: InputType.Password,
+    fieldName: 'userinfoEndpoint',
+    label: labelUserInformationEndpoint,
+    type: InputType.Text,
   },
   {
     category: labelIdentityProvider,

--- a/www/front_src/src/Authentication/Openid/index.test.tsx
+++ b/www/front_src/src/Authentication/Openid/index.test.tsx
@@ -13,6 +13,7 @@ import {
   labelResetTheForm,
   labelSave,
 } from '../Local/translatedLabels';
+import { labelPressEnterToAccept } from '../translatedLabels';
 
 import {
   labelAuthorizationEndpoint,
@@ -107,10 +108,14 @@ describe('Openid configuration form', () => {
     expect(screen.getByLabelText(labelOpenIDConnectOnly)).not.toBeChecked();
     expect(screen.getByLabelText(labelMixed)).toBeChecked();
     expect(
-      screen.getByLabelText(labelTrustedClientAddresses),
+      screen.getByLabelText(
+        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(labelBlacklistClientAddresses),
+      screen.getByLabelText(
+        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
+      ),
     ).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
     expect(screen.getByLabelText(labelBaseUrl)).toHaveValue(
@@ -129,7 +134,9 @@ describe('Openid configuration form', () => {
     expect(screen.getByLabelText(labelEndSessionEndpoint)).toHaveValue(
       '/logout',
     );
-    expect(screen.getByLabelText(labelScopes)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(`${labelScopes} (${labelPressEnterToAccept})`),
+    ).toBeInTheDocument();
     expect(screen.getByText('openid')).toBeInTheDocument();
     expect(screen.getByLabelText(labelLoginClaimValue)).toHaveValue('sub');
     expect(screen.getByLabelText(labelClientID)).toHaveValue('client_id');
@@ -165,7 +172,9 @@ describe('Openid configuration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(labelTrustedClientAddresses),
+      screen.getByLabelText(
+        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
+      ),
       'invalid domain',
     );
     userEvent.keyboard('{Enter}');
@@ -177,7 +186,9 @@ describe('Openid configuration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(labelBlacklistClientAddresses),
+      screen.getByLabelText(
+        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
+      ),
       '127.0.0.1111',
     );
     userEvent.keyboard('{Enter}');

--- a/www/front_src/src/Authentication/Openid/index.test.tsx
+++ b/www/front_src/src/Authentication/Openid/index.test.tsx
@@ -13,7 +13,6 @@ import {
   labelResetTheForm,
   labelSave,
 } from '../Local/translatedLabels';
-import { labelPressEnterToAccept } from '../translatedLabels';
 
 import {
   labelAuthorizationEndpoint,
@@ -108,14 +107,10 @@ describe('Openid configuration form', () => {
     expect(screen.getByLabelText(labelOpenIDConnectOnly)).not.toBeChecked();
     expect(screen.getByLabelText(labelMixed)).toBeChecked();
     expect(
-      screen.getByLabelText(
-        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelTrustedClientAddresses}`),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(
-        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelBlacklistClientAddresses}`),
     ).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
     expect(screen.getByLabelText(labelBaseUrl)).toHaveValue(
@@ -134,9 +129,7 @@ describe('Openid configuration form', () => {
     expect(screen.getByLabelText(labelEndSessionEndpoint)).toHaveValue(
       '/logout',
     );
-    expect(
-      screen.getByLabelText(`${labelScopes} (${labelPressEnterToAccept})`),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(`${labelScopes}`)).toBeInTheDocument();
     expect(screen.getByText('openid')).toBeInTheDocument();
     expect(screen.getByLabelText(labelLoginClaimValue)).toHaveValue('sub');
     expect(screen.getByLabelText(labelClientID)).toHaveValue('client_id');
@@ -172,9 +165,7 @@ describe('Openid configuration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(
-        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelTrustedClientAddresses}`),
       'invalid domain',
     );
     userEvent.keyboard('{Enter}');
@@ -186,9 +177,7 @@ describe('Openid configuration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(
-        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelBlacklistClientAddresses}`),
       '127.0.0.1111',
     );
     userEvent.keyboard('{Enter}');

--- a/www/front_src/src/Authentication/Openid/models.ts
+++ b/www/front_src/src/Authentication/Openid/models.ts
@@ -7,7 +7,7 @@ export interface OpenidConfiguration {
   clientSecret: string | null;
   connectionScopes: Array<string>;
   endSessionEndpoint?: string | null;
-  introspectionTokenEndpoint: string | null;
+  introspectionTokenEndpoint?: string | null;
   isActive: boolean;
   isForced: boolean;
   loginClaim?: string | null;
@@ -26,7 +26,7 @@ export interface OpenidConfigurationToAPI {
   client_secret: string | null;
   connection_scopes: Array<string>;
   endsession_endpoint?: string | null;
-  introspection_token_endpoint: string | null;
+  introspection_token_endpoint?: string | null;
   is_active: boolean;
   is_forced: boolean;
   login_claim?: string | null;

--- a/www/front_src/src/Authentication/Openid/translatedLabels.tsx
+++ b/www/front_src/src/Authentication/Openid/translatedLabels.tsx
@@ -28,3 +28,7 @@ export const labelUseBasicAuthenticatonForTokenEndpointAuthentication =
 export const labelDisableVerifyPeer = 'Disable verify peer';
 export const labelOpenIDConnectOnly = 'OpenID Connect only';
 export const labelMixed = 'Mixed';
+export const labelOr = 'or';
+export const labelNeedTobeFilled = 'need to be filled';
+export const labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled =
+  'At least one of the two following fields must be filled';

--- a/www/front_src/src/Authentication/Openid/translatedLabels.tsx
+++ b/www/front_src/src/Authentication/Openid/translatedLabels.tsx
@@ -28,7 +28,5 @@ export const labelUseBasicAuthenticatonForTokenEndpointAuthentication =
 export const labelDisableVerifyPeer = 'Disable verify peer';
 export const labelOpenIDConnectOnly = 'OpenID Connect only';
 export const labelMixed = 'Mixed';
-export const labelOr = 'or';
-export const labelNeedTobeFilled = 'need to be filled';
 export const labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled =
   'At least one of the two following fields must be filled';

--- a/www/front_src/src/Authentication/Openid/useValidationSchema.ts
+++ b/www/front_src/src/Authentication/Openid/useValidationSchema.ts
@@ -31,9 +31,7 @@ const useValidationSchema = (): Yup.SchemaOf<OpenidConfiguration> => {
     clientSecret: Yup.string().nullable().required(t(labelRequired)),
     connectionScopes: Yup.array().of(Yup.string().required(t(labelRequired))),
     endSessionEndpoint: Yup.string().nullable(),
-    introspectionTokenEndpoint: Yup.string()
-      .nullable()
-      .required(t(labelRequired)),
+    introspectionTokenEndpoint: Yup.string().nullable(),
     isActive: Yup.boolean().required(t(labelRequired)),
     isForced: Yup.boolean().required(t(labelRequired)),
     loginClaim: Yup.string().nullable(),

--- a/www/front_src/src/Authentication/WebSSO/index.test.tsx
+++ b/www/front_src/src/Authentication/WebSSO/index.test.tsx
@@ -13,7 +13,6 @@ import {
   labelResetTheForm,
   labelSave,
 } from '../Local/translatedLabels';
-import { labelPressEnterToAccept } from '../translatedLabels';
 
 import {
   labelBlacklistClientAddresses,
@@ -90,14 +89,10 @@ describe('Web SSOconfiguration form', () => {
     expect(screen.getByLabelText(labelWebSSOOnly)).not.toBeChecked();
     expect(screen.getByLabelText(labelMixed)).toBeChecked();
     expect(
-      screen.getByLabelText(
-        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelTrustedClientAddresses}`),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(
-        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelBlacklistClientAddresses}`),
     ).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
     expect(screen.getByLabelText(labelLoginHeaderAttributeName)).toHaveValue(
@@ -138,9 +133,7 @@ describe('Web SSOconfiguration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(
-        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelTrustedClientAddresses}`),
       'invalid domain',
     );
     userEvent.keyboard('{Enter}');
@@ -152,9 +145,7 @@ describe('Web SSOconfiguration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(
-        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
-      ),
+      screen.getByLabelText(`${labelBlacklistClientAddresses}`),
       '127.0.0.1111',
     );
     userEvent.keyboard('{Enter}');

--- a/www/front_src/src/Authentication/WebSSO/index.test.tsx
+++ b/www/front_src/src/Authentication/WebSSO/index.test.tsx
@@ -13,6 +13,7 @@ import {
   labelResetTheForm,
   labelSave,
 } from '../Local/translatedLabels';
+import { labelPressEnterToAccept } from '../translatedLabels';
 
 import {
   labelBlacklistClientAddresses,
@@ -89,10 +90,14 @@ describe('Web SSOconfiguration form', () => {
     expect(screen.getByLabelText(labelWebSSOOnly)).not.toBeChecked();
     expect(screen.getByLabelText(labelMixed)).toBeChecked();
     expect(
-      screen.getByLabelText(labelTrustedClientAddresses),
+      screen.getByLabelText(
+        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(labelBlacklistClientAddresses),
+      screen.getByLabelText(
+        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
+      ),
     ).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
     expect(screen.getByLabelText(labelLoginHeaderAttributeName)).toHaveValue(
@@ -133,7 +138,9 @@ describe('Web SSOconfiguration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(labelTrustedClientAddresses),
+      screen.getByLabelText(
+        `${labelTrustedClientAddresses} (${labelPressEnterToAccept})`,
+      ),
       'invalid domain',
     );
     userEvent.keyboard('{Enter}');
@@ -145,7 +152,9 @@ describe('Web SSOconfiguration form', () => {
     });
 
     userEvent.type(
-      screen.getByLabelText(labelBlacklistClientAddresses),
+      screen.getByLabelText(
+        `${labelBlacklistClientAddresses} (${labelPressEnterToAccept})`,
+      ),
       '127.0.0.1111',
     );
     userEvent.keyboard('{Enter}');

--- a/www/front_src/src/Authentication/translatedLabels.ts
+++ b/www/front_src/src/Authentication/translatedLabels.ts
@@ -1,3 +1,4 @@
 export const labelActivation = 'Activation';
 export const labelIdentityProvider = 'Identity provider';
 export const labelClientAddresses = 'Client addresses';
+export const labelPressEnterToAccept = 'Press Enter to accept';

--- a/www/front_src/src/Login/index.tsx
+++ b/www/front_src/src/Login/index.tsx
@@ -83,6 +83,7 @@ const LoginPage = (): JSX.Element => {
           <Typography variant="h5">{t(labelLogin)}</Typography>
           <div>
             <Formik<LoginFormValues>
+              validateOnMount
               initialValues={initialValues}
               validationSchema={validationSchema}
               onSubmit={submitLoginForm}


### PR DESCRIPTION
## Description

This changes the fields validation "introspection token endpoint" and "user information endpoint".

Note for the frontend team : I had to validate this manually because Yup triggers about a cyclic dependency.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

You cannot send the form with the "User information endpoint" and "Introspection token endpoint" fields empty.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
