### PR TITLE
fix(UI): Fix scroll on poller wizard

### DIFF
--- a/www/front_src/src/route-components/pollerWizard/index.tsx
+++ b/www/front_src/src/route-components/pollerWizard/index.tsx
@@ -1,6 +1,7 @@
 import { lazy, useState, Suspense } from 'react';
 
 import { equals, isNil, path } from 'ramda';
+import { Responsive } from '@visx/visx';
 
 import makeStyles from '@mui/styles/makeStyles';
 
@@ -47,7 +48,7 @@ const steps = [
 ];
 
 const useStyles = makeStyles((theme) => ({
-  formContainer: {
+  wrapper: {
     margin: theme.spacing(2, 4),
   },
 }));
@@ -82,13 +83,19 @@ const PollerWizard = (): JSX.Element | null => {
   return (
     <BaseWizard>
       <ProgressBar activeStep={currentStep} steps={steps} />
-      <div className={classes.formContainer}>
+      <div className={classes.wrapper}>
         <Suspense fallback={<LoadingSkeleton />}>
-          <Form
-            changeServerType={changeServerType}
-            goToNextStep={goToNextStep}
-            goToPreviousStep={goToPreviousStep}
-          />
+          <Responsive.ParentSize>
+            {({ height }): JSX.Element => (
+              <div style={{ height }}>
+                <Form
+                  changeServerType={changeServerType}
+                  goToNextStep={goToNextStep}
+                  goToPreviousStep={goToPreviousStep}
+                />
+              </div>
+            )}
+          </Responsive.ParentSize>
         </Suspense>
       </div>
     </BaseWizard>


### PR DESCRIPTION
## Description

This fixes a scroll issue (bottom buttons not fully visible) on the poller wizard

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Poller wizard is fully visible on small screen

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
