### PR TITLE
fix(upgrade): drop contact_passwd column at the end of upgrade

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -80,11 +80,6 @@ try {
         );
     }
 
-    if ($pearDB->isColumnExist('contact', 'contact_passwd') === 1) {
-        $errorMessage = "Unable to drop column 'contact_passwd' from 'contact' table";
-        $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
-    }
-
     $errorMessage = "Unable to find constraint unique_index from security_token";
     $constraintExistStatement = $pearDB->query(
         'SELECT CONSTRAINT_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE
@@ -178,6 +173,10 @@ try {
     excludeUsersFromPasswordPolicy($pearDB);
 
     $pearDB->commit();
+    if ($pearDB->isColumnExist('contact', 'contact_passwd') === 1) {
+        $errorMessage = "Unable to drop column 'contact_passwd' from 'contact' table";
+        $pearDB->query("ALTER TABLE `contact` DROP COLUMN `contact_passwd`");
+    }
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {
         $pearDB->rollBack();


### PR DESCRIPTION
## Description

This PR intends to fix an issue where contact.contact_passwd was deleted too early in upgrade. So all password was lost during upgrade.

**Fixes** # MON-13188

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
