### PR TITLE
fix(UI): Remove checkbox for default options sent for ack

### DIFF
--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -20,8 +20,6 @@ import {
   labelNotify,
   labelNotifyHelpCaption,
   labelAcknowledgeServices,
-  labelPersistent,
-  labelSticky,
 } from '../../../translatedLabels';
 import { Resource } from '../../../models';
 import useAclQuery from '../aclQuery';
@@ -123,34 +121,6 @@ const DialogAcknowledge = ({
             />
           </Grid>
         )}
-        <Grid item>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={values.persistent}
-                color="primary"
-                inputProps={{ 'aria-label': t(labelPersistent) }}
-                size="small"
-                onChange={handleChange('persistent')}
-              />
-            }
-            label={t(labelPersistent) as string}
-          />
-        </Grid>
-        <Grid item>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={values.isSticky}
-                color="primary"
-                inputProps={{ 'aria-label': t(labelSticky) }}
-                size="small"
-                onChange={handleChange('isSticky')}
-              />
-            }
-            label={t(labelSticky) as string}
-          />
-        </Grid>
       </Grid>
     </Dialog>
   );

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -46,7 +46,6 @@ import {
   labelCritical,
   labelUnknown,
   labelAddComment,
-  labelPersistent,
 } from '../translatedLabels';
 import useLoadResources from '../Listing/useLoadResources';
 import useListing from '../Listing/useListing';
@@ -77,6 +76,7 @@ jest.mock('react-redux', () => ({
 
 const mockUserContext = {
   acknowledgement: {
+    force_active_checks: true,
     persistent: true,
     sticky: false,
   },
@@ -285,10 +285,8 @@ describe(Actions, () => {
     fireEvent.click(getByText(labelAcknowledge));
 
     const notifyCheckbox = await findByLabelText(labelNotify);
-    const persistentCheckbox = await findByLabelText(labelPersistent);
 
     fireEvent.click(notifyCheckbox);
-    fireEvent.click(persistentCheckbox);
     fireEvent.click(getByLabelText(labelAcknowledgeServices));
 
     mockedAxios.get.mockResolvedValueOnce({ data: {} });
@@ -302,8 +300,9 @@ describe(Actions, () => {
         {
           acknowledgement: {
             comment: labelAcknowledgedByAdmin,
+            force_active_checks: true,
             is_notify_contacts: true,
-            is_persistent_comment: false,
+            is_persistent_comment: true,
             is_sticky: false,
             with_services: true,
           },


### PR DESCRIPTION
## Description

Checkbox for default options sent for ack are displaying
Adapt unit test for Acknowledgement

**Fixes** # (issue)

Remove checkbox for default options sent for ack


## Type of change

- [x] Patch fixing an issue (non-breaking change)


## Target serie

- [x] 21.10.x

<h2> How this pull request can be tested ? </h2>

Set Acknowledgement , and you mus see only checkbox for notify or notify and with services checkbox if it's on a host.

