### PR TITLE
fix(upgrade): properly check if cfg_nagios.logger_version column exists

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -129,7 +129,7 @@ try {
             DROP COLUMN `daemon_dumps_core`"
         );
     }
-    if ($pearDB->isColumnExist('cfg_nagios', 'logger_version') === 1) {
+    if ($pearDB->isColumnExist('cfg_nagios', 'logger_version') !== 1) {
         $errorMessage = "Unable to add logger_version to cfg_nagios table";
         $pearDB->query(
             "ALTER TABLE `cfg_nagios`


### PR DESCRIPTION
## Description

properly check if cfg_nagios.logger_version column exists

**Fixes** MON-13287

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)