### PR TITLE
fix(conf) accept option 'none' in hostTemplateFactoryRdb

### DIFF
--- a/src/Centreon/Infrastructure/HostConfiguration/Repository/Model/HostTemplateFactoryRdb.php
+++ b/src/Centreon/Infrastructure/HostConfiguration/Repository/Model/HostTemplateFactoryRdb.php
@@ -131,7 +131,7 @@ class HostTemplateFactoryRdb
         }
         $optionToDefine = 0;
         $optionsTags = explode(',', $options);
-        $optionsNotAllowed = array_diff($optionsTags, ['d','u','r','f','s',]);
+        $optionsNotAllowed = array_diff($optionsTags, ['d','u','r','f','s','n']);
         if (!empty($optionsNotAllowed)) {
             throw HostTemplateFactoryException::notificationOptionsNotAllowed(implode(',', $optionsNotAllowed));
         }


### PR DESCRIPTION
## Description

option 'n' (none) was not recognised as a valid option

MON-13294 (21.10)
MON-12934 (22.04)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
