### PR TITLE
fix(auth): fix refreshToken typehint in openid provider

### DIFF
--- a/src/Core/Domain/Security/Provider/OpenIdProvider.php
+++ b/src/Core/Domain/Security/Provider/OpenIdProvider.php
@@ -55,9 +55,9 @@ class OpenIdProvider implements OpenIdProviderInterface
     private ProviderToken $providerToken;
 
     /**
-     * @var ProviderToken
+     * @var null|ProviderToken
      */
-    private ProviderToken $refreshToken;
+    private ?ProviderToken $refreshToken = null;
 
     /**
      * @var array<string,mixed>
@@ -111,7 +111,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     /**
      * @inheritDoc
      */
-    public function getProviderRefreshToken(): ProviderToken
+    public function getProviderRefreshToken(): ?ProviderToken
     {
         return $this->refreshToken;
     }

--- a/src/Security/Domain/Authentication/Interfaces/OpenIdProviderInterface.php
+++ b/src/Security/Domain/Authentication/Interfaces/OpenIdProviderInterface.php
@@ -42,7 +42,7 @@ interface OpenIdProviderInterface extends ProviderInterface
     /**
      * @return ProviderToken
      */
-    public function getProviderRefreshToken(): ProviderToken;
+    public function getProviderRefreshToken(): ?ProviderToken;
 
     /**
      * @return ContactInterface|null

--- a/src/Security/Domain/Authentication/Interfaces/OpenIdProviderInterface.php
+++ b/src/Security/Domain/Authentication/Interfaces/OpenIdProviderInterface.php
@@ -40,7 +40,7 @@ interface OpenIdProviderInterface extends ProviderInterface
     public function getProviderToken(): ProviderToken;
 
     /**
-     * @return ProviderToken
+     * @return ProviderToken|null
      */
     public function getProviderRefreshToken(): ?ProviderToken;
 


### PR DESCRIPTION
## Description

Fix typehint of getProviderRefreshToken method and refreshToken initial value

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
