### PR TITLE
fix(UI): User language is not applied once logged

### DIFF
--- a/www/front_src/src/App/endpoint.ts
+++ b/www/front_src/src/App/endpoint.ts
@@ -1,8 +1,16 @@
-const legacyEndpoint = './api/external.php';
-const translationEndpoint = `${legacyEndpoint}?object=centreon_i18n&action=translation`;
+const externalLegacyEndpoint = './api/external.php';
+const internalLegacyEndpoint = './api/internal.php';
+const externalTranslationEndpoint = `${externalLegacyEndpoint}?object=centreon_i18n&action=translation`;
+const internalTranslationEndpoint = `${internalLegacyEndpoint}?object=centreon_i18n&action=translation`;
 const baseEndpoint = './api/latest';
 const userEndpoint = `${baseEndpoint}/configuration/users/current/parameters`;
 const parametersEndpoint = `${baseEndpoint}/administration/parameters`;
 const aclEndpoint = `${baseEndpoint}/users/acl/actions`;
 
-export { parametersEndpoint, translationEndpoint, aclEndpoint, userEndpoint };
+export {
+  parametersEndpoint,
+  externalTranslationEndpoint,
+  internalTranslationEndpoint,
+  aclEndpoint,
+  userEndpoint,
+};

--- a/www/front_src/src/Login/index.test.tsx
+++ b/www/front_src/src/Login/index.test.tsx
@@ -92,6 +92,12 @@ const retrievedProvidersConfiguration = [
   },
 ];
 
+const retrievedTranslations = {
+  en: {
+    hello: 'Hello',
+  },
+};
+
 const TestComponent = (): JSX.Element => (
   <BrowserRouter>
     <SnackbarProvider>
@@ -147,6 +153,9 @@ describe('Login Page', () => {
   beforeEach(() => {
     mockDate.set(mockNow);
     mockedAxios.get
+      .mockResolvedValueOnce({
+        data: retrievedTranslations,
+      })
       .mockResolvedValueOnce({
         data: retrievedWeb,
       })

--- a/www/front_src/src/Login/useLogin.ts
+++ b/www/front_src/src/Login/useLogin.ts
@@ -85,7 +85,8 @@ const useLogin = (): UseLoginState => {
     request: getData,
   });
 
-  const { getInternalTranslation } = useInitializeTranslation();
+  const { getInternalTranslation, getExternalTranslation } =
+    useInitializeTranslation();
 
   const { showSuccessMessage, showWarningMessage, showErrorMessage } =
     useSnackbar();
@@ -146,7 +147,9 @@ const useLogin = (): UseLoginState => {
   const getBrowserLocale = (): string => navigator.language.slice(0, 2);
 
   useEffect(() => {
-    i18n.changeLanguage?.(getBrowserLocale());
+    getExternalTranslation().then(() =>
+      i18n.changeLanguage?.(getBrowserLocale()),
+    );
 
     sendPlatformVersions({
       endpoint: platformVersionsEndpoint,

--- a/www/front_src/src/Login/useLogin.ts
+++ b/www/front_src/src/Login/useLogin.ts
@@ -90,7 +90,7 @@ const useLogin = (): UseLoginState => {
   const { showSuccessMessage, showWarningMessage, showErrorMessage } =
     useSnackbar();
   const navigate = useNavigate();
-  const loadUser = useUser(i18n.changeLanguage);
+  const loadUser = useUser();
 
   const [platformInstallationStatus] = useAtom(platformInstallationStatusAtom);
   const setPasswordResetInformations = useUpdateAtom(

--- a/www/front_src/src/Login/useLogin.ts
+++ b/www/front_src/src/Login/useLogin.ts
@@ -24,6 +24,7 @@ import { platformInstallationStatusAtom } from '../platformInstallationStatusAto
 import useUser from '../Main/useUser';
 import { passwordResetInformationsAtom } from '../ResetPassword/passwordResetInformationsAtom';
 import routeMap from '../reactRoutes/routeMap';
+import useInitializeTranslation from '../Main/useInitializeTranslation';
 
 import postLogin from './api';
 import {
@@ -60,6 +61,7 @@ interface UseLoginState {
 
 const useLogin = (): UseLoginState => {
   const { t, i18n } = useTranslation();
+
   const [platformVersions, setPlatformVersions] =
     useState<PlatformVersions | null>(null);
   const [providersConfiguration, setProvidersConfiguration] =
@@ -82,6 +84,8 @@ const useLogin = (): UseLoginState => {
     decoder: providersConfigurationDecoder,
     request: getData,
   });
+
+  const { getInternalTranslation } = useInitializeTranslation();
 
   const { showSuccessMessage, showWarningMessage, showErrorMessage } =
     useSnackbar();
@@ -130,7 +134,9 @@ const useLogin = (): UseLoginState => {
     })
       .then(({ redirectUri }) => {
         showSuccessMessage(t(labelLoginSucceeded));
-        loadUser()?.then(() => navigate(redirectUri));
+        getInternalTranslation().finally(() =>
+          loadUser()?.then(() => navigate(redirectUri)),
+        );
       })
       .catch((error) =>
         checkPasswordExpiration({ alias: values.alias, error, setSubmitting }),

--- a/www/front_src/src/Main/index.test.tsx
+++ b/www/front_src/src/Main/index.test.tsx
@@ -8,7 +8,7 @@ import { labelConnect } from '../Login/translatedLabels';
 import {
   aclEndpoint,
   parametersEndpoint,
-  translationEndpoint,
+  externalTranslationEndpoint,
 } from '../App/endpoint';
 import { retrievedNavigation } from '../Navigation/mocks';
 import { retrievedExternalComponents } from '../externalComponents/mocks';
@@ -125,6 +125,9 @@ const mockDefaultGetRequests = (): void => {
       data: retrievedUser,
     })
     .mockResolvedValueOnce({
+      data: retrievedTranslations,
+    })
+    .mockResolvedValueOnce({
       data: retrievedNavigation,
     })
     .mockResolvedValueOnce({
@@ -160,6 +163,9 @@ const mockRedirectFromLoginPageGetRequests = (): void => {
     })
     .mockResolvedValueOnce({
       data: retrievedUser,
+    })
+    .mockResolvedValueOnce({
+      data: retrievedTranslations,
     })
     .mockResolvedValueOnce({
       data: retrievedNavigation,
@@ -247,6 +253,9 @@ const mockUpgradeAndUserConnectedGetRequests = (): void => {
       data: retrievedUser,
     })
     .mockResolvedValueOnce({
+      data: retrievedTranslations,
+    })
+    .mockResolvedValueOnce({
       data: retrievedNavigation,
     })
     .mockResolvedValueOnce({
@@ -286,7 +295,7 @@ describe('Main', () => {
 
     await waitFor(() => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
-        translationEndpoint,
+        externalTranslationEndpoint,
         cancelTokenRequestParam,
       );
     });
@@ -435,7 +444,7 @@ describe('Main', () => {
     );
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      translationEndpoint,
+      externalTranslationEndpoint,
       cancelTokenRequestParam,
     );
   });

--- a/www/front_src/src/Main/index.test.tsx
+++ b/www/front_src/src/Main/index.test.tsx
@@ -9,6 +9,7 @@ import {
   aclEndpoint,
   parametersEndpoint,
   externalTranslationEndpoint,
+  internalTranslationEndpoint,
 } from '../App/endpoint';
 import { retrievedNavigation } from '../Navigation/mocks';
 import { retrievedExternalComponents } from '../externalComponents/mocks';
@@ -113,9 +114,6 @@ const renderMain = (): RenderResult =>
 const mockDefaultGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedTranslations,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: true,
@@ -147,13 +145,13 @@ const mockDefaultGetRequests = (): void => {
 const mockRedirectFromLoginPageGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedTranslations,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: true,
       },
+    })
+    .mockResolvedValueOnce({
+      data: retrievedTranslations,
     })
     .mockResolvedValueOnce({
       data: retrievedWeb,
@@ -187,9 +185,6 @@ const mockRedirectFromLoginPageGetRequests = (): void => {
 const mockNotConnectedGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedTranslations,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: true,
@@ -197,6 +192,9 @@ const mockNotConnectedGetRequests = (): void => {
     })
     .mockRejectedValueOnce({
       response: { status: 403 },
+    })
+    .mockResolvedValueOnce({
+      data: retrievedTranslations,
     })
     .mockResolvedValueOnce({
       data: retrievedWeb,
@@ -208,9 +206,6 @@ const mockNotConnectedGetRequests = (): void => {
 
 const mockInstallGetRequests = (): void => {
   mockedAxios.get
-    .mockRejectedValueOnce({
-      data: retrievedTranslations,
-    })
     .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
@@ -225,9 +220,6 @@ const mockInstallGetRequests = (): void => {
 const mockUpgradeAndUserDisconnectedGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedTranslations,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: true,
         is_installed: true,
@@ -240,9 +232,6 @@ const mockUpgradeAndUserDisconnectedGetRequests = (): void => {
 
 const mockUpgradeAndUserConnectedGetRequests = (): void => {
   mockedAxios.get
-    .mockResolvedValueOnce({
-      data: retrievedTranslations,
-    })
     .mockResolvedValueOnce({
       data: {
         has_upgrade_available: true,
@@ -329,10 +318,12 @@ describe('Main', () => {
       );
     });
 
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      userEndpoint,
-      cancelTokenRequestParam,
-    );
+    await waitFor(() => {
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        userEndpoint,
+        cancelTokenRequestParam,
+      );
+    });
 
     await waitFor(() => {
       expect(decodeURI(window.location.href)).toBe(
@@ -444,7 +435,7 @@ describe('Main', () => {
     );
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      externalTranslationEndpoint,
+      internalTranslationEndpoint,
       cancelTokenRequestParam,
     );
   });

--- a/www/front_src/src/Main/useInitializeTranslation.ts
+++ b/www/front_src/src/Main/useInitializeTranslation.ts
@@ -1,3 +1,5 @@
+import { useLayoutEffect } from 'react';
+
 import i18next, { i18n, Resource, ResourceLanguage } from 'i18next';
 import { mergeAll, pipe, reduce, toPairs } from 'ramda';
 import { initReactI18next } from 'react-i18next';
@@ -63,6 +65,10 @@ const useInitializeTranslation = (): UseInitializeTranslationState => {
 
   const getInternalTranslation = (): Promise<void> =>
     getTranslation(internalTranslationEndpoint);
+
+  useLayoutEffect(() => {
+    initializeI18n();
+  }, []);
 
   return {
     getBrowserLocale,

--- a/www/front_src/src/Main/useInitializeTranslation.ts
+++ b/www/front_src/src/Main/useInitializeTranslation.ts
@@ -1,0 +1,76 @@
+import i18next, { i18n, Resource, ResourceLanguage } from 'i18next';
+import { mergeAll, pipe, reduce, toPairs } from 'ramda';
+import { initReactI18next } from 'react-i18next';
+import { useAtomValue } from 'jotai';
+
+import { getData, useRequest } from '@centreon/ui';
+import { userAtom } from '@centreon/ui-context';
+
+import {
+  externalTranslationEndpoint,
+  internalTranslationEndpoint,
+} from '../App/endpoint';
+
+interface UseInitializeTranslationState {
+  getBrowserLocale: () => string;
+  getExternalTranslation: () => Promise<void>;
+  getInternalTranslation: () => Promise<void>;
+  i18next: i18n;
+  initializeI18n: (retrievedTranslations?: ResourceLanguage) => void;
+}
+
+const useInitializeTranslation = (): UseInitializeTranslationState => {
+  const { sendRequest: getTranslations } = useRequest<ResourceLanguage>({
+    httpCodesBypassErrorSnackbar: [500],
+    request: getData,
+  });
+
+  const { locale } = useAtomValue(userAtom);
+
+  const getBrowserLocale = (): string => navigator.language.slice(0, 2);
+
+  const initializeI18n = (retrievedTranslations?: ResourceLanguage): void => {
+    i18next.use(initReactI18next).init({
+      fallbackLng: 'en',
+      keySeparator: false,
+      lng: locale?.substring(0, 2) || getBrowserLocale(),
+      nsSeparator: false,
+      resources: pipe(
+        toPairs as (t) => Array<[string, ResourceLanguage]>,
+        reduce(
+          (acc, [language, values]) =>
+            mergeAll([acc, { [language]: { translation: values } }]),
+          {},
+        ),
+      )(retrievedTranslations) as Resource,
+    });
+  };
+
+  const getTranslation = (endpoint: string): Promise<void> => {
+    return getTranslations({
+      endpoint,
+    })
+      .then((retrievedTranslations) => {
+        initializeI18n(retrievedTranslations);
+      })
+      .catch(() => {
+        initializeI18n();
+      });
+  };
+
+  const getExternalTranslation = (): Promise<void> =>
+    getTranslation(externalTranslationEndpoint);
+
+  const getInternalTranslation = (): Promise<void> =>
+    getTranslation(internalTranslationEndpoint);
+
+  return {
+    getBrowserLocale,
+    getExternalTranslation,
+    getInternalTranslation,
+    i18next,
+    initializeI18n,
+  };
+};
+
+export default useInitializeTranslation;

--- a/www/front_src/src/Main/useMain.ts
+++ b/www/front_src/src/Main/useMain.ts
@@ -1,21 +1,8 @@
 import { useEffect } from 'react';
 
-import i18next, { Resource, ResourceLanguage } from 'i18next';
 import { useAtom } from 'jotai';
 import { useAtomValue } from 'jotai/utils';
-import {
-  and,
-  includes,
-  isEmpty,
-  isNil,
-  mergeAll,
-  not,
-  or,
-  pipe,
-  reduce,
-  toPairs,
-} from 'ramda';
-import { initReactI18next } from 'react-i18next';
+import { and, includes, isEmpty, isNil, not, or } from 'ramda';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getData, useRequest, useSnackbar } from '@centreon/ui';
@@ -24,11 +11,11 @@ import { userAtom } from '@centreon/ui-context';
 import { webVersionsDecoder } from '../api/decoders';
 import { webVersionsEndpoint } from '../api/endpoint';
 import { PlatformInstallationStatus } from '../api/models';
-import { translationEndpoint } from '../App/endpoint';
 import reactRoutes from '../reactRoutes/routeMap';
 import { platformInstallationStatusAtom } from '../platformInstallationStatusAtom';
 
 import useUser, { areUserParametersLoadedAtom } from './useUser';
+import useInitializeTranslation from './useInitializeTranslation';
 
 const useMain = (): void => {
   const { sendRequest: getWebVersions } =
@@ -36,11 +23,14 @@ const useMain = (): void => {
       decoder: webVersionsDecoder,
       request: getData,
     });
-  const { sendRequest: getTranslations } = useRequest<ResourceLanguage>({
-    httpCodesBypassErrorSnackbar: [500],
-    request: getData,
-  });
   const { showErrorMessage } = useSnackbar();
+
+  const {
+    getBrowserLocale,
+    getInternalTranslation,
+    i18next,
+    getExternalTranslation,
+  } = useInitializeTranslation();
 
   const [webVersions, setWebVersions] = useAtom(platformInstallationStatusAtom);
   const user = useAtomValue(userAtom);
@@ -50,25 +40,6 @@ const useMain = (): void => {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParameter] = useSearchParams();
-
-  const getBrowserLocale = (): string => navigator.language.slice(0, 2);
-
-  const initializeI18n = (retrievedTranslations?: ResourceLanguage): void => {
-    i18next.use(initReactI18next).init({
-      fallbackLng: 'en',
-      keySeparator: false,
-      lng: getBrowserLocale(),
-      nsSeparator: false,
-      resources: pipe(
-        toPairs as (t) => Array<[string, ResourceLanguage]>,
-        reduce(
-          (acc, [language, values]) =>
-            mergeAll([acc, { [language]: { translation: values } }]),
-          {},
-        ),
-      )(retrievedTranslations) as Resource,
-    });
-  };
 
   const displayAuthenticationError = (): void => {
     const authenticationError = searchParameter.get('authenticationError');
@@ -82,23 +53,13 @@ const useMain = (): void => {
 
   useEffect(() => {
     displayAuthenticationError();
-
-    getTranslations({
-      endpoint: translationEndpoint,
-    })
-      .then((retrievedTranslations) => {
-        initializeI18n(retrievedTranslations);
-      })
-      .catch(() => {
-        initializeI18n();
-      })
-      .finally(() => {
-        getWebVersions({
-          endpoint: webVersionsEndpoint,
-        }).then((retrievedWebVersions) => {
-          setWebVersions(retrievedWebVersions);
-        });
-      });
+    getExternalTranslation().finally(() =>
+      getWebVersions({
+        endpoint: webVersionsEndpoint,
+      }).then((retrievedWebVersions) => {
+        setWebVersions(retrievedWebVersions);
+      }),
+    );
   }, []);
 
   useEffect((): void => {
@@ -108,6 +69,14 @@ const useMain = (): void => {
 
     loadUser();
   }, [webVersions]);
+
+  useEffect((): void => {
+    if (not(areUserParametersLoaded)) {
+      return;
+    }
+
+    getInternalTranslation();
+  }, [areUserParametersLoaded]);
 
   useEffect(() => {
     const canChangeToBrowserLanguage = and(

--- a/www/front_src/src/Main/useMain.ts
+++ b/www/front_src/src/Main/useMain.ts
@@ -25,12 +25,8 @@ const useMain = (): void => {
     });
   const { showErrorMessage } = useSnackbar();
 
-  const {
-    getBrowserLocale,
-    getInternalTranslation,
-    i18next,
-    getExternalTranslation,
-  } = useInitializeTranslation();
+  const { getBrowserLocale, getInternalTranslation, i18next } =
+    useInitializeTranslation();
 
   const [webVersions, setWebVersions] = useAtom(platformInstallationStatusAtom);
   const user = useAtomValue(userAtom);
@@ -53,13 +49,11 @@ const useMain = (): void => {
 
   useEffect(() => {
     displayAuthenticationError();
-    getExternalTranslation().finally(() =>
-      getWebVersions({
-        endpoint: webVersionsEndpoint,
-      }).then((retrievedWebVersions) => {
-        setWebVersions(retrievedWebVersions);
-      }),
-    );
+    getWebVersions({
+      endpoint: webVersionsEndpoint,
+    }).then((retrievedWebVersions) => {
+      setWebVersions(retrievedWebVersions);
+    });
   }, []);
 
   useEffect((): void => {

--- a/www/front_src/src/Main/useMain.ts
+++ b/www/front_src/src/Main/useMain.ts
@@ -36,7 +36,7 @@ const useMain = (): void => {
   const user = useAtomValue(userAtom);
   const areUserParametersLoaded = useAtomValue(areUserParametersLoadedAtom);
 
-  const loadUser = useUser(i18next.changeLanguage);
+  const loadUser = useUser();
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParameter] = useSearchParams();

--- a/www/front_src/src/Main/useUser.ts
+++ b/www/front_src/src/Main/useUser.ts
@@ -58,7 +58,7 @@ const useUser = (
           timezone,
           use_deprecated_pages: useDeprecatedPages,
         });
-        changeLanguage?.((retrievedUser as User).locale.substring(0, 2));
+        // changeLanguage?.((retrievedUser as User).locale.substring(0, 2));
         setAreUserParametersLoaded(true);
       })
       .catch(() => {

--- a/www/front_src/src/Main/useUser.ts
+++ b/www/front_src/src/Main/useUser.ts
@@ -10,9 +10,7 @@ import { userEndpoint } from '../api/endpoint';
 
 export const areUserParametersLoadedAtom = atom<boolean | null>(null);
 
-const useUser = (
-  changeLanguage?: (locale: string) => void,
-): (() => null | Promise<void>) => {
+const useUser = (): (() => null | Promise<void>) => {
   const { sendRequest: getUser } = useRequest<User>({
     decoder: userDecoder,
     httpCodesBypassErrorSnackbar: [403, 401, 500],
@@ -58,7 +56,6 @@ const useUser = (
           timezone,
           use_deprecated_pages: useDeprecatedPages,
         });
-        // changeLanguage?.((retrievedUser as User).locale.substring(0, 2));
         setAreUserParametersLoaded(true);
       })
       .catch(() => {

--- a/www/front_src/src/ResetPassword/index.test.tsx
+++ b/www/front_src/src/ResetPassword/index.test.tsx
@@ -65,6 +65,12 @@ const retrievedLogin = {
   redirect_uri: '/monitoring/resources',
 };
 
+const retrievedTranslations = {
+  en: {
+    hello: 'Hello',
+  },
+};
+
 const TestComponent = ({ initialValues }: Props): JSX.Element => (
   <BrowserRouter>
     <SnackbarProvider>
@@ -102,6 +108,9 @@ describe('Reset password Page', () => {
     });
 
     mockedAxios.get
+      .mockResolvedValueOnce({
+        data: retrievedTranslations,
+      })
       .mockResolvedValueOnce({
         data: retrievedWeb,
       })

--- a/www/front_src/src/ResetPassword/useResetPassword.ts
+++ b/www/front_src/src/ResetPassword/useResetPassword.ts
@@ -38,7 +38,7 @@ function differentPasswords(this, newPassword?: string): boolean {
 }
 
 const useResetPassword = (): UseResetPasswordState => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const navigate = useNavigate();
 
   const { showSuccessMessage } = useSnackbar();
@@ -48,7 +48,7 @@ const useResetPassword = (): UseResetPasswordState => {
 
   const passwordResetInformations = useAtomValue(passwordResetInformationsAtom);
 
-  const loadUser = useUser(i18n.changeLanguage);
+  const loadUser = useUser();
   const { sendLogin } = useLogin();
 
   const submitResetPassword = (


### PR DESCRIPTION
## Description

This applies the user language when the user is logged.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the Login page as a disconnected user
- -> The page is translated according to your browser language
- Log in
- -> The page is translated according to you user language

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
