### PR TITLE
Sanitizing and binding queries in centreon user class

### DIFF
--- a/www/class/centreonUser.class.php
+++ b/www/class/centreonUser.class.php
@@ -165,17 +165,21 @@ class CentreonUser
     public function checkUserStatus($sid, $pearDB)
     {
         $query1 = "SELECT contact_admin, contact_id FROM session, contact " .
-            "WHERE session.session_id = '" . $sid .
-            "' AND contact.contact_id = session.user_id AND contact.contact_register = '1'";
-        $dbResult = $pearDB->query($query1);
-        $admin = $dbResult->fetch();
-        $dbResult->closeCursor();
+            "WHERE session.session_id = :session_id" .
+            " AND contact.contact_id = session.user_id AND contact.contact_register = '1'";
+        $statement = $pearDB->prepare($query1);
+        $statement->bindValue(':session_id', $sid);
+        $statement->execute();
+        $admin = $statement->fetch(\PDO::FETCH_ASSOC);
+        $statement->closeCursor();
 
         $query2 = "SELECT count(*) FROM `acl_group_contacts_relations` " .
-            "WHERE contact_contact_id = '" . $admin["contact_id"] . "'";
-        $dbResult = $pearDB->query($query2);
-        $admin2 = $dbResult->fetch();
-        $dbResult->closeCursor();
+            "WHERE contact_contact_id = :contact_id";
+        $statement = $pearDB->prepare($query2);
+        $statement->bindValue(':contact_id', (int)$admin["contact_id"], \PDO::PARAM_INT);
+        $statement->execute();
+        $admin2 = $statement->fetch(\PDO::FETCH_ASSOC);
+        $statement->closeCursor();
 
         if ($admin["contact_admin"]) {
             unset($admin);


### PR DESCRIPTION
## Description

Sanitizing and binding queries in CentreonUser.class.php to avoid sql injections and most importantly for security.

**Fixes** # MON-12839

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
