### PR TITLE
fix(widgets): display all pollers for user when no ACL filtering done

### DIFF
--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -82,19 +82,15 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
 
             if ($entriesCount !== false && ($total = $entriesCount->fetchColumn()) !== false) {
                 // it means here that there is poller relations with this user
-                if ((int) $total > 0) {
-                    while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
-                        $tab[$record['id']] = $record['name'];
-                    }
-                } else {
+                if ((int) $total === 0) {
                     // if no relations found for this user it means that he can see all poller available
                     $statement = $this->db->query(
                         "SELECT id, name FROM nagios_server WHERE ns_activate = '1'"
                     );
+                }
 
-                    while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
-                        $tab[$record['id']] = $record['name'];
-                    }
+                while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+                    $tab[$record['id']] = $record['name'];
                 }
             }
         }

--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -88,10 +88,9 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
                     }
                 } else {
                     // if no relations found for this user it means that he can see all poller available
-                    $statement = $this->db->prepare(
+                    $statement = $this->db->query(
                         "SELECT id, name FROM nagios_server WHERE ns_activate = '1'"
                     );
-                    $statement->execute();
 
                     while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
                         $tab[$record['id']] = $record['name'];

--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -50,7 +50,7 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
         if (! isset($tab)) {
             $userACL = new CentreonACL($this->userId);
             $isContactAdmin = $userACL->admin;
-            $request = 'SELECT id, name FROM nagios_server ns';
+            $request = 'SELECT SQL_CALC_FOUND_ROWS id, name FROM nagios_server ns';
 
             if (! $isContactAdmin) {
                 $request .= ' INNER JOIN acl_resources_poller_relations arpr
@@ -78,9 +78,9 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
                 $statement->bindValue(':userId', $this->userId, \PDO::PARAM_INT);
             }
             $statement->execute();
-            $result = $this->db->query('SELECT FOUND_ROWS()');
+            $entriesCount = $this->db->query('SELECT FOUND_ROWS()');
 
-            if ($result !== false && ($total = $result->fetchColumn()) !== false) {
+            if ($entriesCount !== false && ($total = $entriesCount->fetchColumn()) !== false) {
                 // it means here that there is poller relations with this user
                 if ((int) $total > 0) {
                     while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {


### PR DESCRIPTION
## Description

This PR follows https://github.com/centreon/centreon/pull/11129
There is a specificity with ACL regarding pollers

If there is no filtering done on ACL resource access poller listing then the user can see all pollers.
If there is a fileting done on ACL resource access poller listing then the user can only see the selected pollers

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira details

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
