### PR TITLE
fix(UI): Fix waterfall effect and bring back the carousel indicators

### DIFF
--- a/www/front_src/src/Extensions/Listing/ExtensionDetailsDialog/index.tsx
+++ b/www/front_src/src/Extensions/Listing/ExtensionDetailsDialog/index.tsx
@@ -3,9 +3,8 @@ import { useState, useEffect } from 'react';
 import Carousel from 'react-material-ui-carousel';
 import { Responsive } from '@visx/visx';
 import { useTranslation } from 'react-i18next';
+import { equals, length } from 'ramda';
 
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import {
   Chip,
   Typography,
@@ -47,6 +46,11 @@ interface Props {
   onUpdate: (id: string, type: string) => void;
   type: string;
 }
+
+const hasOneImage = (images: Array<string>): boolean =>
+  equals(1, length(images));
+
+const imageHeight = 280;
 
 const ExtensionDetailPopup = ({
   id,
@@ -106,28 +110,41 @@ const ExtensionDetailPopup = ({
   };
 
   return (
-    <Dialog open labelConfirm="Close" onClose={onClose} onConfirm={onClose}>
-      <Grid container direction="column" spacing={2} style={{ width: 520 }}>
-        <Grid item style={{ height: 300 }}>
+    <Dialog
+      open
+      labelConfirm="Close"
+      labelTitle=""
+      onClose={onClose}
+      onConfirm={onClose}
+    >
+      <Grid container direction="column" spacing={2} sx={{ width: 540 }}>
+        <Grid item>
           <Responsive.ParentSize>
             {({ width }): JSX.Element =>
-              loading ? (
-                <SliderSkeleton width={width} />
-              ) : (
+              extensionDetails.images ? (
                 <Carousel
+                  cycleNavigation
                   fullHeightHover
-                  NextIcon={<ChevronRightIcon />}
-                  PrevIcon={<ChevronLeftIcon />}
                   animation="slide"
                   autoPlay={false}
-                  sx={{
-                    height: '100%',
-                  }}
+                  height={imageHeight}
+                  indicators={!hasOneImage(extensionDetails.images)}
+                  navButtonsAlwaysInvisible={hasOneImage(
+                    extensionDetails.images,
+                  )}
                 >
                   {extensionDetails.images?.map((image) => (
-                    <img alt={image} key={image} src={image} width={width} />
+                    <img
+                      alt={image}
+                      height="100%"
+                      key={image}
+                      src={image}
+                      width="100%"
+                    />
                   ))}
                 </Carousel>
+              ) : (
+                <SliderSkeleton width={width} />
               )
             }
           </Responsive.ParentSize>


### PR DESCRIPTION
## Description

This fixes the waterfall effect and displays carousel indicators

https://user-images.githubusercontent.com/12515407/169830990-f7ca48e9-0293-4c7e-b174-306a8edd02fb.mov

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add one or more modules to your platform
- Go to administration > extensions > manager
- Open details for a module
- -> There is no waterfall effect while displaying the details dialog and indicators are visible if the module contains more than 1 image 

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
