### PR TITLE
fix(install): avoid usage of chown and chmod on web install

### DIFF
--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -90,9 +90,6 @@ $centreonConfFile = $centreonEtcPath . '/centreon.conf.php';
 $contents = file_get_contents('../../var/configFileTemplate');
 $contents = str_replace(array_keys($macroReplacements), array_values($macroReplacements), $contents);
 file_put_contents($centreonConfFile, $contents);
-chmod($centreonConfFile, 0660);
-chown($centreonConfFile, 'apache');
-chgrp($centreonConfFile, 'apache');
 
 /**
  * conf.pm
@@ -101,9 +98,6 @@ $centreonConfPmFile = $centreonEtcPath . '/conf.pm';
 $contents = file_get_contents('../../var/configFilePmTemplate');
 $contents = str_replace(array_keys($macroReplacements), array_values($macroReplacements), $contents);
 file_put_contents($centreonConfPmFile, $contents);
-chmod($centreonConfPmFile, 0660);
-chown($centreonConfPmFile, 'centreon');
-chgrp($centreonConfPmFile, 'centreon');
 
 /**
  * Database configuration file

--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -90,6 +90,7 @@ $centreonConfFile = $centreonEtcPath . '/centreon.conf.php';
 $contents = file_get_contents('../../var/configFileTemplate');
 $contents = str_replace(array_keys($macroReplacements), array_values($macroReplacements), $contents);
 file_put_contents($centreonConfFile, $contents);
+chmod($centreonConfFile, 0660);
 
 /**
  * conf.pm


### PR DESCRIPTION
## Description

avoid usage of chown and chmod on web install
Rights are handled by spec file

**Fixes** MON-13008

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)