### PR TITLE
fix(UI): Fix layout issues and missing autocompletes on poller wizard

### DIFF
--- a/www/front_src/src/PollerWizard/pollerStep1/index.tsx
+++ b/www/front_src/src/PollerWizard/pollerStep1/index.tsx
@@ -196,16 +196,14 @@ const PollerWizardStepOne = ({
           </div>
         ) : (
           <div className={classes.form}>
-            {waitListOption && waitListOption.length !== 0 && (
-              <SelectField
-                fullWidth
-                label={t(labelSelectPollerIp)}
-                name="server_ip"
-                options={waitListOption}
-                selectedOptionId={stepOneFormData.server_ip}
-                onChange={handleChange}
-              />
-            )}
+            <SelectField
+              fullWidth
+              label={t(labelSelectPollerIp)}
+              name="server_ip"
+              options={waitListOption || []}
+              selectedOptionId={stepOneFormData.server_ip}
+              onChange={handleChange}
+            />
             <TextField
               fullWidth
               required

--- a/www/front_src/src/PollerWizard/pollerStep2/index.tsx
+++ b/www/front_src/src/PollerWizard/pollerStep2/index.tsx
@@ -138,26 +138,23 @@ const PollerWizardStepTwo = ({
       </div>
       <form onSubmit={handleSubmit}>
         <div className={classes.form}>
-          {linkedRemoteMasterOption.length !== 0 && (
-            <SelectField
+          <SelectField
+            fullWidth
+            label={t(labelLinkedRemoteMaster)}
+            name="linked_remote_master"
+            options={linkedRemoteMasterOption || []}
+            selectedOptionId={stepTwoFormData.linked_remote_master}
+            onChange={handleChange}
+          />
+          {stepTwoFormData.linked_remote_master && (
+            <MultiAutocompleteField
               fullWidth
-              label={t(labelLinkedRemoteMaster)}
-              name="linked_remote_master"
-              options={linkedRemoteMasterOption}
-              selectedOptionId={stepTwoFormData.linked_remote_master}
-              onChange={handleChange}
+              label={t(labelLinkedadditionalRemote)}
+              options={linkedRemoteSlavesOption || []}
+              value={stepTwoFormData.linked_remote_slaves}
+              onChange={changeValue}
             />
           )}
-          {stepTwoFormData.linked_remote_master &&
-            linkedRemoteSlavesOption.length >= 2 && (
-              <MultiAutocompleteField
-                fullWidth
-                label={t(labelLinkedadditionalRemote)}
-                options={linkedRemoteSlavesOption}
-                value={stepTwoFormData.linked_remote_slaves}
-                onChange={changeValue}
-              />
-            )}
           <FormControlLabel
             control={
               <Checkbox

--- a/www/front_src/src/PollerWizard/remoteServerStep1/index.tsx
+++ b/www/front_src/src/PollerWizard/remoteServerStep1/index.tsx
@@ -283,16 +283,14 @@ const RemoteServerWizardStepOne = ({
           </div>
         ) : (
           <div className={classes.form}>
-            {waitListOption && waitListOption.length !== 0 ? (
-              <SelectField
-                fullWidth
-                label={t(labelSelectRemoteLinks)}
-                name="server_ip"
-                options={waitListOption}
-                selectedOptionId={stepOneFormData.server_ip}
-                onChange={handleChange}
-              />
-            ) : null}
+            <SelectField
+              fullWidth
+              label={t(labelSelectRemoteLinks)}
+              name="server_ip"
+              options={waitListOption || []}
+              selectedOptionId={stepOneFormData.server_ip}
+              onChange={handleChange}
+            />
             <TextField
               fullWidth
               required

--- a/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
+++ b/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
@@ -119,15 +119,13 @@ const RemoteServerWizardStepTwo = ({
         </Typography>
       </div>
       <form autoComplete="off" onSubmit={handleSubmit}>
-        {remoteServersOption && (
-          <MultiAutocompleteField
-            fullWidth
-            label={t(labelRemoteServers)}
-            options={remoteServersOption}
-            value={linkedPollers}
-            onChange={changeValue}
-          />
-        )}
+        <MultiAutocompleteField
+          fullWidth
+          label={t(labelRemoteServers)}
+          options={remoteServersOption || []}
+          value={linkedPollers}
+          onChange={changeValue}
+        />
         <WizardButtons
           disabled={loading}
           goToPreviousStep={goToPreviousStep}

--- a/www/front_src/src/route-components/pollerWizard/index.tsx
+++ b/www/front_src/src/route-components/pollerWizard/index.tsx
@@ -1,9 +1,9 @@
-import { lazy, useState, Suspense } from 'react';
+import { lazy, useState, Suspense, useRef, useEffect } from 'react';
 
 import { equals, isNil, path } from 'ramda';
-import { Responsive } from '@visx/visx';
 
 import makeStyles from '@mui/styles/makeStyles';
+import { Box } from '@mui/material';
 
 import { ServerType, WizardFormProps } from '../../PollerWizard/models';
 import BaseWizard from '../../PollerWizard/forms/baseWizard';
@@ -58,6 +58,8 @@ const PollerWizard = (): JSX.Element | null => {
 
   const [currentStep, setCurrentStep] = useState(0);
   const [serverType, setServerType] = useState<ServerType>(ServerType.Base);
+  const [listingHeight, setListingHeight] = useState(window.innerHeight);
+  const listingRef = useRef<HTMLDivElement | null>(null);
 
   const goToNextStep = (): void => {
     setCurrentStep((step) => step + 1);
@@ -71,6 +73,18 @@ const PollerWizard = (): JSX.Element | null => {
     setServerType(type);
   };
 
+  const resize = (): void => {
+    setListingHeight(window.innerHeight);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', resize);
+
+    return () => {
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
   const Form = path<(props: WizardFormProps) => JSX.Element>(
     [currentStep, equals(currentStep, 0) ? ServerType.Base : serverType],
     formSteps,
@@ -80,24 +94,29 @@ const PollerWizard = (): JSX.Element | null => {
     return null;
   }
 
+  const listingContainerHeight =
+    listingHeight - (listingRef.current?.getBoundingClientRect().top || 0);
+
   return (
     <BaseWizard>
       <ProgressBar activeStep={currentStep} steps={steps} />
-      <div className={classes.wrapper}>
-        <Suspense fallback={<LoadingSkeleton />}>
-          <Responsive.ParentSize>
-            {({ height }): JSX.Element => (
-              <div style={{ height }}>
-                <Form
-                  changeServerType={changeServerType}
-                  goToNextStep={goToNextStep}
-                  goToPreviousStep={goToPreviousStep}
-                />
-              </div>
-            )}
-          </Responsive.ParentSize>
-        </Suspense>
-      </div>
+      <Box
+        ref={listingRef}
+        sx={{
+          maxHeight: listingContainerHeight,
+          overflowY: 'auto',
+        }}
+      >
+        <div className={classes.wrapper}>
+          <Suspense fallback={<LoadingSkeleton />}>
+            <Form
+              changeServerType={changeServerType}
+              goToNextStep={goToNextStep}
+              goToPreviousStep={goToPreviousStep}
+            />
+          </Suspense>
+        </div>
+      </Box>
     </BaseWizard>
   );
 };


### PR DESCRIPTION
## Description

This addresses several issues about broken wizard layout and autocompletes that doesn't appear in the form 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

The poller wizard should work as the previous version

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
