### PR TITLE
fix(theme): Update of the session when the user's theme is changed

### DIFF
--- a/config/packages/Centreon.yaml
+++ b/config/packages/Centreon.yaml
@@ -393,3 +393,7 @@ services:
 
     Centreon\Domain\Log\LegacyLogger:
         public: true
+
+    # Session
+    Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface:
+        class: Core\Infrastructure\Common\Repository\MultiReadSessionRepository

--- a/src/Core/Application/Common/Session/Repository/ReadSessionRepositoryInterface.php
+++ b/src/Core/Application/Common/Session/Repository/ReadSessionRepositoryInterface.php
@@ -33,7 +33,7 @@ interface ReadSessionRepositoryInterface
      *
      * @throws \Throwable
      */
-    public function findSessionIdsByUserid(int $userId): array;
+    public function findSessionIdsByUserId(int $userId): array;
 
     /**
      * Get a value from session using a key.

--- a/src/Core/Application/Common/Session/Repository/ReadSessionRepositoryInterface.php
+++ b/src/Core/Application/Common/Session/Repository/ReadSessionRepositoryInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Common\Session\Repository;
+
+interface ReadSessionRepositoryInterface
+{
+    /**
+     * Find the session id using the user id.
+     *
+     * @param int $userId
+     * @return string[]
+     *
+     * @throws \Throwable
+     */
+    public function findSessionIdsByUserid(int $userId): array;
+
+    /**
+     * Get a value from session using a key.
+     *
+     * @param string $sessionId
+     * @param string $key
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    public function getValueFromSession(string $sessionId, string $key): mixed;
+}

--- a/src/Core/Application/Common/Session/Repository/WriteSessionRepositoryInterface.php
+++ b/src/Core/Application/Common/Session/Repository/WriteSessionRepositoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Common\Session\Repository;
+
+interface WriteSessionRepositoryInterface
+{
+    /**
+     * Update a value in session.
+     *
+     * @param string $sessionId
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    public function updateSession(string $sessionId, string $key, mixed $value): void;
+}

--- a/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
+++ b/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace Core\Application\Configuration\User\UseCase\PatchUser;
 
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
+use Core\Application\Common\Session\Repository\WriteSessionRepositoryInterface;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
@@ -31,6 +33,7 @@ use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Application\Configuration\User\Exception\UserException;
 use Core\Application\Configuration\User\Repository\ReadUserRepositoryInterface;
 use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
+use Core\Domain\Configuration\User\Model\User;
 
 final class PatchUser
 {
@@ -39,10 +42,14 @@ final class PatchUser
     /**
      * @param ReadUserRepositoryInterface $readUserRepository
      * @param WriteUserRepositoryInterface $writeUserRepository
+     * @param ReadSessionRepositoryInterface $readSessionRepository
+     * @param WriteSessionRepositoryInterface $writeSessionRepository
      */
     public function __construct(
         private ReadUserRepositoryInterface $readUserRepository,
-        private WriteUserRepositoryInterface $writeUserRepository
+        private WriteUserRepositoryInterface $writeUserRepository,
+        private ReadSessionRepositoryInterface $readSessionRepository,
+        private WriteSessionRepositoryInterface $writeSessionRepository
     ) {
     }
 
@@ -87,13 +94,36 @@ final class PatchUser
                 $this->debug('New theme', ['theme' => $request->theme]);
                 $user->setTheme($request->theme);
                 $this->writeUserRepository->update($user);
+                $this->updateUserInSession($user, $request->theme);
             } catch (\Throwable $ex) {
+                $this->error($ex->getMessage());
                 throw UserException::errorWhenUpdatingUserTheme($ex);
             }
             $presenter->setResponseStatus(new NoContentResponse());
         } catch (\Throwable $ex) {
             $this->error($ex->getTraceAsString());
             $this->unexpectedError($ex->getMessage(), $presenter);
+        }
+    }
+
+    private function updateUserInSession(User $user, string $selectedTheme): void
+    {
+        $sessionIds = $this->readSessionRepository->findSessionIdsByUserid($user->getId());
+
+        foreach ($sessionIds as $sessionId) {
+            /**
+             * @var \Centreon $centreon
+             */
+            $centreon = $this->readSessionRepository->getValueFromSession(
+                $sessionId,
+                'centreon'
+            );
+            $centreon->user->theme = $selectedTheme;
+            $this->writeSessionRepository->updateSession(
+                $sessionId,
+                'centreon',
+                $centreon
+            );
         }
     }
 

--- a/src/Core/Infrastructure/Common/Repository/DbReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/DbReadSessionRepository.php
@@ -62,6 +62,6 @@ class DbReadSessionRepository extends AbstractRepositoryDRB implements ReadSessi
      */
     public function getValueFromSession(string $sessionId, string $key): mixed
     {
-        throw RepositoryException::notImplemented('DbReadRepository::getValueFromSession');
+        throw RepositoryException::notImplemented(__METHOD__);
     }
 }

--- a/src/Core/Infrastructure/Common/Repository/DbReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/DbReadSessionRepository.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Core\Infrastructure\Common\Repository;
 
-use _PHPStan_61858e129\Nette\NotImplementedException;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
 use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
@@ -41,7 +40,7 @@ class DbReadSessionRepository extends AbstractRepositoryDRB implements ReadSessi
     /**
      * @inheritDoc
      */
-    public function findSessionIdsByUserid(int $userId): array
+    public function findSessionIdsByUserId(int $userId): array
     {
         $statement = $this->db->prepare(
             $this->translateDbName(

--- a/src/Core/Infrastructure/Common/Repository/DbReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/DbReadSessionRepository.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Common\Repository;
+
+use _PHPStan_61858e129\Nette\NotImplementedException;
+use Centreon\Infrastructure\DatabaseConnection;
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
+
+class DbReadSessionRepository extends AbstractRepositoryDRB implements ReadSessionRepositoryInterface
+{
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findSessionIdsByUserid(int $userId): array
+    {
+        $statement = $this->db->prepare(
+            $this->translateDbName(
+                'SELECT session_id FROM session WHERE user_id = :user_id'
+            )
+        );
+        $statement->bindValue(':user_id', $userId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        $sessionIds = [];
+        while ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $sessionIds[] = $result['session_id'];
+        }
+        return $sessionIds;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getValueFromSession(string $sessionId, string $key): mixed
+    {
+        throw RepositoryException::notImplemented('DbReadRepository::getValueFromSession');
+    }
+}

--- a/src/Core/Infrastructure/Common/Repository/MultiReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/MultiReadSessionRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Common\Repository;
+
+use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
+
+class MultiReadSessionRepository implements ReadSessionRepositoryInterface
+{
+    public function __construct(
+        private SystemReadSessionRepository $systemRepository,
+        private DbReadSessionRepository $dbReadSessionRepository
+    ) {
+    }
+
+    public function findSessionIdsByUserid(int $userId): array
+    {
+        return $this->dbReadSessionRepository->findSessionIdsByUserid($userId);
+    }
+
+    public function getValueFromSession(string $sessionId, string $key): mixed
+    {
+        return $this->systemRepository->getValueFromSession($sessionId, $key);
+    }
+}

--- a/src/Core/Infrastructure/Common/Repository/MultiReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/MultiReadSessionRepository.php
@@ -27,17 +27,27 @@ use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
 
 class MultiReadSessionRepository implements ReadSessionRepositoryInterface
 {
+    /**
+     * @param SystemReadSessionRepository $systemRepository
+     * @param DbReadSessionRepository $dbReadSessionRepository
+     */
     public function __construct(
         private SystemReadSessionRepository $systemRepository,
         private DbReadSessionRepository $dbReadSessionRepository
     ) {
     }
 
-    public function findSessionIdsByUserid(int $userId): array
+    /**
+     * @inheritDoc
+     */
+    public function findSessionIdsByUserId(int $userId): array
     {
-        return $this->dbReadSessionRepository->findSessionIdsByUserid($userId);
+        return $this->dbReadSessionRepository->findSessionIdsByUserId($userId);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getValueFromSession(string $sessionId, string $key): mixed
     {
         return $this->systemRepository->getValueFromSession($sessionId, $key);

--- a/src/Core/Infrastructure/Common/Repository/RepositoryException.php
+++ b/src/Core/Infrastructure/Common/Repository/RepositoryException.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Common\Repository;
+
+class RepositoryException extends \Exception
+{
+    /**
+     * @param string $method
+     * @return self
+     */
+    public static function notImplemented(string $method): self
+    {
+        return new self($method . ' not implemented');
+    }
+}

--- a/src/Core/Infrastructure/Common/Repository/SystemReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/SystemReadSessionRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Common\Repository;
+
+use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
+
+class SystemReadSessionRepository implements ReadSessionRepositoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function findSessionIdsByUserid(int $userId): array
+    {
+        throw RepositoryException::notImplemented('SystemReadRepository::findSessionIdsByUserid');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getValueFromSession(string $sessionId, string $key): mixed
+    {
+        session_id($sessionId);
+        session_start();
+        $value = $_SESSION[$key];
+        session_write_close();
+        return $value;
+    }
+}

--- a/src/Core/Infrastructure/Common/Repository/SystemReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/SystemReadSessionRepository.php
@@ -30,7 +30,7 @@ class SystemReadSessionRepository implements ReadSessionRepositoryInterface
     /**
      * @inheritDoc
      */
-    public function findSessionIdsByUserid(int $userId): array
+    public function findSessionIdsByUserId(int $userId): array
     {
         throw RepositoryException::notImplemented('SystemReadRepository::findSessionIdsByUserid');
     }

--- a/src/Core/Infrastructure/Common/Repository/SystemReadSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/SystemReadSessionRepository.php
@@ -32,7 +32,7 @@ class SystemReadSessionRepository implements ReadSessionRepositoryInterface
      */
     public function findSessionIdsByUserId(int $userId): array
     {
-        throw RepositoryException::notImplemented('SystemReadRepository::findSessionIdsByUserid');
+        throw RepositoryException::notImplemented(__METHOD__);
     }
 
     /**

--- a/src/Core/Infrastructure/Common/Repository/SystemWriteSessionRepository.php
+++ b/src/Core/Infrastructure/Common/Repository/SystemWriteSessionRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Infrastructure\Common\Repository;
+
+use Core\Application\Common\Session\Repository\WriteSessionRepositoryInterface;
+
+class SystemWriteSessionRepository implements WriteSessionRepositoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function updateSession(string $sessionId, string $key, mixed $value): void
+    {
+        session_id($sessionId);
+        session_start();
+        $_SESSION[$key] = $value;
+        session_write_close();
+    }
+}

--- a/tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
+++ b/tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace Tests\Core\Application\Configuration\User\UseCase\PatchUser;
 
+use Core\Application\Common\Session\Repository\ReadSessionRepositoryInterface;
+use Core\Application\Common\Session\Repository\WriteSessionRepositoryInterface;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Configuration\User\Exception\UserException;
@@ -36,6 +38,8 @@ use Core\Infrastructure\Configuration\User\Api\PatchUser\PatchUserPresenter;
 beforeEach(function () {
     $this->writeUserRepository = $this->createMock(WriteUserRepositoryInterface::class);
     $this->readUserRepository = $this->createMock(ReadUserRepositoryInterface::class);
+    $this->readSessionRepository = $this->createMock(ReadSessionRepositoryInterface::class);
+    $this->writeSessionRepository = $this->createMock(WriteSessionRepositoryInterface::class);
     $this->request = new PatchUserRequest();
     $this->request->theme = 'light';
     $this->request->userId = 1;
@@ -47,7 +51,12 @@ it('tests the error message when user is not found', function () {
         ->expects($this->once())
         ->method('findById')
         ->willReturn(null);
-    $useCase = new PatchUser($this->readUserRepository, $this->writeUserRepository);
+    $useCase = new PatchUser(
+        $this->readUserRepository,
+        $this->writeUserRepository,
+        $this->readSessionRepository,
+        $this->writeSessionRepository
+    );
     $useCase($this->request, $this->presenter);
     expect($this->presenter->getResponseStatus())
         ->toEqual(new NotFoundResponse('User'));
@@ -58,7 +67,12 @@ it('tests the exception while searching for the user', function () {
         ->expects($this->once())
         ->method('findById')
         ->willThrowException(new UserException());
-    $useCase = new PatchUser($this->readUserRepository, $this->writeUserRepository);
+    $useCase = new PatchUser(
+        $this->readUserRepository,
+        $this->writeUserRepository,
+        $this->readSessionRepository,
+        $this->writeSessionRepository
+    );
     $useCase($this->request, $this->presenter);
     expect($this->presenter->getResponseStatus())
         ->toEqual(
@@ -77,7 +91,12 @@ it('tests the error message when there are no available themes', function () {
         ->expects($this->once())
         ->method('findAvailableThemes')
         ->willReturn([]);
-    $useCase = new PatchUser($this->readUserRepository, $this->writeUserRepository);
+    $useCase = new PatchUser(
+        $this->readUserRepository,
+        $this->writeUserRepository,
+        $this->readSessionRepository,
+        $this->writeSessionRepository
+    );
     $useCase($this->request, $this->presenter);
     expect($this->presenter->getResponseStatus())
         ->toEqual(new ErrorResponse('Abnormally empty list of themes'));
@@ -93,7 +112,12 @@ it('tests the error message when the given theme is not in the list of available
         ->expects($this->once())
         ->method('findAvailableThemes')
         ->willReturn(['blue', 'green']);
-    $useCase = new PatchUser($this->readUserRepository, $this->writeUserRepository);
+    $useCase = new PatchUser(
+        $this->readUserRepository,
+        $this->writeUserRepository,
+        $this->readSessionRepository,
+        $this->writeSessionRepository
+    );
     $useCase($this->request, $this->presenter);
     expect($this->presenter->getResponseStatus())
         ->toEqual(new ErrorResponse('Requested theme not found'));
@@ -109,7 +133,12 @@ it('tests the exception while searching for available themes', function () {
         ->expects($this->once())
         ->method('findAvailableThemes')
         ->willThrowException(new UserException());
-    $useCase = new PatchUser($this->readUserRepository, $this->writeUserRepository);
+    $useCase = new PatchUser(
+        $this->readUserRepository,
+        $this->writeUserRepository,
+        $this->readSessionRepository,
+        $this->writeSessionRepository
+    );
     $useCase($this->request, $this->presenter);
     expect($this->presenter->getResponseStatus())
         ->toEqual(
@@ -134,7 +163,12 @@ it('tests the exception while updating the theme of user', function () {
         ->with($user)
         ->willThrowException(new UserException());
 
-    $useCase = new PatchUser($this->readUserRepository, $this->writeUserRepository);
+    $useCase = new PatchUser(
+        $this->readUserRepository,
+        $this->writeUserRepository,
+        $this->readSessionRepository,
+        $this->writeSessionRepository
+    );
     $useCase($this->request, $this->presenter);
     expect($this->presenter->getResponseStatus())
         ->toEqual(
@@ -143,3 +177,4 @@ it('tests the exception while updating the theme of user', function () {
             )
         );
 });
+

--- a/tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
+++ b/tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
@@ -177,4 +177,3 @@ it('tests the exception while updating the theme of user', function () {
             )
         );
 });
-


### PR DESCRIPTION
## Description

When the user's theme is updated its sessions are not updated unless it reconnects.
The goal is to update all the user's sessions when the user's theme is updated.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
