### PR TITLE
fix(hostDetails): properly display icons and status for options

### DIFF
--- a/www/include/monitoring/objectDetails/hostDetails.php
+++ b/www/include/monitoring/objectDetails/hostDetails.php
@@ -343,11 +343,7 @@ if (!$is_admin && !$haveAccess) {
         ];
 
         if (is_array($data)) {
-            foreach ($data as $key => $value) {
-                if (!empty($value)) {
-                    $host_status[$host_name][$key] = $value;
-                }
-            }
+            $host_status[$host_name] = $data;
 
             // Get host timezone
             if (empty($host_status[$host_name]["timezone"])) {

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -192,14 +192,14 @@
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_host_checks_active}</td>
                                                 <td class="ListColLeft">
-                                                    {if !empty($host_data.active_checks_enabled)}
+                                                    {if isset($host_data.active_checks_enabled)}
                                                         <span class="badge {$color_onoff[$host_data.active_checks_enabled]}"  >
                                                             {$en_disable[$host_data.active_checks_enabled]}
                                                         </span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_checks">
-                                                    {if !empty($host_data.active_checks_enabled) && (isset($aclAct.host_checks) || $admin == 1)}
+                                                    {if isset($host_data.active_checks_enabled) && (isset($aclAct.host_checks) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_checks', '{$en_inv[$host_data.active_checks_enabled]}');"><img src={$img_en[$host_data.active_checks_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.active_checks_enabled]} {$m_mon_check_this_host}" /></a>
                                                     {/if}
                                                 </td>
@@ -207,12 +207,12 @@
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_host_checks_passive}</td>
                                                 <td class="ListColLeft">
-                                                    {if !empty($host_data.passive_checks_enabled)}
+                                                    {if isset($host_data.passive_checks_enabled)}
                                                         <span class="badge {$color_onoff[$host_data.passive_checks_enabled]}"  >{$en_disable[$host_data.passive_checks_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup">
-                                                    {if !empty($host_data.passive_checks_enabled) && (isset($aclAct.host_checks) || $admin == 1)}
+                                                    {if isset($host_data.passive_checks_enabled) && (isset($aclAct.host_checks) || $admin == 1)}
                                                         <a href="#" onClick="send_command('host_passive_checks', '{$en_inv[$host_data.passive_checks_enabled]}');">
                                                         <img src={$img_en[$host_data.passive_checks_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.passive_checks_enabled]} {$m_mon_passive_check_this_host}" /></a>
                                                     {/if}
@@ -222,12 +222,12 @@
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_host_notification}</td>
                                                 <td class="ListColLeft">
-                                                    {if !empty($host_data.notifications_enabled)}
+                                                    {if isset($host_data.notifications_enabled)}
                                                         <span class="badge {$color_onoff[$host_data.notifications_enabled]}"  >{$en_disable[$host_data.notifications_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_notifications">
-                                                    {if !empty($host_data.notifications_enabled) && (isset($aclAct.host_notifications) || $admin == 1)}
+                                                    {if isset($host_data.notifications_enabled) && (isset($aclAct.host_notifications) || $admin == 1)}
                                                         <a href="#" onClick="send_command('host_notifications', '{$en_inv[$host_data.notifications_enabled]}');"><img src={$img_en[$host_data.notifications_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.notifications_enabled]} {$m_mon_notify_this_host}" /></a>
                                                     {/if}
                                                 </td>
@@ -237,12 +237,12 @@
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_obsess_over_host}</td>
                                                 <td class="ListColLeft">
-                                                    {if !empty($host_data.obsess_over_host)}
+                                                    {if isset($host_data.obsess_over_host)}
                                                         <span class="badge {$color_onoff[$host_data.obsess_over_host]}"  >{$en_disable[$host_data.obsess_over_host]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_obsess">
-                                                    {if !empty($host_data.obsess_over_host) && (isset($aclAct.obsess_over_host)|| $admin == 1)}
+                                                    {if isset($host_data.obsess_over_host) && (isset($aclAct.obsess_over_host)|| $admin == 1)}
                                                     <a href="#" onClick="send_command('host_obsess', '{$en_inv[$host_data.obsess_over_host]}');"><img src={$img_en[$host_data.obsess_over_host]} class="ico-16" alt="{$en_inv_text[$host_data.obsess_over_host]} {$m_mon_obsess_over_host}" /></a>
                                                     {/if}
                                                 </td>
@@ -252,12 +252,12 @@
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_event_handler}</td>
                                                 <td class="ListColLeft">
-                                                    {if !empty($host_data.event_handler_enabled)}
+                                                    {if isset($host_data.event_handler_enabled)}
                                                         <span class="badge {$color_onoff[$host_data.event_handler_enabled]}"  >{$en_disable[$host_data.event_handler_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_event_handler">
-                                                    {if !empty($host_data.event_handler_enabled) && (isset($aclAct.host_event_handler) || $admin == 1)}
+                                                    {if isset($host_data.event_handler_enabled) && (isset($aclAct.host_event_handler) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_event_handler', '{$en_inv[$host_data.event_handler_enabled]}');"><img src={$img_en[$host_data.event_handler_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.event_handler_enabled]} {$m_mon_ed_event_handler}" /></a>
                                                     {/if}
                                                 </td>
@@ -267,12 +267,12 @@
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_flap_detection}</td>
                                                 <td class="ListColLeft">
-                                                    {if !empty($host_data.flap_detection_enabled)}
+                                                    {if isset($host_data.flap_detection_enabled)}
                                                         <span class="badge {$color_onoff[$host_data.flap_detection_enabled]}" >{$en_disable[$host_data.flap_detection_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_flap_detection">
-                                                    {if !empty($host_data.flap_detection_enabled) && (isset($aclAct.host_flap_detection) || $admin == 1)}
+                                                    {if isset($host_data.flap_detection_enabled) && (isset($aclAct.host_flap_detection) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_flap_detection', '{$en_inv[$host_data.flap_detection_enabled]}');">
                                                         <img src={$img_en[$host_data.flap_detection_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.flap_detection_enabled]} {$m_mon_ed_flapping_detect}" /></a>
                                                     {/if}
@@ -281,9 +281,9 @@
                                             {/if}
                                             {if $host_data.current_state != 'UP'}
                                                 {if
-                                                    (isset($aclAct.host_acknowledgement) && !empty($host_data.problem_has_been_acknowledged))
-                                                    || (isset($aclAct.host_disacknowledgement) && !empty($host_data.problem_has_been_acknowledged))
-                                                    || ($admin == true && !empty($host_data.problem_has_been_acknowledged))
+                                                    (isset($aclAct.host_acknowledgement) && isset($host_data.problem_has_been_acknowledged))
+                                                    || (isset($aclAct.host_disacknowledgement) && isset($host_data.problem_has_been_acknowledged))
+                                                    || ($admin == true && isset($host_data.problem_has_been_acknowledged))
                                                 }
                                                     <tr class='list_one'>
                                                         <td class="ListColLeft">{$m_mon_services_en_acknowledge}</td>

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -172,7 +172,7 @@
                                     <td class="ListColLeft ColPopup">{t}Timezone{/t}</td>
                                     <td class="ListColLeft ListColNoWrap"><span>{$host_data.timezone}</span></td>
                                 </tr>
-                                {if isset$host_data.comments)}
+                                {if isset($host_data.comments)}
                                 <tr class='list_two'>
                                     <td class="ListColLeft ColPopup">{$m_mon_host_comment}</td>
                                     <td class="ListColLeft ListColNoWrap containsURI">{$host_data.comments}</td>

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -172,7 +172,7 @@
                                     <td class="ListColLeft ColPopup">{t}Timezone{/t}</td>
                                     <td class="ListColLeft ListColNoWrap"><span>{$host_data.timezone}</span></td>
                                 </tr>
-                                {if isset($host_data.comments)}
+                                {if isset$host_data.comments)}
                                 <tr class='list_two'>
                                     <td class="ListColLeft ColPopup">{$m_mon_host_comment}</td>
                                     <td class="ListColLeft ListColNoWrap containsURI">{$host_data.comments}</td>
@@ -192,14 +192,14 @@
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_host_checks_active}</td>
                                                 <td class="ListColLeft">
-                                                    {if isset($host_data.active_checks_enabled)}
+                                                    {if $host_data.active_checks_enabled != null}
                                                         <span class="badge {$color_onoff[$host_data.active_checks_enabled]}"  >
                                                             {$en_disable[$host_data.active_checks_enabled]}
                                                         </span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_checks">
-                                                    {if isset($host_data.active_checks_enabled) && (isset($aclAct.host_checks) || $admin == 1)}
+                                                    {if $host_data.active_checks_enabled != null && (isset($aclAct.host_checks) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_checks', '{$en_inv[$host_data.active_checks_enabled]}');"><img src={$img_en[$host_data.active_checks_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.active_checks_enabled]} {$m_mon_check_this_host}" /></a>
                                                     {/if}
                                                 </td>
@@ -207,12 +207,12 @@
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_host_checks_passive}</td>
                                                 <td class="ListColLeft">
-                                                    {if isset($host_data.passive_checks_enabled)}
+                                                    {if $host_data.passive_checks_enabled != null}
                                                         <span class="badge {$color_onoff[$host_data.passive_checks_enabled]}"  >{$en_disable[$host_data.passive_checks_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup">
-                                                    {if isset($host_data.passive_checks_enabled) && (isset($aclAct.host_checks) || $admin == 1)}
+                                                    {if $host_data.passive_checks_enabled != null && (isset($aclAct.host_checks) || $admin == 1)}
                                                         <a href="#" onClick="send_command('host_passive_checks', '{$en_inv[$host_data.passive_checks_enabled]}');">
                                                         <img src={$img_en[$host_data.passive_checks_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.passive_checks_enabled]} {$m_mon_passive_check_this_host}" /></a>
                                                     {/if}
@@ -222,12 +222,12 @@
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_host_notification}</td>
                                                 <td class="ListColLeft">
-                                                    {if isset($host_data.notifications_enabled)}
+                                                    {if $host_data.notifications_enabled != null}
                                                         <span class="badge {$color_onoff[$host_data.notifications_enabled]}"  >{$en_disable[$host_data.notifications_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_notifications">
-                                                    {if isset($host_data.notifications_enabled) && (isset($aclAct.host_notifications) || $admin == 1)}
+                                                    {if $host_data.notifications_enabled != null && (isset($aclAct.host_notifications) || $admin == 1)}
                                                         <a href="#" onClick="send_command('host_notifications', '{$en_inv[$host_data.notifications_enabled]}');"><img src={$img_en[$host_data.notifications_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.notifications_enabled]} {$m_mon_notify_this_host}" /></a>
                                                     {/if}
                                                 </td>
@@ -248,7 +248,7 @@
                                                 </td>
                                             </tr>
                                             {/if}
-                                            {if $aclAct.host_event_handler != null || $admin == true}
+                                            {if isset($aclAct.host_event_handler)|| $admin == true}
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_event_handler}</td>
                                                 <td class="ListColLeft">
@@ -263,7 +263,7 @@
                                                 </td>
                                             </tr>
                                             {/if}
-                                            {if $aclAct.host_flap_detection != null || $admin == true}
+                                            {if isset($aclAct.host_flap_detection) || $admin == true}
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_flap_detection}</td>
                                                 <td class="ListColLeft">
@@ -281,8 +281,8 @@
                                             {/if}
                                             {if $host_data.current_state != 'UP'}
                                                 {if
-                                                    ($aclAct.host_acknowledgement != null && isset($host_data.problem_has_been_acknowledged))
-                                                    || (isset($aclAct.host_disacknowledgement) && isset($host_data.problem_has_been_acknowledged))
+                                                    (isset($aclAct.host_acknowledgement) && $host_data.problem_has_been_acknowledged != null)
+                                                    || (isset($aclAct.host_disacknowledgement) && $host_data.problem_has_been_acknowledged != null)
                                                     || ($admin == true && $host_data.problem_has_been_acknowledged != null)
                                                 }
                                                     <tr class='list_one'>

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -172,7 +172,7 @@
                                     <td class="ListColLeft ColPopup">{t}Timezone{/t}</td>
                                     <td class="ListColLeft ListColNoWrap"><span>{$host_data.timezone}</span></td>
                                 </tr>
-                                {if $host_data.comments}
+                                {if isset($host_data.comments)}
                                 <tr class='list_two'>
                                     <td class="ListColLeft ColPopup">{$m_mon_host_comment}</td>
                                     <td class="ListColLeft ListColNoWrap containsURI">{$host_data.comments}</td>

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -237,42 +237,42 @@
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_obsess_over_host}</td>
                                                 <td class="ListColLeft">
-                                                    {if isset($host_data.obsess_over_host)}
+                                                    {if $host_data.obsess_over_host != null}
                                                         <span class="badge {$color_onoff[$host_data.obsess_over_host]}"  >{$en_disable[$host_data.obsess_over_host]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_obsess">
-                                                    {if isset($host_data.obsess_over_host) && (isset($aclAct.obsess_over_host)|| $admin == 1)}
+                                                    {if $host_data.obsess_over_host != null && (isset($aclAct.obsess_over_host) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_obsess', '{$en_inv[$host_data.obsess_over_host]}');"><img src={$img_en[$host_data.obsess_over_host]} class="ico-16" alt="{$en_inv_text[$host_data.obsess_over_host]} {$m_mon_obsess_over_host}" /></a>
                                                     {/if}
                                                 </td>
                                             </tr>
                                             {/if}
-                                            {if isset($aclAct.host_event_handler) || $admin == true}
+                                            {if $aclAct.host_event_handler != null || $admin == true}
                                             <tr class='list_one'>
                                                 <td class="ListColLeft">{$m_mon_event_handler}</td>
                                                 <td class="ListColLeft">
-                                                    {if isset($host_data.event_handler_enabled)}
+                                                    {if $host_data.event_handler_enabled != null}
                                                         <span class="badge {$color_onoff[$host_data.event_handler_enabled]}"  >{$en_disable[$host_data.event_handler_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_event_handler">
-                                                    {if isset($host_data.event_handler_enabled) && (isset($aclAct.host_event_handler) || $admin == 1)}
+                                                    {if $host_data.event_handler_enabled != null && (isset($aclAct.host_event_handler) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_event_handler', '{$en_inv[$host_data.event_handler_enabled]}');"><img src={$img_en[$host_data.event_handler_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.event_handler_enabled]} {$m_mon_ed_event_handler}" /></a>
                                                     {/if}
                                                 </td>
                                             </tr>
                                             {/if}
-                                            {if isset($aclAct.host_flap_detection) || $admin == true}
+                                            {if $aclAct.host_flap_detection != null || $admin == true}
                                             <tr class='list_two'>
                                                 <td class="ListColLeft">{$m_mon_flap_detection}</td>
                                                 <td class="ListColLeft">
-                                                    {if isset($host_data.flap_detection_enabled)}
+                                                    {if $host_data.flap_detection_enabled != null}
                                                         <span class="badge {$color_onoff[$host_data.flap_detection_enabled]}" >{$en_disable[$host_data.flap_detection_enabled]}</span>
                                                     {/if}
                                                 </td>
                                                 <td class="ListColRight ColPopup" id="host_flap_detection">
-                                                    {if isset($host_data.flap_detection_enabled) && (isset($aclAct.host_flap_detection) || $admin == 1)}
+                                                    {if $host_data.flap_detection_enabled != null && (isset($aclAct.host_flap_detection) || $admin == 1)}
                                                     <a href="#" onClick="send_command('host_flap_detection', '{$en_inv[$host_data.flap_detection_enabled]}');">
                                                         <img src={$img_en[$host_data.flap_detection_enabled]} class="ico-16" alt="{$en_inv_text[$host_data.flap_detection_enabled]} {$m_mon_ed_flapping_detect}" /></a>
                                                     {/if}
@@ -281,9 +281,9 @@
                                             {/if}
                                             {if $host_data.current_state != 'UP'}
                                                 {if
-                                                    (isset($aclAct.host_acknowledgement) && isset($host_data.problem_has_been_acknowledged))
+                                                    ($aclAct.host_acknowledgement != null && isset($host_data.problem_has_been_acknowledged))
                                                     || (isset($aclAct.host_disacknowledgement) && isset($host_data.problem_has_been_acknowledged))
-                                                    || ($admin == true && isset($host_data.problem_has_been_acknowledged))
+                                                    || ($admin == true && $host_data.problem_has_been_acknowledged != null)
                                                 }
                                                     <tr class='list_one'>
                                                         <td class="ListColLeft">{$m_mon_services_en_acknowledge}</td>


### PR DESCRIPTION
## Description

This PR has the same purpose that this one https://github.com/centreon/centreon/pull/10906 (display properly statuses labels and icons for host options) - It fixes also the display of notification number when this one is EMPTY

![image](https://user-images.githubusercontent.com/31647811/168620467-f2756c4f-0113-467d-a7f2-b4d79e9620ac.png)


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira issue details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
