### PR TITLE
fix(install): add style to install buttons

### DIFF
--- a/www/Themes/Generic-theme/style.css
+++ b/www/Themes/Generic-theme/style.css
@@ -683,11 +683,6 @@ a.btc {
     background: var(--bt-info-background-color) !important;
 }
 
-.bt_back_install {
-    background: none !important;
-    color: var(--color-mine-shaft) !important;
-}
-
 .bt_warning {
     background: var(--bt-warning-background-color) !important;
 }

--- a/www/Themes/Generic-theme/style.css
+++ b/www/Themes/Generic-theme/style.css
@@ -683,6 +683,11 @@ a.btc {
     background: var(--bt-info-background-color) !important;
 }
 
+.bt_back_install {
+    background: none !important;
+    color: var(--color-mine-shaft) !important;
+}
+
 .bt_warning {
     background: var(--bt-warning-background-color) !important;
 }

--- a/www/install/install.css
+++ b/www/install/install.css
@@ -95,6 +95,11 @@ textarea {
 	}
 /* custom */
 
+.bt_back_install {
+    background: none !important;
+    color: var(--color-mine-shaft) !important;
+}
+
 table.shell {
 	border: 1px solid #fff;
 	height: 300px;

--- a/www/install/step_upgrade/templates/content.tpl
+++ b/www/install/step_upgrade/templates/content.tpl
@@ -33,7 +33,7 @@
 
         <td align='right'>
             {if ($step-1 && !$blockPreview)}
-                <input class='btc bt_info' type='button' id='previous' value='Back' onClick='jumpTo({$step-1});'/>
+                <input class='btc bt_back_install' type='button' id='previous' value='Back' onClick='jumpTo({$step-1});'/>
             {/if}
             <input class='btc bt_default' type='button' id='refresh' value='Refresh' onClick='jumpTo({$step});'/>
             {if (!isset($valid) || $valid)}

--- a/www/install/steps/templates/content.tpl
+++ b/www/install/steps/templates/content.tpl
@@ -36,7 +36,7 @@
 
         <td align='right'>
         {if ($step-1)}
-        <input class='btc bt_info' type='button' id='previous' value='Back' onClick='loadStep("previousStep");'/>
+        <input class='btc bt_back_install' type='button' id='previous' value='Back' onClick='loadStep("previousStep");'/>
         {/if}
         <input class='btc bt_default' type='button' id='refresh' value='Refresh' onClick='loadStep("stepContent");'/>
         {if (!isset($validate) || $validate)}

--- a/www/install/steps/templates/install.tpl
+++ b/www/install/steps/templates/install.tpl
@@ -6,6 +6,7 @@
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved."/>
     <meta name="robots" content="index, nofollow"/>
+    <link rel="stylesheet" href="../Themes/Generic-theme/Variables-css/variables.css" type="text/css">
     <link rel="stylesheet" href="../Themes/Generic-theme/style.css" type="text/css">
     <link rel="stylesheet" href="./install.css" type="text/css">
     <link rel="stylesheet" href="./pub_install.css" type="text/css">


### PR DESCRIPTION
## Description

This PR intends to add style to install buttons
![image](https://user-images.githubusercontent.com/61694165/167378625-118898d7-c6c1-48fa-843d-c86cd68836e1.png)

The back button is unstyled to be less attractive

**Fixes** # MON-13210

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
