### PR TITLE
fix(web): fix the comment deletion for host monitored by poller

### DIFF
--- a/www/include/monitoring/comments/comments.php
+++ b/www/include/monitoring/comments/comments.php
@@ -78,7 +78,7 @@ switch ($o) {
             if (!empty($select)) {
                 foreach ($select as $key => $value) {
                     $res = explode(';', urldecode($key));
-                    DeleteComment($res[0], [(int)$res[1] . ';' . (int)$res[2] => 'on']);
+                    DeleteComment($res[0], [$res[1] . ';' . (int)$res[2] => 'on']);
                 }
             }
         } else {

--- a/www/include/monitoring/comments/common-Func.php
+++ b/www/include/monitoring/comments/common-Func.php
@@ -47,7 +47,6 @@ function DeleteComment($type = null, $hosts = [])
 
     foreach ($hosts as $key => $value) {
         $res = preg_split("/\;/", $key);
-        $res[0] = filter_var($res[0] ?? 0, FILTER_VALIDATE_INT);
         $res[1] = filter_var($res[1] ?? 0, FILTER_VALIDATE_INT);
         write_command(" DEL_" . $type . "_COMMENT;" . $res[1], GetMyHostPoller($pearDB, $res[0]));
     }


### PR DESCRIPTION
## Description

The function GetMyHostPoller deals with a host name and not a host id.
So we have to send the host name related to the comment we want to delete.

**Fixes** MON-12828

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
