### PR TITLE
fix(api): fix duplicate columns name for downtime

### DIFF
--- a/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/www/class/centreon-clapi/centreonDowntime.class.php
@@ -146,33 +146,49 @@ class CentreonDowntime extends CentreonObject
             echo $paramString . "\n";
             $filterList = '';
         } else {
+            if (isset($filter[1])) {
+                switch (strtolower($filter[1])) {
+                    case 'host':
+                        $paramString .= ";hosts\n";
+                        break;
+                    case 'hg':
+                        $paramString .= ";host groups\n";
+                        break;
+                    case 'service':
+                        $paramString .= ";services\n";
+                        break;
+                    case 'sg':
+                        $paramString .= ";service groups\n";
+                        break;
+                    default:
+                        throw new CentreonClapiException(self::UNKNOWNPARAMETER);
+                }
+            } else {
+                $paramString .= ";hosts;host groups;services;service groups\n";
+            }
             foreach ($elements as $element) {
                 if (isset($filter[1])) {
                     switch (strtolower($filter[1])) {
                         case 'host':
-                            echo $paramString . ";hosts\n";
                             $filterList = ';' . $this->listHosts($element["dt_id"]);
                             break;
                         case 'hg':
-                            echo $paramString . ";host groups\n";
                             $filterList = ';' . $this->listHostGroups($element["dt_id"]);
                             break;
                         case 'service':
-                            echo $paramString . ";services\n";
                             $filterList = ';' . $this->listServices($element["dt_id"]);
                             break;
                         case 'sg':
-                            echo $paramString . ";service groups\n";
                             $filterList = ';' . $this->listServiceGroups($element["dt_id"]);
                             break;
                         default:
                             throw new CentreonClapiException(self::UNKNOWNPARAMETER);
                     }
                 } else {
-                    echo $paramString . ";hosts;host groups;services;service groups\n";
                     $filterList = ';' . $this->listResources($element["dt_id"]);
                 }
             }
+        echo $paramString;
         }
 
         foreach ($elements as $tab) {
@@ -548,7 +564,7 @@ class CentreonDowntime extends CentreonObject
         }
 
         return implode("|", $hosts) . $this->delim . implode("|", $hostgroups) . $this->delim .
-            implode("|", $services) . $this->delim . implode("|", $servicegroups) . "\n";
+            implode("|", $services) . $this->delim . implode("|", $servicegroups);
     }
 
     /**

--- a/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/www/class/centreon-clapi/centreonDowntime.class.php
@@ -145,6 +145,9 @@ class CentreonDowntime extends CentreonObject
         if (count($filter) === 0) {
             echo $paramString . "\n";
             $filterList = '';
+            foreach ($elements as $element) {
+                echo implode($this->delim, $element) . "\n";
+            }
         } else {
             if (isset($filter[1])) {
                 switch (strtolower($filter[1])) {
@@ -166,33 +169,32 @@ class CentreonDowntime extends CentreonObject
             } else {
                 $paramString .= ";hosts;host groups;services;service groups\n";
             }
+            echo $paramString;
             foreach ($elements as $element) {
                 if (isset($filter[1])) {
                     switch (strtolower($filter[1])) {
                         case 'host':
-                            $filterList = ';' . $this->listHosts($element["dt_id"]);
+                            $filterList = $this->listHosts($element["dt_id"]);
                             break;
                         case 'hg':
-                            $filterList = ';' . $this->listHostGroups($element["dt_id"]);
+                            $filterList = $this->listHostGroups($element["dt_id"]);
                             break;
                         case 'service':
-                            $filterList = ';' . $this->listServices($element["dt_id"]);
+                            $filterList = $this->listServices($element["dt_id"]);
                             break;
                         case 'sg':
-                            $filterList = ';' . $this->listServiceGroups($element["dt_id"]);
+                            $filterList = $this->listServiceGroups($element["dt_id"]);
                             break;
                         default:
                             throw new CentreonClapiException(self::UNKNOWNPARAMETER);
                     }
                 } else {
-                    $filterList = ';' . $this->listResources($element["dt_id"]);
+                    $filterList = $this->listResources($element["dt_id"]);
+                }
+                if (!empty($filterList)) {
+                    echo implode($this->delim, $element) . ';' . $filterList . "\n";
                 }
             }
-        echo $paramString;
-        }
-
-        foreach ($elements as $tab) {
-            echo implode($this->delim, $tab) . $filterList . "\n";
         }
     }
 


### PR DESCRIPTION
## Description

fix duplicate columns name when we want to list the downtimes

**Fixes** MON-13059

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)