### PR TITLE
fix(UI): User menu is truncated with long username

### DIFF
--- a/tests/e2e/cypress/integration/Login/01-login/index.ts
+++ b/tests/e2e/cypress/integration/Login/01-login/index.ts
@@ -27,7 +27,7 @@ Given('I am logged in', () => {
 When('I click on the logout action', () => {
   cy.contains('Rows per page');
   cy.get('[aria-label="Profile"]').click();
-  cy.get('[aria-label="Logout"]').click();
+  cy.contains('Logout').click();
 });
 
 Then('I am logged out and redirected to the login page', () => {

--- a/www/front_src/src/Header/userMenu/index.test.tsx
+++ b/www/front_src/src/Header/userMenu/index.test.tsx
@@ -12,6 +12,7 @@ import { areUserParametersLoadedAtom } from '../../Main/useUser';
 import { logoutEndpoint } from '../../api/endpoint';
 
 import { userEndpoint } from './api/endpoint';
+import { labelProfile } from './translatedLabels';
 
 import UserMenu from '.';
 
@@ -102,6 +103,12 @@ describe('User Menu', () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByLabelText(labelProfile)).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByLabelText(labelProfile));
+
+    await waitFor(() => {
       expect(screen.getByText('Admin admin')).toBeInTheDocument();
     });
 
@@ -122,6 +129,12 @@ describe('User Menu', () => {
     renderUserMenu();
 
     await waitFor(() => {
+      expect(screen.getByLabelText(labelProfile)).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByLabelText(labelProfile));
+
+    await waitFor(() => {
       expect(screen.getByText(labelCopyAutologinLink)).toBeInTheDocument();
     });
 
@@ -137,6 +150,12 @@ describe('User Menu', () => {
   it(`logs out the user when the "${labelLogout}" button is clicked`, async () => {
     mockRequestsWithLogout();
     renderUserMenu();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(labelProfile)).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByLabelText(labelProfile));
 
     await waitFor(() => {
       expect(screen.getByText(labelLogout)).toBeInTheDocument();

--- a/www/front_src/src/Header/userMenu/translatedLabels.ts
+++ b/www/front_src/src/Header/userMenu/translatedLabels.ts
@@ -1,3 +1,6 @@
 export const labelYouHaveBeenLoggedOut = 'You have been logged out';
 export const labelProfile = 'Profile';
 export const labelPasswordWillExpireIn = 'Your password will expire in';
+export const labelEditProfile = 'Edit profile';
+export const labelCopyAutologinLink = 'Copy autologin link';
+export const labelLogout = 'Logout';


### PR DESCRIPTION
## Description

This fixes layout on the user menu issue when the username was too long by refurbishing the user menu in order to clean it.
![Screenshot 2022-05-05 at 13 42 41](https://user-images.githubusercontent.com/12515407/166916648-f109b142-dc04-4d9c-81ce-7a8dd3f4eebb.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Change your user fullname to a long name such as `adminadminadminadminadminadminadmin`
- Open the user menu
- -> The username is truncated and the "Edit profile" button is no longer cramped

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
