### PR TITLE
fix(conf): fix substitution for host massive change

### DIFF
--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -2541,7 +2541,7 @@ function sanitizeFormHostParameters(array $ret): array
                 break;
             case 'mc_contact_additive_inheritance':
             case 'mc_cg_additive_inheritance':
-                $bindParams[':' . ltrim($inputName, 'mc_')] = [
+                $bindParams[':' . str_replace('mc_', '', $inputName)] = [
                     \PDO::PARAM_INT => (isset($ret[$inputName]) ? 1 : 0)
                 ];
                 break;


### PR DESCRIPTION
## Description

Fix the string substitution of additive inheritance parameter during a massive change on hosts.

**Fixes** MON-12126

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
