### PR TITLE
Sanitizing and binding "meta service" related queries

### DIFF
--- a/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -170,23 +170,23 @@ function multipleMetaServiceInDB($metas = array(), $nbrDup = array())
                     /* Duplicate contacts */
                     $query = "SELECT DISTINCT contact_id FROM meta_contact WHERE meta_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
-                    while ($Contact = $dbResult->fetch()) {
+                    while ($contact = $dbResult->fetch()) {
                         $query = "INSERT INTO meta_contact VALUES (:max_mc_id, :contact_id)";
                         $statement = $pearDB->prepare($query);
                         $statement->bindValue(':max_mc_id', (int) $maxId["MAX(meta_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':contact_id', (int) $Contact["contact_id"], \PDO::PARAM_INT);
+                        $statement->bindValue(':contact_id', (int) $contact["contact_id"], \PDO::PARAM_INT);
                         $statement->execute();
                     }
                     /* Duplicate contactgroups */
                     $query = "SELECT DISTINCT cg_cg_id FROM meta_contactgroup_relation WHERE meta_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
 
-                    while ($Cg = $dbResult->fetch()) {
+                    while ($cg = $dbResult->fetch()) {
                         $query = "INSERT INTO meta_contactgroup_relation " .
                             "VALUES (:max_mg_id, :cg_id)";
                         $statement = $pearDB->prepare($query);
                         $statement->bindValue(':max_mg_id', (int) $maxId["MAX(meta_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':cg_id', (int) $Cg["cg_cg_id"], \PDO::PARAM_INT);
+                        $statement->bindValue(':cg_id', (int) $cg["cg_cg_id"], \PDO::PARAM_INT);
                         $statement->execute();
                     }
                     $dbResult = $pearDB->query("SELECT * FROM meta_service_relation WHERE meta_id = '" . $key . "'");

--- a/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -57,8 +57,7 @@ function testExistence($name = null)
     #Modif case
     if ($statement->rowCount() >= 1 && $meta["meta_id"] == $id) {
         return true;
-    } #Duplicate entry
-    elseif ($statement->rowCount() >= 1 && $meta["meta_id"] != $id) {
+    } elseif ($statement->rowCount() >= 1 && $meta["meta_id"] != $id) {
         return false;
     } else {
         return true;

--- a/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -463,7 +463,7 @@ function updateMetaServiceContact($meta_id)
     /* Purge old relation */
     $queryPurge = "DELETE FROM meta_contact WHERE meta_id = :meta_id";
     $statement = $pearDB->prepare($queryPurge);
-    $statement->bindValue('meta_id', (int) $meta_id, \PDO::PARAM_INT);
+    $statement->bindValue(':meta_id', (int) $meta_id, \PDO::PARAM_INT);
     $statement->execute();
 
     /* Add relation between metaservice and contact */

--- a/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -51,7 +51,7 @@ function testExistence($name = null)
     }
     $query = "SELECT meta_id FROM meta_service WHERE meta_name = :meta_name";
     $statement = $pearDB->prepare($query);
-    $statement->bindValue(':meta_name', htmlentities($name, ENT_QUOTES, "UTF-8"));
+    $statement->bindValue(':meta_name', htmlentities($name, ENT_QUOTES, "UTF-8"), \PDO::PARAM_STR);
     $statement->execute();
     $meta = $statement->fetch(\PDO::FETCH_ASSOC);
     #Modif case
@@ -173,8 +173,8 @@ function multipleMetaServiceInDB($metas = array(), $nbrDup = array())
                     while ($Contact = $dbResult->fetch()) {
                         $query = "INSERT INTO meta_contact VALUES (:max_mc_id, :contact_id)";
                         $statement = $pearDB->prepare($query);
-                        $statement->bindValue(':max_mc_id', (int)$maxId["MAX(meta_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':contact_id', (int)$Contact["contact_id"], \PDO::PARAM_INT);
+                        $statement->bindValue(':max_mc_id', (int) $maxId["MAX(meta_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':contact_id', (int) $Contact["contact_id"], \PDO::PARAM_INT);
                         $statement->execute();
                     }
                     /* Duplicate contactgroups */
@@ -185,8 +185,8 @@ function multipleMetaServiceInDB($metas = array(), $nbrDup = array())
                         $query = "INSERT INTO meta_contactgroup_relation " .
                             "VALUES (:max_mg_id, :cg_id)";
                         $statement = $pearDB->prepare($query);
-                        $statement->bindValue(':max_mg_id', (int)$maxId["MAX(meta_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':cg_id', (int)$Cg["cg_cg_id"], \PDO::PARAM_INT);
+                        $statement->bindValue(':max_mg_id', (int) $maxId["MAX(meta_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':cg_id', (int) $Cg["cg_cg_id"], \PDO::PARAM_INT);
                         $statement->execute();
                     }
                     $dbResult = $pearDB->query("SELECT * FROM meta_service_relation WHERE meta_id = '" . $key . "'");
@@ -463,7 +463,7 @@ function updateMetaServiceContact($meta_id)
     /* Purge old relation */
     $queryPurge = "DELETE FROM meta_contact WHERE meta_id = :meta_id";
     $statement = $pearDB->prepare($queryPurge);
-    $statement->bindValue('meta_id', (int)$meta_id, \PDO::PARAM_INT);
+    $statement->bindValue('meta_id', (int) $meta_id, \PDO::PARAM_INT);
     $statement->execute();
 
     /* Add relation between metaservice and contact */


### PR DESCRIPTION
## Description

Sanitizing, binding and clearing legacy queries in DB-Func.php file mainly to avoid sql injection attacks.

![image](https://user-images.githubusercontent.com/97593234/165921975-99ab5b69-fbd8-4620-be8e-203069dc0368.png)

**Fixes** # MON-12870

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
