### PR TITLE
fix(ui) : [Dark mode] Fixed text color macros that are not visible in light mode.

### DIFF
--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -210,4 +210,8 @@
     --success-message-border-color: var(--up-to-date-color);
     --custom-macros-placeholder-font-color: var(--color-black);
     --custom-macros-font-color: var(--color-white);
+    --custom-macros-command-border-color: var(--color-menthol-2);
+    --custom-macros-template-border-color: var(--color-rayola-2);
+    --custom-macros-command-background-color: var(--color-menthol);
+    --custom-macros-template-background-color: var(--color-rayola);
 }

--- a/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/www/Themes/Generic-theme/Variables-css/variables.css
@@ -797,7 +797,7 @@
     --gorgone-config-file-font-color: var(--color-black);
     --gorgone-config-file-background-color: var(--body-background);
     /* Custom macros variables */
-    --custom-macros-placeholder-font-color: var(--color-white);
+    --custom-macros-placeholder-font-color: var(--color-black);
     --custom-macros-font-color: var(--color-black);
     --custom-macros-command-border-color: var(--color-menthol-2);
     --custom-macros-template-border-color: var(--color-rayola-2);


### PR DESCRIPTION
## Description

Tweak macro font color in light mode

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
