### PR TITLE
fix(conf/export) fix export when servicegroup is disabled

### DIFF
--- a/www/class/config-generate/servicegroup.class.php
+++ b/www/class/config-generate/servicegroup.class.php
@@ -164,7 +164,7 @@ class Servicegroup extends AbstractObject
                 "SELECT servicegroup_sg_id, host_host_id, service_service_id
                 FROM servicegroup_relation sgr, servicegroup sg
                 WHERE service_service_id = :service_id AND (host_host_id = :host_id OR host_host_id IS NULL)
-                AND sgr.servicegroup_sg_id = sg.sg_id AND sg.sg_activate"
+                AND sgr.servicegroup_sg_id = sg.sg_id AND sg.sg_activate = '1'"
             );
         }
         $this->stmt_service_sg->bindParam(':service_id', $service_id, PDO::PARAM_INT);


### PR DESCRIPTION
## Description

Trying to export a disabled servicegroup cause config export to fail

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
