### PR TITLE
fix(auth): avoid php warning when authentication failed

### DIFF
--- a/src/Security/Domain/Authentication/Model/LocalProvider.php
+++ b/src/Security/Domain/Authentication/Model/LocalProvider.php
@@ -105,6 +105,10 @@ class LocalProvider implements LocalProviderInterface
             ""
         );
 
+        if ($auth->userInfos === null) {
+            throw AuthenticationException::notAuthenticated();
+        }
+
         $this->debug(
             '[LOCAL PROVIDER] local provider trying to authenticate using legacy Authentication',
             [
@@ -150,10 +154,8 @@ class LocalProvider implements LocalProviderInterface
             throw AuthenticationException::notAuthenticated();
         }
 
-        if ($auth->userInfos !== null) {
-            $this->contactId = (int) $auth->userInfos['contact_id'];
-            $this->setLegacySession(new \Centreon($auth->userInfos));
-        }
+        $this->contactId = (int) $auth->userInfos['contact_id'];
+        $this->setLegacySession(new \Centreon($auth->userInfos));
         $this->info('[LOCAL PROVIDER] authentication succeed');
     }
 


### PR DESCRIPTION
## Description

avoid php warning when authentication failed

**Fixes** MON-13241

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)