### PR TITLE
fix(security): increase default password expiration to 6 months

### DIFF
--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -4253,7 +4253,7 @@ components:
                   nullable: true
                   minimum: 604800
                   maximum: 31557600
-                  default: 7776000
+                  default: 15552000
                 excluded_users:
                   description: list of users without password expiration rule
                   type: array

--- a/tests/php/Core/Infrastructure/Security/ProviderConfiguration/Local/Api/UpdateConfiguration/UpdateConfigurationControllerTest.php
+++ b/tests/php/Core/Infrastructure/Security/ProviderConfiguration/Local/Api/UpdateConfiguration/UpdateConfigurationControllerTest.php
@@ -147,7 +147,7 @@ class UpdateConfigurationControllerTest extends TestCase
                 "attempts" => 6,
                 "blocking_duration" => 900,
                 "password_expiration" => [
-                    'expiration_delay' => 7776000,
+                    'expiration_delay' => 15552000,
                     'excluded_users' => [
                         'admin',
                     ],

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -1419,7 +1419,7 @@ INSERT INTO `provider_configuration` (type, name, custom_configuration, is_activ
 VALUES (
   'local',
   'local',
-  '{"password_security_policy": {"password_length": 12, "has_uppercase_characters": true, "has_lowercase_characters": true, "has_numbers": true, "has_special_characters": true, "attempts": 5, "blocking_duration": 900, "password_expiration_delay": 7776000, "delay_before_new_password": 3600, "can_reuse_passwords": false }}',
+  '{"password_security_policy": {"password_length": 12, "has_uppercase_characters": true, "has_lowercase_characters": true, "has_numbers": true, "has_special_characters": true, "attempts": 5, "blocking_duration": 900, "password_expiration_delay": 15552000, "delay_before_new_password": 3600, "can_reuse_passwords": false }}',
   true,
   true
 ),

--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -459,7 +459,7 @@ function updateSecurityPolicyConfiguration(CentreonDB $pearDB): void
             "has_special_characters" => true,
             "attempts" => 5,
             "blocking_duration" => 900,
-            "password_expiration_delay" => 7776000,
+            "password_expiration_delay" => 15552000,
             "delay_before_new_password" => 3600,
             "can_reuse_passwords" => false,
         ],


### PR DESCRIPTION
## Description

increase default password expiration to 6 months

**Fixes** MON-13053

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)