### PR TITLE
Sanitize and bind "downtime" class queries

### DIFF
--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -924,12 +924,10 @@ class CentreonDowntime
      */
     private function downTimeExists($dtName): bool
     {
-        $query = 'SELECT COUNT(*) as nb FROM downtime WHERE dt_name = :dt_name';
-        $statement = $this->db->prepare($query);
+        $statement = $this->db->prepare('SELECT 1 FROM downtime WHERE dt_name = :dt_name LIMIT 1');
         $statement->bindValue(':dt_name', $dtName, \PDO::PARAM_STR);
         $statement->execute();
-        $row = $statement->fetch(\PDO::FETCH_ASSOC);
-        return $row['nb'] > 0;
+        return (bool) $statement->fetch(\PDO::FETCH_ASSOC);
     }
 
     /**

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -494,6 +494,36 @@ class CentreonDowntime
         } else {
             $ids = $this->normalizeArray($ids);
         }
+        $query = 'SELECT COUNT(*) as nb FROM downtime WHERE dt_name = :dt_name';
+        $findIndexStatement = $this->db->prepare($query);
+        $rq = 'INSERT INTO downtime (dt_name, dt_description, dt_activate)
+								VALUES (:dt_name, :dt_description, :dt_activate)';
+        $newDtStatement = $this->db->prepare($rq);
+        $query = "SELECT dt_id FROM downtime WHERE dt_name = :dt_name";
+        $newDtIdStatement = $this->db->prepare($query);
+        $query = 'INSERT INTO downtime_period (dt_id, dtp_start_time, dtp_end_time,
+                            dtp_day_of_week, dtp_month_cycle, dtp_day_of_month, dtp_fixed, dtp_duration,
+                            dtp_activate)
+                            SELECT :dt_id_new, dtp_start_time, dtp_end_time, dtp_day_of_week, dtp_month_cycle,
+                            dtp_day_of_month, dtp_fixed, dtp_duration, dtp_activate
+                            FROM downtime_period WHERE dt_id = :dt_id';
+        $periodsStatement = $this->db->prepare($query);
+        $hostsStatement = $this->db->prepare(
+            'INSERT INTO downtime_host_relation (dt_id, host_host_id)
+                            SELECT :dt_id_new, host_host_id FROM downtime_host_relation WHERE dt_id = :dt_id'
+        );
+        $hostGroupsStatement = $this->db->prepare(
+            'INSERT INTO downtime_hostgroup_relation (dt_id, hg_hg_id)
+                            SELECT :dt_id_new, hg_hg_id FROM downtime_hostgroup_relation WHERE dt_id = :dt_id'
+        );
+        $servicesStatement = $this->db->prepare('INSERT INTO downtime_service_relation
+                            (dt_id, host_host_id, service_service_id)
+                            SELECT :dt_id_new, host_host_id, service_service_id
+                            FROM downtime_service_relation WHERE dt_id = :dt_id');
+        $serviceGroupsStatement = $this->db->prepare(
+            'INSERT INTO downtime_servicegroup_relation (dt_id, sg_sg_id)
+                            SELECT :dt_id_new, sg_sg_id FROM downtime_servicegroup_relation WHERE dt_id = :dt_id'
+        );
         foreach ($ids as $id) {
             if (isset($nb[$id])) {
                 $query = "SELECT dt_name, dt_description, dt_activate FROM downtime WHERE dt_id = " . $id;
@@ -509,58 +539,57 @@ class CentreonDowntime
                 $index = $i = 1;
                 while ($i <= $nb[$id]) {
                     /* Find the index for duplicate name */
-                    $query = "SELECT COUNT(*) as nb FROM downtime WHERE dt_name = '" . $dt_name . "_" . $index . "'";
-                    $res = $this->db->query($query);
-                    $row = $res->fetch();
+                    $findIndexStatement->bindValue(':dt_name', $dt_name . '_' . $index, \PDO::PARAM_STR);
+                    $findIndexStatement->execute();
+                    $row = $findIndexStatement->fetch(\PDO::FETCH_ASSOC);
                     if ($row["nb"] == 0) {
                         /* Insert the new downtime */
-                        $rq = "INSERT INTO downtime (dt_name, dt_description, dt_activate)
-								VALUES ('" . $dt_name . "_" . $index . "', '" . $dt_desc . "', '" . $dt_activate . "')";
                         try {
-                            $res = $this->db->query($rq);
+                            $newDtStatement->bindValue(':dt_name', $dt_name . '_' . $index, \PDO::PARAM_STR);
+                            $newDtStatement->bindValue(':dt_description', $dt_desc, \PDO::PARAM_STR);
+                            $newDtStatement->bindValue(':dt_activate', $dt_activate, \PDO::PARAM_STR);
+                            $newDtStatement->execute();
                         } catch (\PDOException $e) {
                             return;
                         }
                         /* Get the new downtime id */
-                        $query = "SELECT dt_id FROM downtime WHERE dt_name = '" . $dt_name . "_" . $index . "'";
-                        $res = $this->db->query($query);
-                        $row = $res->fetch();
-                        $res->closeCursor();
+                        $newDtIdStatement->bindValue(':dt_name', $dt_name . '_' . $index, \PDO::PARAM_STR);
+                        $newDtIdStatement->execute();
+                        $row = $newDtIdStatement->fetch(\PDO::FETCH_ASSOC);
+                        $newDtIdStatement->closeCursor();
                         $id_new = $row['dt_id'];
                         /* Copy the periods for new downtime */
-                        $query = "INSERT INTO downtime_period (dt_id, dtp_start_time, dtp_end_time,
-                            dtp_day_of_week, dtp_month_cycle, dtp_day_of_month, dtp_fixed, dtp_duration,
-                            dtp_activate)
-                            SELECT " . $id_new . ", dtp_start_time, dtp_end_time, dtp_day_of_week, dtp_month_cycle,
-                            dtp_day_of_month, dtp_fixed, dtp_duration, dtp_activate
-                            FROM downtime_period WHERE dt_id = " . $id;
-                        $this->db->query($query);
+                        $periodsStatement->bindValue(':dt_id_new', (int) $id_new, \PDO::PARAM_INT);
+                        $periodsStatement->bindValue(':dt_id', (int) $id, \PDO::PARAM_INT);
+                        $periodsStatement->execute();
 
                         /*
                          * Duplicate Relations for hosts
                          */
-                        $this->db->query("INSERT INTO downtime_host_relation (dt_id, host_host_id)
-                            SELECT $id_new, host_host_id FROM downtime_host_relation WHERE dt_id = '$id'");
+                        $hostsStatement->bindValue(':dt_id_new', (int) $id_new, \PDO::PARAM_INT);
+                        $hostsStatement->bindValue(':dt_id', (int) $id, \PDO::PARAM_INT);
+                        $hostsStatement->execute();
 
                         /*
                          * Duplicate Relations for hostgroups
                          */
-                        $this->db->query("INSERT INTO downtime_hostgroup_relation (dt_id, hg_hg_id)
-                            SELECT $id_new, hg_hg_id FROM downtime_hostgroup_relation WHERE dt_id = '$id'");
+                        $hostGroupsStatement->bindValue(':dt_id_new', (int) $id_new, \PDO::PARAM_INT);
+                        $hostGroupsStatement->bindValue(':dt_id', (int) $id, \PDO::PARAM_INT);
+                        $hostGroupsStatement->execute();
 
                         /*
                          * Duplicate Relations for services
                          */
-                        $this->db->query("INSERT INTO downtime_service_relation
-                            (dt_id, host_host_id, service_service_id)
-                            SELECT $id_new, host_host_id, service_service_id
-                            FROM downtime_service_relation WHERE dt_id = '$id'");
+                        $servicesStatement->bindValue(':dt_id_new', (int) $id_new, \PDO::PARAM_INT);
+                        $servicesStatement->bindValue(':dt_id', (int) $id, \PDO::PARAM_INT);
+                        $servicesStatement->execute();
 
                         /*
                          * Duplicate Relations for servicegroups
                          */
-                        $this->db->query("INSERT INTO downtime_servicegroup_relation (dt_id, sg_sg_id)
-                            SELECT $id_new, sg_sg_id FROM downtime_servicegroup_relation WHERE dt_id = '$id'");
+                        $serviceGroupsStatement->bindValue(':dt_id_new', (int) $id_new, \PDO::PARAM_INT);
+                        $serviceGroupsStatement->bindValue(':dt_id', (int) $id, \PDO::PARAM_INT);
+                        $serviceGroupsStatement->execute();
 
                         $i++;
                     }

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -922,7 +922,7 @@ class CentreonDowntime
      * @param string $dtName
      * @return bool
      */
-    private function downTimeExists($dtName): bool
+    private function downtimeExists($dtName): bool
     {
         $statement = $this->db->prepare('SELECT 1 FROM downtime WHERE dt_name = :dt_name LIMIT 1');
         $statement->bindValue(':dt_name', $dtName, \PDO::PARAM_STR);

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -505,9 +505,9 @@ class CentreonDowntime
                 $row = $res->fetch();
                 $index = $i = 1;
                 while ($i <= $nb[$id]) {
-                    if (!$this->downTimeExists($row['dt_name'] . '_' . $index)) {
+                    if (!$this->downtimeExists($row['dt_name'] . '_' . $index)) {
                         $row['index'] = $index;
-                        $this->duplicateDownTime($this->db, $row);
+                        $this->duplicateDowntime($row);
                         $i++;
                     }
                     $index++;
@@ -891,22 +891,21 @@ class CentreonDowntime
     /**
      * All in one function to duplicate downtime.
      *
-     * @param CentreonDB $dbh
      * @param array $params
      */
-    private function duplicateDownTime($dbh, $params): void
+    private function duplicateDowntime(array $params): void
     {
-        $dbh->beginTransaction();
+        $this->db->beginTransaction();
         try {
-            $params['dt_id_new'] = $this->createDownTime($params);
-            $this->createDownTimePeriods($params);
-            $this->createDownTimeHostsRelations($params);
-            $this->createDownTimeHostGroupsRelations($params);
-            $this->createDownTimeServicesRelations($params);
-            $this->createDownTimeServiceGroupsRelations($params);
-            $dbh->commit();
+            $params['dt_id_new'] = $this->createDowntime($params);
+            $this->createDowntimePeriods($params);
+            $this->createDowntimeHostsRelations($params);
+            $this->createDowntimeHostGroupsRelations($params);
+            $this->createDowntimeServicesRelations($params);
+            $this->createDowntimeServiceGroupsRelations($params);
+            $this->db->commit();
         } catch (\Exception $e) {
-            $dbh->rollBack();
+            $this->db->rollBack();
         }
     }
 
@@ -932,7 +931,7 @@ class CentreonDowntime
      * @param array<string, string> $params
      * @return int
      */
-    private function createDownTime(array $params): int
+    private function createDowntime(array $params): int
     {
         $rq = 'INSERT INTO downtime (dt_name, dt_description, dt_activate)
 			   VALUES (:dt_name, :dt_description, :dt_activate)';
@@ -949,7 +948,7 @@ class CentreonDowntime
      *
      * @param array<string, string> $params
      */
-    private function createDownTimePeriods(array $params): void
+    private function createDowntimePeriods(array $params): void
     {
         $query = 'INSERT INTO downtime_period (dt_id, dtp_start_time, dtp_end_time,
             dtp_day_of_week, dtp_month_cycle, dtp_day_of_month, dtp_fixed, dtp_duration,
@@ -968,7 +967,7 @@ class CentreonDowntime
      *
      * @param array<string, string> $params
      */
-    private function createDownTimeHostsRelations(array $params): void
+    private function createDowntimeHostsRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_host_relation (dt_id, host_host_id)
@@ -984,7 +983,7 @@ class CentreonDowntime
      *
      * @param array<string, string> $params
      */
-    private function createDownTimeHostGroupsRelations(array $params): void
+    private function createDowntimeHostGroupsRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_hostgroup_relation (dt_id, hg_hg_id)
@@ -1000,7 +999,7 @@ class CentreonDowntime
      *
      * @param array<string, string> $params
      */
-    private function createDownTimeServicesRelations(array $params): void
+    private function createDowntimeServicesRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_service_relation
@@ -1018,7 +1017,7 @@ class CentreonDowntime
      *
      * @param array<string, string> $params
      */
-    private function createDownTimeServiceGroupsRelations(array $params): void
+    private function createDowntimeServiceGroupsRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_servicegroup_relation (dt_id, sg_sg_id)

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -935,7 +935,7 @@ class CentreonDowntime
     private function createDownTime(array $params): int
     {
         $rq = 'INSERT INTO downtime (dt_name, dt_description, dt_activate)
-			VALUES (:dt_name, :dt_description, :dt_activate)';
+			   VALUES (:dt_name, :dt_description, :dt_activate)';
         $statement = $this->db->prepare($rq);
         $statement->bindValue(':dt_name', $params['dt_name'] . '_' . $params['index'], \PDO::PARAM_STR);
         $statement->bindValue(':dt_description', $params['dt_description'], \PDO::PARAM_STR);

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -895,7 +895,10 @@ class CentreonDowntime
      */
     private function duplicateDowntime(array $params): void
     {
-        $this->db->beginTransaction();
+        $isAlreadyInTransaction = $this->db->inTransaction();
+        if (! $isAlreadyInTransaction) {
+            $this->db->beginTransaction();
+        }
         try {
             $params['dt_id_new'] = $this->createDowntime($params);
             $this->createDowntimePeriods($params);
@@ -903,9 +906,13 @@ class CentreonDowntime
             $this->createDowntimeHostGroupsRelations($params);
             $this->createDowntimeServicesRelations($params);
             $this->createDowntimeServiceGroupsRelations($params);
-            $this->db->commit();
+            if (! $isAlreadyInTransaction) {
+                $this->db->commit();
+            }
         } catch (\Exception $e) {
-            $this->db->rollBack();
+            if (! $isAlreadyInTransaction) {
+                $this->db->rollBack();
+            }
         }
     }
 

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -929,13 +929,13 @@ class CentreonDowntime
     /**
      * Creating new downtime and returns id.
      *
-     * @param array $params
+     * @param array<string, string> $params
      * @return int
      */
-    private function createDownTime($params): int
+    private function createDownTime(array $params): int
     {
         $rq = 'INSERT INTO downtime (dt_name, dt_description, dt_activate)
-								VALUES (:dt_name, :dt_description, :dt_activate)';
+			VALUES (:dt_name, :dt_description, :dt_activate)';
         $statement = $this->db->prepare($rq);
         $statement->bindValue(':dt_name', $params['dt_name'] . '_' . $params['index'], \PDO::PARAM_STR);
         $statement->bindValue(':dt_description', $params['dt_description'], \PDO::PARAM_STR);
@@ -947,16 +947,16 @@ class CentreonDowntime
     /**
      * Creating downtime periods for the new downtime.
      *
-     * @param array $params
+     * @param array<string, string> $params
      */
-    private function createDownTimePeriods($params): void
+    private function createDownTimePeriods(array $params): void
     {
         $query = 'INSERT INTO downtime_period (dt_id, dtp_start_time, dtp_end_time,
-                            dtp_day_of_week, dtp_month_cycle, dtp_day_of_month, dtp_fixed, dtp_duration,
-                            dtp_activate)
-                            SELECT :dt_id_new, dtp_start_time, dtp_end_time, dtp_day_of_week, dtp_month_cycle,
-                            dtp_day_of_month, dtp_fixed, dtp_duration, dtp_activate
-                            FROM downtime_period WHERE dt_id = :dt_id';
+            dtp_day_of_week, dtp_month_cycle, dtp_day_of_month, dtp_fixed, dtp_duration,
+            dtp_activate)
+            SELECT :dt_id_new, dtp_start_time, dtp_end_time, dtp_day_of_week, dtp_month_cycle,
+            dtp_day_of_month, dtp_fixed, dtp_duration, dtp_activate
+            FROM downtime_period WHERE dt_id = :dt_id';
         $statement = $this->db->prepare($query);
         $statement->bindValue(':dt_id_new', (int) $params['dt_id_new'], \PDO::PARAM_INT);
         $statement->bindValue(':dt_id', (int) $params['dt_id'], \PDO::PARAM_INT);
@@ -966,13 +966,13 @@ class CentreonDowntime
     /**
      * Creating hosts relations for the new downtime.
      *
-     * @param array $params
+     * @param array<string, string> $params
      */
-    private function createDownTimeHostsRelations($params): void
+    private function createDownTimeHostsRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_host_relation (dt_id, host_host_id)
-                            SELECT :dt_id_new, host_host_id FROM downtime_host_relation WHERE dt_id = :dt_id'
+            SELECT :dt_id_new, host_host_id FROM downtime_host_relation WHERE dt_id = :dt_id'
         );
         $statement->bindValue(':dt_id_new', (int) $params['dt_id_new'], \PDO::PARAM_INT);
         $statement->bindValue(':dt_id', (int) $params['dt_id'], \PDO::PARAM_INT);
@@ -982,13 +982,13 @@ class CentreonDowntime
     /**
      * Create host groups for the new downtime.
      *
-     * @param array $params
+     * @param array<string, string> $params
      */
-    private function createDownTimeHostGroupsRelations($params): void
+    private function createDownTimeHostGroupsRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_hostgroup_relation (dt_id, hg_hg_id)
-                            SELECT :dt_id_new, hg_hg_id FROM downtime_hostgroup_relation WHERE dt_id = :dt_id'
+            SELECT :dt_id_new, hg_hg_id FROM downtime_hostgroup_relation WHERE dt_id = :dt_id'
         );
         $statement->bindValue(':dt_id_new', (int) $params['dt_id_new'], \PDO::PARAM_INT);
         $statement->bindValue(':dt_id', (int) $params['dt_id'], \PDO::PARAM_INT);
@@ -998,14 +998,16 @@ class CentreonDowntime
     /**
      * Creating services relations for the new downtime.
      *
-     * @param array $params
+     * @param array<string, string> $params
      */
-    private function createDownTimeServicesRelations($params): void
+    private function createDownTimeServicesRelations(array $params): void
     {
-        $statement = $this->db->prepare('INSERT INTO downtime_service_relation
-                            (dt_id, host_host_id, service_service_id)
-                            SELECT :dt_id_new, host_host_id, service_service_id
-                            FROM downtime_service_relation WHERE dt_id = :dt_id');
+        $statement = $this->db->prepare(
+            'INSERT INTO downtime_service_relation
+            (dt_id, host_host_id, service_service_id)
+            SELECT :dt_id_new, host_host_id, service_service_id
+            FROM downtime_service_relation WHERE dt_id = :dt_id'
+        );
         $statement->bindValue(':dt_id_new', (int) $params['dt_id_new'], \PDO::PARAM_INT);
         $statement->bindValue(':dt_id', (int) $params['dt_id'], \PDO::PARAM_INT);
         $statement->execute();
@@ -1014,13 +1016,13 @@ class CentreonDowntime
     /**
      * Creating service groups relations for the new downtime.
      *
-     * @param array $params
+     * @param array<string, string> $params
      */
-    private function createDownTimeServiceGroupsRelations($params): void
+    private function createDownTimeServiceGroupsRelations(array $params): void
     {
         $statement = $this->db->prepare(
             'INSERT INTO downtime_servicegroup_relation (dt_id, sg_sg_id)
-                            SELECT :dt_id_new, sg_sg_id FROM downtime_servicegroup_relation WHERE dt_id = :dt_id'
+            SELECT :dt_id_new, sg_sg_id FROM downtime_servicegroup_relation WHERE dt_id = :dt_id'
         );
         $statement->bindValue(':dt_id_new', (int) $params['dt_id_new'], \PDO::PARAM_INT);
         $statement->bindValue(':dt_id', (int) $params['dt_id'], \PDO::PARAM_INT);


### PR DESCRIPTION
## Description

Sanitizing and binding "downtime" class queries to avoid any sql injections attacks.

**Fixes** # MON-12878

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
