### PR TITLE
fix(UI): Switch basic authentication values

### DIFF
--- a/www/front_src/src/Authentication/Openid/Form/inputs.ts
+++ b/www/front_src/src/Authentication/Openid/Form/inputs.ts
@@ -138,12 +138,12 @@ export const inputs: Array<InputProps> = [
       setFieldValue(
         'authenticationType',
         value
-          ? AuthenticationType.ClientSecretPost
-          : AuthenticationType.ClientSecretBasic,
+          ? AuthenticationType.ClientSecretBasic
+          : AuthenticationType.ClientSecretPost,
       );
     },
     fieldName: 'authenticationType',
-    getChecked: (value) => equals(AuthenticationType.ClientSecretPost, value),
+    getChecked: (value) => equals(AuthenticationType.ClientSecretBasic, value),
     label: labelUseBasicAuthenticatonForTokenEndpointAuthentication,
     type: InputType.Switch,
   },

--- a/www/front_src/src/Authentication/Openid/index.test.tsx
+++ b/www/front_src/src/Authentication/Openid/index.test.tsx
@@ -140,7 +140,7 @@ describe('Openid configuration form', () => {
       screen.getByLabelText(
         labelUseBasicAuthenticatonForTokenEndpointAuthentication,
       ),
-    ).toBeChecked();
+    ).not.toBeChecked();
     expect(screen.getByLabelText(labelDisableVerifyPeer)).not.toBeChecked();
   });
 


### PR DESCRIPTION
## Description

This switch the basic authentication input values

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the Open ID Connect configuration form
- Check the "Use basic authentication for token endpoint authentication" switch
- Save the form
- -> "client_secret_basic" is dispatched to the API in the payload

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
