### PR TITLE
fix(resources): default values correctly sent to ack endpoint

### DIFF
--- a/src/Centreon/Application/Controller/AcknowledgementController.php
+++ b/src/Centreon/Application/Controller/AcknowledgementController.php
@@ -788,10 +788,6 @@ class AcknowledgementController extends AbstractController
             throw new ValidationFailedException($errorList);
         }
 
-        // set default values [sticky, persistent_comment] to true
-        $acknowledgement->setSticky(true);
-        $acknowledgement->setPersistentComment(true);
-
         foreach ($resources as $resource) {
             // start acknowledgement process
             try {

--- a/www/front_src/src/Resources/Actions/api/index.ts
+++ b/www/front_src/src/Resources/Actions/api/index.ts
@@ -16,6 +16,7 @@ interface AcknowledgeParams {
   forceActiveChecks: boolean;
   notify: boolean;
   persistent: boolean;
+  sticky: boolean;
 }
 
 interface ResourcesWithAcknowledgeParams {
@@ -37,7 +38,8 @@ const acknowledgeResources =
           comment: params.comment,
           force_active_checks: params.forceActiveChecks,
           is_notify_contacts: params.notify,
-          persistent: params.persistent,
+          is_persistent_comment: params.persistent,
+          is_sticky: params.sticky,
           with_services: params.acknowledgeAttachedResources,
         },
         resources: map(pick(['type', 'id', 'parent']), resources),

--- a/www/front_src/src/Resources/Actions/api/index.ts
+++ b/www/front_src/src/Resources/Actions/api/index.ts
@@ -14,9 +14,9 @@ interface AcknowledgeParams {
   acknowledgeAttachedResources?: boolean;
   comment: string;
   forceActiveChecks: boolean;
+  isSticky: boolean;
   notify: boolean;
   persistent: boolean;
-  sticky: boolean;
 }
 
 interface ResourcesWithAcknowledgeParams {
@@ -39,7 +39,7 @@ const acknowledgeResources =
           force_active_checks: params.forceActiveChecks,
           is_notify_contacts: params.notify,
           is_persistent_comment: params.persistent,
-          is_sticky: params.sticky,
+          is_sticky: params.isSticky,
           with_services: params.acknowledgeAttachedResources,
         },
         resources: map(pick(['type', 'id', 'parent']), resources),

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -71,6 +71,8 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const onRefresh = jest.fn();
 
+jest.setTimeout(11000);
+
 jest.mock('react-redux', () => ({
   ...(jest.requireActual('react-redux') as jest.Mocked<unknown>),
   useSelector: jest.fn(),
@@ -80,7 +82,7 @@ const mockUserContext = {
   acknowledgement: {
     force_active_checks: false,
     persistent: true,
-    sticky: false,
+    sticky: true,
   },
   acl: {
     actions: {
@@ -305,7 +307,8 @@ describe(Actions, () => {
             comment: labelAcknowledgedByAdmin,
             force_active_checks: false,
             is_notify_contacts: true,
-            persistent: true,
+            is_persistent_comment: true,
+            is_sticky: true,
             with_services: true,
           },
 

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -71,8 +71,6 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const onRefresh = jest.fn();
 
-jest.setTimeout(11000);
-
 jest.mock('react-redux', () => ({
   ...(jest.requireActual('react-redux') as jest.Mocked<unknown>),
   useSelector: jest.fn(),


### PR DESCRIPTION
## Description
This PR fixes issues with Aknowledgements and default values provided to the endpoint on Resource Status.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket
## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
