### PR TITLE
fix(ui) : Light mode: Config > users, admin user, selection check box is not disabled

### DIFF
--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -188,4 +188,5 @@
     --service-unknown-font-color: var(--color-black);
     --list-ack-background-color: var(--color-horses-neck);
     --list-ack-hover-background-color: var(--list-one-hover-background-color);
+    --md-checkbox--disabled-border-color-before: var(--color-black-rgba-6);
 }

--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -189,4 +189,5 @@
     --list-ack-background-color: var(--color-horses-neck);
     --list-ack-hover-background-color: var(--list-one-hover-background-color);
     --md-checkbox--disabled-border-color-before: var(--color-black-rgba-6);
+    --md-checkbox--disabled-checked-background-color-before: var(--color-black-rgba-54);
 }

--- a/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/www/Themes/Generic-theme/Variables-css/variables.css
@@ -37,7 +37,7 @@
     --md-checkbox-border-color : var(--color-black-rgba)  ;
     --md-checkbox-background : var(--color-white) ;
     --md-checkbox--disabled-border-color-before : var(--color-black-rgba-1);
-    --md-checkbox--disabled-checked-background-color-before  : var(--color-black-rgba);
+    --md-checkbox--disabled-checked-background-color-before  : var(--color-black-rgba-26);
     --md-check-input-disabled-checked-before:  var(--color-success);
     --md-checkbox-checked-label-before-background-color: var(--color-primary-dark);
     --md-checkbox-border-color-after: var(--color-white);

--- a/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/www/Themes/Generic-theme/Variables-css/variables.css
@@ -36,7 +36,7 @@
     --md-checkbox--checked-background : var(--color-checked-background-rgb) ;
     --md-checkbox-border-color : var(--color-black-rgba)  ;
     --md-checkbox-background : var(--color-white) ;
-    --md-checkbox--disabled-border-color-before : var(--color-black-rgba);
+    --md-checkbox--disabled-border-color-before : var(--color-black-rgba-1);
     --md-checkbox--disabled-checked-background-color-before  : var(--color-black-rgba);
     --md-check-input-disabled-checked-before:  var(--color-success);
     --md-checkbox-checked-label-before-background-color: var(--color-primary-dark);


### PR DESCRIPTION
## Description

Fixing light mode disabled checkbox to be able to distinct them from the normal ones.

Light:
![image](https://user-images.githubusercontent.com/97593234/167438013-b7cd27c6-f017-433b-ae73-d0d99c915158.png)

Dark:
![image](https://user-images.githubusercontent.com/97593234/167439021-b3cf0f3b-6e5e-4afb-85b7-d403697c6de6.png)

**Fixes** # MON-13243

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
