### PR TITLE
fix(partition): Do not generate PHP error with MySQL 8

### DIFF
--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -621,8 +621,6 @@ class PartEngine
                 return true;
             }
         } elseif ($config["plugin_status"] === "ACTIVE") {
-            unset($config);
-
             return true;
         return false;
     }

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -622,6 +622,7 @@ class PartEngine
             }
         } elseif ($config["plugin_status"] === "ACTIVE") {
             return true;
+        }
         return false;
     }
 

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2022 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -592,7 +593,6 @@ class PartEngine
         $dbResult = $db->query("SELECT plugin_status FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name = 'partition'");
         $config = $dbResult->fetch();
         $dbResult->closeCursor();
-        
         if ($config === false || empty($config["plugin_status"])) {
             // as the plugin "partition" was deprecated in mysql 5.7
             // and as it was removed from mysql 8 and replaced by the native partitioning one,

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -593,7 +593,7 @@ class PartEngine
         $config = $dbResult->fetch();
         $dbResult->closeCursor();
         
-        if (empty($config) || empty($config["plugin_status"])) {
+        if ($config === false || empty($config["plugin_status"])) {
             // as the plugin "partition" was deprecated in mysql 5.7
             // and as it was removed from mysql 8 and replaced by the native partitioning one,
             // we need to check the current version and db before failing this step

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2022 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -581,7 +581,7 @@ class PartEngine
 
     /**
      *
-     * Check if MySQL version is compatible with partitionning.
+     * Check if MySQL/MariaDB version is compatible with partitionning.
      *
      * @param $db The Db singleton
      *
@@ -592,11 +592,8 @@ class PartEngine
         $dbResult = $db->query("SELECT plugin_status FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name = 'partition'");
         $config = $dbResult->fetch();
         $dbResult->closeCursor();
-        if ($config["plugin_status"] == "ACTIVE") {
-            unset($config);
-
-            return true;
-        } elseif (empty($config["plugin_status"])) {
+        
+        if (empty($config) || empty($config["plugin_status"])) {
             // as the plugin "partition" was deprecated in mysql 5.7
             // and as it was removed from mysql 8 and replaced by the native partitioning one,
             // we need to check the current version and db before failing this step
@@ -623,8 +620,13 @@ class PartEngine
 
                 return true;
             }
+        } elseif ($config["plugin_status"] == "ACTIVE") {
+            unset($config);
+
+            return true;
+        } else {
+            return false;
         }
-        return false;
     }
 
     /**

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -620,7 +620,7 @@ class PartEngine
 
                 return true;
             }
-        } elseif ($config["plugin_status"] == "ACTIVE") {
+        } elseif ($config["plugin_status"] === "ACTIVE") {
             unset($config);
 
             return true;

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -624,9 +624,7 @@ class PartEngine
             unset($config);
 
             return true;
-        } else {
-            return false;
-        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Description

Don't generate PHP error if request result is empty

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
