### PR TITLE
fix(conf/export) fix export when hostgroup is disabled

### DIFF
--- a/www/class/config-generate/host.class.php
+++ b/www/class/config-generate/host.class.php
@@ -60,11 +60,11 @@ class Host extends AbstractHost
 
         if (!isset($host['hg'])) {
             if (is_null($this->stmt_hg)) {
-                $this->stmt_hg = $this->backend_instance->db->prepare("SELECT
-                    hostgroup_hg_id
-                FROM hostgroup_relation
-                WHERE host_host_id = :host_id
-                ");
+                $this->stmt_hg = $this->backend_instance->db->prepare(
+                    "SELECT hostgroup_hg_id
+                    FROM hostgroup_relation hgr, hostgroup hg
+                    WHERE host_host_id = :host_id AND hg.hg_id = hgr.hostgroup_hg_id AND hg.hg_activate = '1'"
+                );
             }
             $this->stmt_hg->bindParam(':host_id', $host['host_id'], PDO::PARAM_INT);
             $this->stmt_hg->execute();

--- a/www/class/config-generate/hostgroup.class.php
+++ b/www/class/config-generate/hostgroup.class.php
@@ -68,7 +68,7 @@ class Hostgroup extends AbstractObject
         $this->stmt_hg->execute();
         if ($hostGroup = $this->stmt_hg->fetch(\PDO::FETCH_ASSOC)) {
             $this->hg[$hg_id] = $hostGroup;
-            $this->hg[$hg_id]['members'] = array();
+            $this->hg[$hg_id]['members'] = [];
         }
     }
 

--- a/www/class/config-generate/hostgroup.class.php
+++ b/www/class/config-generate/hostgroup.class.php
@@ -58,20 +58,18 @@ class Hostgroup extends AbstractObject
     private function getHostgroupFromId($hg_id)
     {
         if (is_null($this->stmt_hg)) {
-            $this->stmt_hg = $this->backend_instance->db->prepare("SELECT 
-                    $this->attributes_select
+            $this->stmt_hg = $this->backend_instance->db->prepare(
+                "SELECT  $this->attributes_select
                 FROM hostgroup
-                WHERE hg_id = :hg_id AND hg_activate = '1'
-                ");
+                WHERE hg_id = :hg_id AND hg_activate = '1'"
+            );
         }
         $this->stmt_hg->bindParam(':hg_id', $hg_id, PDO::PARAM_INT);
         $this->stmt_hg->execute();
-        $results = $this->stmt_hg->fetchAll(PDO::FETCH_ASSOC);
-        $this->hg[$hg_id] = array_pop($results);
-        if (is_null($this->hg[$hg_id])) {
-            return null;
+        if ($hostGroup = $this->stmt_hg->fetch(\PDO::FETCH_ASSOC)) {
+            $this->hg[$hg_id] = $hostGroup;
+            $this->hg[$hg_id]['members'] = array();
         }
-        $this->hg[$hg_id]['members'] = array();
     }
 
     public function addHostInHg($hg_id, $host_id, $host_name)


### PR DESCRIPTION
## Description

Trying to export a disabled hostgroup cause config export to fail

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
