### PR TITLE
fix(resources): correctly display icons shared by multiple resources

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
@@ -549,10 +549,13 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
             $statement->execute(array_values($iconIds));
 
             while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                $resourceIndex = array_search((int) $record['icon_id'], $iconIds);
-                $resources[$resourceIndex]->getIcon()
-                    ?->setName($record['icon_name'])
-                    ->setUrl($record['icon_directory'] . DIRECTORY_SEPARATOR . $record['icon_path']);
+                $resourceIndexes = array_keys($iconIds, (int) $record['icon_id']);
+
+                foreach ($resourceIndexes as $resourceIndex) {
+                    $resources[$resourceIndex]->getIcon()
+                        ?->setName($record['icon_name'])
+                        ->setUrl($record['icon_directory'] . DIRECTORY_SEPARATOR . $record['icon_path']);
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Issue was that the icon found was displayed only once even if it was used by several resources.
Issue in code, array_search stops at the first occurence found...

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Use new repository
-  Create a host
- Duplicate it
- Go to resource status
- Icon is displayed on 1/2 hosts

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
