### PR TITLE
fix(conf) export broker conf when output ids are not consecutives

### DIFF
--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -301,13 +301,13 @@ class Broker extends AbstractObjectJSON
                 }
 
                 // cast into arrays instead of objects with integer as key
-                $object[$key] = array_values($object[$key]);
                 foreach ($subValuesToCastInArray as $configGroupId => $subValues) {
                     foreach ($subValues as $subValue) {
                         $object[$key][$configGroupId][$subValue] =
-                            array_values($object[$key][$configGroupId][$subValue]);
+                        array_values($object[$key][$configGroupId][$subValue]);
                     }
                 }
+                $object[$key] = array_values($object[$key]);
             }
 
             // Stats parameters

--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -304,7 +304,7 @@ class Broker extends AbstractObjectJSON
                 foreach ($subValuesToCastInArray as $configGroupId => $subValues) {
                     foreach ($subValues as $subValue) {
                         $object[$key][$configGroupId][$subValue] =
-                        array_values($object[$key][$configGroupId][$subValue]);
+                            array_values($object[$key][$configGroupId][$subValue]);
                     }
                 }
                 $object[$key] = array_values($object[$key]);


### PR DESCRIPTION
## Description

Having discontinued output ids and using grouped fields (like lua parameters) in broker configuration caused an error during broker configuration export

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
