### PR TITLE
fix(api): return 401 instead of 500 on login failed

### DIFF
--- a/src/Centreon/Application/Controller/AuthenticationController.php
+++ b/src/Centreon/Application/Controller/AuthenticationController.php
@@ -31,7 +31,7 @@ use Centreon\Domain\Authentication\UseCase\LogoutRequest;
 use Centreon\Domain\Authentication\UseCase\AuthenticateApi;
 use Centreon\Domain\Authentication\UseCase\AuthenticateApiRequest;
 use Centreon\Domain\Authentication\UseCase\AuthenticateApiResponse;
-use Centreon\Domain\Authentication\Exception\AuthenticationException;
+use Core\Domain\Security\Authentication\AuthenticationException;
 use Security\Infrastructure\Authentication\API\Model_2110\ApiAuthenticationFactory;
 
 /**


### PR DESCRIPTION
## Description

return 401 instead of 500 on login failed

**Fixes** MON-12922

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)