### PR TITLE
fix(conf) checkbox uncheckable due to wrong onClick action

### DIFF
--- a/www/include/configuration/configNagios/formNagios.php
+++ b/www/include/configuration/configNagios/formNagios.php
@@ -478,7 +478,7 @@ foreach ($debugLevel as $key => $val) {
         $val,
         [
             "id" => "debug" . $key,
-            "onClick" => in_array($key, ['-1', '0'], true)
+            "onClick" => in_array((string) $key, ['-1', '0'], true)
                 ? "unCheckOthers('debug-level', this.name);"
                 : "unCheckAllAndNaught('debug-level');",
             'class' => 'debug-level'


### PR DESCRIPTION
## Description

The first two checkbox of debug level where uncheckable due to wrong js function call on click event:

![image-20220509-170553](https://user-images.githubusercontent.com/88387848/167600002-c3ea7f7b-91f1-4a22-a010-be4a832bc8cf.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
