### PR TITLE
fix(UI): vertical scrool re-appear now by add overFlow with auto value

### DIFF
--- a/www/front_src/src/Navigation/Sidebar/Menu/CollapsibleItems.tsx
+++ b/www/front_src/src/Navigation/Sidebar/Menu/CollapsibleItems.tsx
@@ -112,6 +112,7 @@ const useStyles = makeStyles((theme) => ({
       collapseScrollMaxWidth
         ? theme.spacing(collapseScrollMaxWidth)
         : theme.spacing(collapseWidth),
+    overflow: 'auto',
     position: 'fixed',
     top: ({ currentTop }: StyleProps): number | undefined => currentTop,
     whiteSpace: 'normal',


### PR DESCRIPTION
## Description

Vertical scrool doesn't work anymore with lot of submenus if screen'size is reduce

**Fixes** # (issue)

vertical scrool re-appear now by add overFlow with auto value

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Log on Centreon , reduce size of your screen , add navigate to Parameter > Administration 

