### PR TITLE
fix(install): fix install dir slash on source fresh install 

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1769,7 +1769,7 @@ createConfFile() {
  *
  */
 
-\$conf_centreon['centreon_dir'] = "$INSTALL_DIR_CENTREON/";
+\$conf_centreon['centreon_dir'] = "$INSTALL_DIR_CENTREON";
 \$conf_centreon['centreon_etc'] = "$CENTREON_ETC/";
 \$conf_centreon['centreon_dir_www'] = "$INSTALL_DIR_CENTREON/www/";
 \$conf_centreon['centreon_dir_rrd'] = "$INSTALL_DIR_CENTREON/rrd/";

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1769,7 +1769,7 @@ createConfFile() {
  *
  */
 
-\$conf_centreon['centreon_dir'] = "$INSTALL_DIR_CENTREON";
+\$conf_centreon['centreon_dir'] = "$INSTALL_DIR_CENTREON/";
 \$conf_centreon['centreon_etc'] = "$CENTREON_ETC/";
 \$conf_centreon['centreon_dir_www'] = "$INSTALL_DIR_CENTREON/www/";
 \$conf_centreon['centreon_dir_rrd'] = "$INSTALL_DIR_CENTREON/rrd/";

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -81,7 +81,7 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('ldap_last_acl_update', '0'),
 ('ldap_contact_tmpl', '0'),
 ('broker','broker'),
-('oreon_path','@centreon_dir@'),
+('oreon_path','@centreon_dir@/'),
 ('oreon_web_path','/centreon/'),
 ('session_expire','120'),
 ('maxViewMonitoring','30'),

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -81,7 +81,7 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('ldap_last_acl_update', '0'),
 ('ldap_contact_tmpl', '0'),
 ('broker','broker'),
-('oreon_path','@centreon_dir@/'),
+('oreon_path','@centreon_dir@'),
 ('oreon_web_path','/centreon/'),
 ('session_expire','120'),
 ('maxViewMonitoring','30'),


### PR DESCRIPTION
## Description


This PR intends to fix install dir slash on source fresh install.


Fresh install are handle here: https://github.com/centreon/centreon-build/pull/889
**Fixes** # MON-13064

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
