### PR TITLE
fix(upgrade): add contact_theme column on upgrade

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -72,6 +72,15 @@ try {
         );
     }
 
+    // Add contact_theme column to contact table
+    if ($pearDB->isColumnExist('contact', 'contact_theme') !== 1) {
+        $errorMessage = "Unable to add column 'contact_theme' to table 'contact'";
+        $pearDB->query(
+            "ALTER TABLE `contact` ADD COLUMN "
+            . "`contact_theme` enum('light','dark') DEFAULT 'light' AFTER `contact_js_effects`"
+        );
+    }
+
     /**
      * Transactional queries
      */


### PR DESCRIPTION
## Description

The contact_theme column of the contact table is not created during the update

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
