### PR TITLE
fix(UI): "Reset" and "Save" buttons are not visible when switching theme

### DIFF
--- a/www/front_src/src/Authentication/FormButtons.tsx
+++ b/www/front_src/src/Authentication/FormButtons.tsx
@@ -148,6 +148,7 @@ const FormButtons = (): JSX.Element => {
       askingBeforeReset,
       tab,
       unsavedDialogOpened,
+      classes,
     ],
   });
 };

--- a/www/front_src/src/Authentication/Local/Form/PasswordCasePolicy/index.tsx
+++ b/www/front_src/src/Authentication/Local/Form/PasswordCasePolicy/index.tsx
@@ -67,7 +67,7 @@ const PasswordCasePolicy = (): JSX.Element => {
         </div>
       </div>
     ),
-    memoProps: [passwordLengthError, passwordLengthValue],
+    memoProps: [passwordLengthError, passwordLengthValue, classes],
   });
 };
 

--- a/www/front_src/src/Authentication/Local/Form/PasswordExpirationPolicy/PasswordExpiration/index.tsx
+++ b/www/front_src/src/Authentication/Local/Form/PasswordExpirationPolicy/PasswordExpiration/index.tsx
@@ -100,7 +100,7 @@ const PasswordExpiration = (): JSX.Element => {
         </div>
       </div>
     ),
-    memoProps: [passwordExpirationValue, passwordExpirationError],
+    memoProps: [passwordExpirationValue, passwordExpirationError, classes],
   });
 };
 

--- a/www/front_src/src/Authentication/Local/TimeInputs/TimeInput.tsx
+++ b/www/front_src/src/Authentication/Local/TimeInputs/TimeInput.tsx
@@ -170,7 +170,15 @@ const TimeInput = ({
         <Typography>{t(label)}</Typography>
       </div>
     ),
-    memoProps: [timeValue, unit, labels, name, required, getAbsoluteValue],
+    memoProps: [
+      timeValue,
+      unit,
+      labels,
+      name,
+      required,
+      getAbsoluteValue,
+      classes,
+    ],
   });
 };
 

--- a/www/front_src/src/Authentication/index.tsx
+++ b/www/front_src/src/Authentication/index.tsx
@@ -3,10 +3,13 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue } from 'jotai';
 import { useUpdateAtom } from 'jotai/utils';
+import { Responsive } from '@visx/visx';
 
 import { Box, Container, Paper, Tab } from '@mui/material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { makeStyles } from '@mui/styles';
+
+import { userAtom } from '@centreon/ui-context';
 
 import { Provider } from './models';
 import LocalAuthentication from './Local';
@@ -84,7 +87,7 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
   },
   panel: {
-    height: '88%',
+    height: '80%',
     padding: 0,
   },
   paper: {
@@ -96,11 +99,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const marginBottomHeight = 88;
+
 const Authentication = (): JSX.Element => {
   const classes = useStyles();
   const { t } = useTranslation();
 
   const appliedTab = useAtomValue(appliedTabAtom);
+  const { themeMode } = useAtomValue(userAtom);
   const setTab = useUpdateAtom(tabAtom);
 
   const changeTab = (_, newTab: Provider): void => {
@@ -116,16 +122,26 @@ const Authentication = (): JSX.Element => {
   );
 
   const tabPanels = useMemo(
-    () =>
-      panels.map(({ Component, value, image }) => (
-        <TabPanel className={classes.panel} key={value} value={value}>
-          <div className={classes.formContainer}>
-            <Component />
-            <img alt="padlock" className={classes.image} src={image} />
-          </div>
-        </TabPanel>
-      )),
-    [],
+    () => (
+      <Responsive.ParentSize>
+        {({ height }): Array<JSX.Element> =>
+          panels.map(({ Component, value, image }) => (
+            <TabPanel
+              className={classes.panel}
+              key={value}
+              style={{ height: height - marginBottomHeight }}
+              value={value}
+            >
+              <div className={classes.formContainer}>
+                <Component />
+                <img alt="padlock" className={classes.image} src={image} />
+              </div>
+            </TabPanel>
+          ))
+        }
+      </Responsive.ParentSize>
+    ),
+    [themeMode],
   );
 
   return (


### PR DESCRIPTION
## Description

This makes the Tab Panel fully responsive and fixes broken layout when switching between themes

https://user-images.githubusercontent.com/12515407/166689641-86e3ca61-164d-488d-b704-3ac9145368e6.mov


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the Administration > Authentication page
- For instance, click on the tab “OpenID Connect configuration”
- → “Save” and “Reset” buttons are displayed correctly
- Click on the toggle button at the top of the page to switch the theme mode
- → The form layout has changed and “Reset” and “Save” buttons are not displayed
- The form layout has not changed and “Reset” and “Save” buttons are displayed

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
