### PR TITLE
fix(ui): fix double click on poller wizard button

### DIFF
--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -51,7 +51,7 @@
             <td>
                 {if !$isRemote}
                     {if $mode_access == 'w'}
-                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" target="_top">
+                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" isreact="true" target="_top">
                             <span class="ui-icon ui-icon-white {$wizardAddBtn.iconClass}"></span> {$wizardAddBtn.text}
                         </a>
                         <a href="{$addBtn.link}" class="{$addBtn.class}">


### PR DESCRIPTION
## Description

fix double click on poller wizard button

**Fixes** MON-13280

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)