### PR TITLE
Sanitizing and binding "hostgroups" queries

### DIFF
--- a/www/include/configuration/configObject/hostgroup/listHostGroup.php
+++ b/www/include/configuration/configObject/hostgroup/listHostGroup.php
@@ -152,13 +152,15 @@ for ($i = 0; $hg = $dbResult->fetch(); $i++) {
     }
     $rq = "SELECT h.host_id, h.host_activate
                FROM hostgroup_relation hgr, host h $aclFrom
-               WHERE hostgroup_hg_id = '" . $hg['hg_id'] . "'
+               WHERE hostgroup_hg_id = :hostgroup_hg_id
                AND h.host_id = hgr.host_host_id
                AND h.host_register = '1' $aclCond";
-    $dbResult2 = $pearDB->query($rq);
+    $statement = $pearDB->prepare($rq);
+    $statement->bindValue(':hostgroup_hg_id', (int) $hg['hg_id'], \PDO::PARAM_INT);
+    $statement->execute();
     $nbrhostActArr = array();
     $nbrhostDeactArr = array();
-    while ($row = $dbResult2->fetch()) {
+    while (($row = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
         if ($row['host_activate']) {
             $nbrhostActArr[$row['host_id']] = true;
         } else {


### PR DESCRIPTION
## Description

Sanitizing and binding "hostgroups" queries to improve security and avoid any sql injection attacks.

**Fixes** # MON-12874

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)


## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
