### PR TITLE
fix(conf/export) fix export when service template is disable

### DIFF
--- a/www/class/config-generate/service.class.php
+++ b/www/class/config-generate/service.class.php
@@ -175,7 +175,7 @@ class Service extends AbstractService
             $cg = array();
             $loop = array();
             while (!is_null($serviceId)) {
-                if (isset($loop[$serviceId])) {
+                if (isset($loop[$serviceId]) || ! isset($servicesTpl[$serviceId])) {
                     break;
                 }
                 $loop[$serviceId] = 1;


### PR DESCRIPTION
## Description

A disabled template service linked to an exported service caused the conf export to fail

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
