### PR TITLE
Fix some endpoints on the poller wizard

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15100,3 +15100,6 @@ msgstr ""
 
 # msgid "Error"
 # msgstr ""
+
+# msgid "Do not use configured proxy to connect to this server"
+# msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16811,3 +16811,6 @@ msgstr "Destination du journal"
 
 msgid "Error"
 msgstr "Erreur"
+
+msgid "Do not use configured proxy to connect to this server"
+msgstr "Ne pas utiliser le proxy configuré pour se connecter à ce serveur"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15551,3 +15551,6 @@ msgstr ""
 
 # msgid "Error"
 # msgstr ""
+
+# msgid "Do not use configured proxy to connect to this server"
+# msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15539,3 +15539,6 @@ msgstr ""
 
 # msgid "Error"
 # msgstr ""
+
+# msgid "Do not use configured proxy to connect to this server"
+# msgstr ""

--- a/www/front_src/src/PollerWizard/api/endpoints.ts
+++ b/www/front_src/src/PollerWizard/api/endpoints.ts
@@ -3,8 +3,8 @@ const legacyBaseEndpoint = './api/internal.php';
 const baseRemoteConfigurationEndpoint = `${legacyBaseEndpoint}?object=centreon_configuration_remote`;
 
 export const pollerWaitListEndpoint = `${baseRemoteConfigurationEndpoint}&action=getPollerWaitList`;
-export const getPollersEndpoint = `${baseRemoteConfigurationEndpoint}&action=getRemotesList`;
+export const remoteServersEndpoint = `${baseRemoteConfigurationEndpoint}&action=getRemotesList`;
 export const remoteServerWaitListEndpoint = `${baseRemoteConfigurationEndpoint}&action=getWaitList`;
-export const getRemoteServersEndpoint = `${baseRemoteConfigurationEndpoint}&action=getRemotesList`;
+export const pollersEndpoint = `./api/internal.php?object=centreon_configuration_poller&action=list`;
 export const wizardFormEndpoint = `${baseRemoteConfigurationEndpoint}&action=linkCentreonRemoteServer`;
 export const exportTaskEndpoint = `${legacyBaseEndpoint}?object=centreon_task_service&action=getTaskStatus`;

--- a/www/front_src/src/PollerWizard/forms/baseWizard.tsx
+++ b/www/front_src/src/PollerWizard/forms/baseWizard.tsx
@@ -5,6 +5,7 @@ import makeStyles from '@mui/styles/makeStyles';
 
 const useStyles = makeStyles((theme) => ({
   page: {
+    height: 'fit-content',
     margin: '0 auto',
     padding: theme.spacing(2, 0),
     width: '40%',

--- a/www/front_src/src/PollerWizard/models.ts
+++ b/www/front_src/src/PollerWizard/models.ts
@@ -31,3 +31,8 @@ export interface PollerRemoteList {
   ip: string;
   name: string;
 }
+
+export interface Poller {
+  id: string;
+  text: string;
+}

--- a/www/front_src/src/PollerWizard/pollerStep2/index.tsx
+++ b/www/front_src/src/PollerWizard/pollerStep2/index.tsx
@@ -26,7 +26,7 @@ import {
 } from '../translatedLabels';
 import { Props, PollerRemoteList, WizardButtonsTypes } from '../models';
 import WizardButtons from '../forms/wizardButtons';
-import { getPollersEndpoint, wizardFormEndpoint } from '../api/endpoints';
+import { remoteServersEndpoint, wizardFormEndpoint } from '../api/endpoints';
 
 interface StepTwoFormData {
   linked_remote_master: string;
@@ -41,14 +41,16 @@ const PollerWizardStepTwo = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const [pollers, setPollers] = useState<Array<PollerRemoteList>>([]);
+  const [remoteServers, setRemoteServers] = useState<Array<PollerRemoteList>>(
+    [],
+  );
   const [stepTwoFormData, setStepTwoFormData] = useState<StepTwoFormData>({
     linked_remote_master: '',
     linked_remote_slaves: [],
     open_broker_flow: false,
   });
 
-  const { sendRequest: getPollersRequest } = useRequest<
+  const { sendRequest: getRemoteServersRequest } = useRequest<
     Array<PollerRemoteList>
   >({
     request: postData,
@@ -63,10 +65,11 @@ const PollerWizardStepTwo = ({
   const pollerData = useAtomValue<PollerData | null>(pollerAtom);
   const setWizard = useUpdateAtom(setWizardDerivedAtom);
 
-  const getPollers = (): void => {
-    getPollersRequest({ data: null, endpoint: getPollersEndpoint }).then(
-      setPollers,
-    );
+  const getRemoteServers = (): void => {
+    getRemoteServersRequest({
+      data: null,
+      endpoint: remoteServersEndpoint,
+    }).then(setRemoteServers);
   };
 
   const handleChange = (event): void => {
@@ -119,14 +122,17 @@ const PollerWizardStepTwo = ({
       .catch(() => undefined);
   };
 
-  const linkedRemoteMasterOption = pollers.map(pick(['id', 'name']));
+  const linkedRemoteMasterOption = remoteServers.map(pick(['id', 'name']));
 
-  const linkedRemoteSlavesOption = pollers
-    .filter((poller) => poller.id !== stepTwoFormData.linked_remote_master)
+  const linkedRemoteSlavesOption = remoteServers
+    .filter(
+      (remoteServer) =>
+        remoteServer.id !== stepTwoFormData.linked_remote_master,
+    )
     .map(pick(['id', 'name']));
 
   useEffect(() => {
-    getPollers();
+    getRemoteServers();
   }, []);
 
   return (

--- a/www/front_src/src/PollerWizard/remoteServerStep1/index.tsx
+++ b/www/front_src/src/PollerWizard/remoteServerStep1/index.tsx
@@ -18,7 +18,7 @@ import {
   labelDbPassword,
   labelDbUser,
   labelServerName,
-  labelOpenBrokerFlow,
+  labelDoNotUseConfiguredProxy,
   labelSelectRemoteLinks,
   labelSelectRemoteServer,
   labelServerIp,
@@ -278,7 +278,7 @@ const RemoteServerWizardStepOne = ({
                   onChange={handleChange}
                 />
               }
-              label={`${t(labelOpenBrokerFlow)}`}
+              label={`${t(labelDoNotUseConfiguredProxy)}`}
             />
           </div>
         ) : (
@@ -370,7 +370,7 @@ const RemoteServerWizardStepOne = ({
                   onChange={handleChange}
                 />
               }
-              label={`${t(labelOpenBrokerFlow)}`}
+              label={`${t(labelDoNotUseConfiguredProxy)}`}
             />
           </div>
         )}

--- a/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
+++ b/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
@@ -39,7 +39,7 @@ const RemoteServerWizardStepTwo = ({
 
   const [linkedPollers, setLinkedPollers] = useState<Array<SelectEntry>>([]);
 
-  const { sendRequest: getRPollersRequest } = useRequest<{
+  const { sendRequest: getPollersRequest } = useRequest<{
     items: Array<Poller>;
   }>({
     request: getData,

--- a/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
+++ b/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
@@ -60,7 +60,7 @@ const RemoteServerWizardStepTwo = ({
   };
 
   const getPollers = (): void => {
-    getRPollersRequest({
+    getPollersRequest({
       data: null,
       endpoint: pollersEndpoint,
     }).then(({ items }) => {

--- a/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
+++ b/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
@@ -8,6 +8,7 @@ import { useUpdateAtom, useAtomValue } from 'jotai/utils';
 import { Typography } from '@mui/material';
 
 import {
+  getData,
   postData,
   useRequest,
   SelectEntry,
@@ -25,8 +26,8 @@ import {
   labelAdvancedServerConfiguration,
   labelRemoteServers,
 } from '../translatedLabels';
-import { Props, PollerRemoteList, WizardButtonsTypes } from '../models';
-import { getRemoteServersEndpoint, wizardFormEndpoint } from '../api/endpoints';
+import { Props, WizardButtonsTypes, Poller } from '../models';
+import { pollersEndpoint, wizardFormEndpoint } from '../api/endpoints';
 
 const RemoteServerWizardStepTwo = ({
   goToNextStep,
@@ -34,15 +35,14 @@ const RemoteServerWizardStepTwo = ({
 }: Props): JSX.Element => {
   const classes = useStyles();
   const { t } = useTranslation();
-  const [remoteServers, setRemoteServers] =
-    useState<Array<PollerRemoteList> | null>(null);
+  const [pollers, setPollers] = useState<Array<Poller> | null>(null);
 
   const [linkedPollers, setLinkedPollers] = useState<Array<SelectEntry>>([]);
 
-  const { sendRequest: getRemoteServersRequest } = useRequest<
-    Array<PollerRemoteList>
-  >({
-    request: postData,
+  const { sendRequest: getRPollersRequest } = useRequest<{
+    items: Array<Poller>;
+  }>({
+    request: getData,
   });
   const { sendRequest: postWizardFormRequest, sending: loading } = useRequest<{
     s;
@@ -55,19 +55,21 @@ const RemoteServerWizardStepTwo = ({
   const pollerData = useAtomValue(remoteServerAtom);
   const setWizard = useUpdateAtom(setRemoteServerWizardDerivedAtom);
 
-  const filterOutDefaultPoller = (itemArr): Array<PollerRemoteList> => {
+  const filterOutDefaultPoller = (itemArr): Array<Poller> => {
     return itemArr.filter(({ id }) => id !== '1');
   };
 
-  const getRemoteServers = (): void => {
-    getRemoteServersRequest({
+  const getPollers = (): void => {
+    getRPollersRequest({
       data: null,
-      endpoint: getRemoteServersEndpoint,
-    }).then((retrievedRemoteServers) => {
-      setRemoteServers(
-        isEmpty(retrievedRemoteServers)
+      endpoint: pollersEndpoint,
+    }).then(({ items }) => {
+      setPollers(
+        isEmpty(items)
           ? null
-          : filterOutDefaultPoller(retrievedRemoteServers),
+          : filterOutDefaultPoller(
+              items.map(({ id, text }) => ({ id, name: text })),
+            ),
       );
     });
   };
@@ -105,10 +107,12 @@ const RemoteServerWizardStepTwo = ({
       .catch(() => undefined);
   };
 
-  const remoteServersOption = remoteServers?.map(pick(['id', 'name']));
+  const pollersOptions = pollers?.map(
+    pick(['id', 'name']),
+  ) as Array<SelectEntry>;
 
   useEffect(() => {
-    getRemoteServers();
+    getPollers();
   }, []);
 
   return (
@@ -122,7 +126,7 @@ const RemoteServerWizardStepTwo = ({
         <MultiAutocompleteField
           fullWidth
           label={t(labelRemoteServers)}
-          options={remoteServersOption || []}
+          options={pollersOptions || []}
           value={linkedPollers}
           onChange={changeValue}
         />

--- a/www/front_src/src/PollerWizard/translatedLabels.ts
+++ b/www/front_src/src/PollerWizard/translatedLabels.ts
@@ -38,6 +38,9 @@ export const labelRemoteServers =
 export const labelOpenBrokerFlow =
   'Advanced: reverse Centreon Broker communication flow';
 
+export const labelDoNotUseConfiguredProxy =
+  'Do not use configured proxy to connect to this server';
+
 export const labelFinalStep = 'Finalizing Setup';
 export const labelNext = 'Next';
 export const labelPrevious = 'Previous';


### PR DESCRIPTION
## Description

This addresses an issue about the endpoint to retrieve the pollers.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

On the step 2 of the poller wizard, the poller endpoint is called and pollers are displayed in the autocomplete's option

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
