### PR TITLE
fix(resources): add missing primary key to resources_tags table

### DIFF
--- a/www/install/createTablesCentstorage.sql
+++ b/www/install/createTablesCentstorage.sql
@@ -348,6 +348,7 @@ CREATE TABLE `tags` (
 CREATE TABLE `resources_tags` (
   `tag_id` bigint(20) unsigned NOT NULL,
   `resource_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`tag_id`,`resource_id`),
   KEY `resources_tags_resources_resource_id_fk` (`resource_id`),
   KEY `resources_tags_tag_id_fk` (`tag_id`),
   CONSTRAINT `resources_tags_resources_resource_id_fk` FOREIGN KEY (`resource_id`) REFERENCES `resources` (`resource_id`) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/www/install/sql/centstorage/Update-CSTG-22.04.0-beta.1.sql
+++ b/www/install/sql/centstorage/Update-CSTG-22.04.0-beta.1.sql
@@ -59,6 +59,7 @@ CREATE TABLE `tags` (
 CREATE TABLE `resources_tags` (
   `tag_id` bigint(20) unsigned NOT NULL,
   `resource_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`tag_id`,`resource_id`),
   KEY `resources_tags_resources_resource_id_fk` (`resource_id`),
   KEY `resources_tags_tag_id_fk` (`tag_id`),
   CONSTRAINT `resources_tags_resources_resource_id_fk` FOREIGN KEY (`resource_id`) REFERENCES `resources` (`resource_id`) ON DELETE CASCADE ON UPDATE CASCADE,


### PR DESCRIPTION
## Description

Add missing PRIMARY KEY TO resources_tags table

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
