### PR TITLE
fix(purge): do not use deletion_time field in the comments deletion

### DIFF
--- a/www/class/centreonPurgeEngine.class.php
+++ b/www/class/centreonPurgeEngine.class.php
@@ -57,8 +57,7 @@ class CentreonPurgeEngine
      */
     public function __construct()
     {
-        $this->purgeCommentsQuery = 'DELETE FROM comments WHERE (deletion_time is not null and deletion_time ' .
-            '< __RETENTION__) OR (expire_time < __RETENTION__ AND expire_time <> 0)';
+        $this->purgeCommentsQuery = 'DELETE FROM comments WHERE entry_time < __RETENTION__';
         $this->purgeDowntimesQuery = 'DELETE FROM downtimes WHERE (actual_end_time is not null and actual_end_time ' .
             '< __RETENTION__) OR (deletion_time is not null and deletion_time < __RETENTION__)';
         $this->purgeAuditLogQuery = 'DELETE FROM log_action WHERE action_log_date < __RETENTION__';


### PR DESCRIPTION
## Description

Currently, the purge script deletes comments only in these two cases:

- a retention duration is set AND the deletion time is older than the retention
- a retention duration is set AND the expire time is older than the retention

Deletion time is set if we delete a comment from the GUI or if a downtime ends.

We need to change the condition and delete comments taking into account the entry time.

**Fixes** MON-13407

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)