### PR TITLE
Sanitize and bind "ACL group" list queries

### DIFF
--- a/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -547,10 +547,13 @@ function updateGroupResources($acl_group_id, $ret = array())
 function duplicateContacts($idTD, $acl_id, $pearDB)
 {
     $request = "INSERT INTO acl_group_contacts_relations (contact_contact_id, acl_group_id) "
-        . "SELECT contact_contact_id, '$acl_id' AS acl_group_id "
+        . "SELECT contact_contact_id, :acl_group_id AS acl_group_id "
         . "FROM acl_group_contacts_relations "
-        . "WHERE acl_group_id = '$idTD'";
-    $pearDB->query($request);
+        . "WHERE acl_group_id = :acl_group_id_td";
+    $statement = $pearDB->prepare($request);
+    $statement->bindValue(':acl_group_id', (int) $acl_id, \PDO::PARAM_INT);
+    $statement->bindValue(':acl_group_id_td', (int) $idTD, \PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**
@@ -562,10 +565,13 @@ function duplicateContacts($idTD, $acl_id, $pearDB)
 function duplicateContactGroups($idTD, $acl_id, $pearDB)
 {
     $request = "INSERT INTO acl_group_contactgroups_relations (cg_cg_id, acl_group_id) "
-        . "SELECT cg_cg_id, '$acl_id' AS acl_group_id "
+        . "SELECT cg_cg_id, :acl_group_id AS acl_group_id "
         . "FROM acl_group_contactgroups_relations "
-        . "WHERE acl_group_id = '$idTD'";
-    $pearDB->query($request);
+        . "WHERE acl_group_id = :acl_group_id_td";
+    $statement = $pearDB->prepare($request);
+    $statement->bindValue(':acl_group_id', (int) $acl_id, \PDO::PARAM_INT);
+    $statement->bindValue(':acl_group_id_td', (int) $idTD, \PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**
@@ -577,10 +583,13 @@ function duplicateContactGroups($idTD, $acl_id, $pearDB)
 function duplicateResources($idTD, $acl_id, $pearDB)
 {
     $request = "INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) "
-        . "SELECT acl_res_id, '$acl_id' AS acl_group_id "
+        . "SELECT acl_res_id, :acl_group_id AS acl_group_id "
         . "FROM acl_res_group_relations "
-        . "WHERE acl_group_id = '$idTD'";
-    $pearDB->query($request);
+        . "WHERE acl_group_id = :acl_group_id_td";
+    $statement = $pearDB->prepare($request);
+    $statement->bindValue(':acl_group_id', (int) $acl_id, \PDO::PARAM_INT);
+    $statement->bindValue(':acl_group_id_td', (int) $idTD, \PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**
@@ -592,10 +601,13 @@ function duplicateResources($idTD, $acl_id, $pearDB)
 function duplicateActions($idTD, $acl_id, $pearDB)
 {
     $request = "INSERT INTO acl_group_actions_relations (acl_action_id, acl_group_id) "
-        . "SELECT acl_action_id, '$acl_id' AS acl_group_id "
+        . "SELECT acl_action_id, :acl_group_id AS acl_group_id "
         . "FROM acl_group_actions_relations "
-        . "WHERE acl_group_id = '$idTD'";
-    $pearDB->query($request);
+        . "WHERE acl_group_id = :acl_group_id_td";
+    $statement = $pearDB->prepare($request);
+    $statement->bindValue(':acl_group_id', (int) $acl_id, \PDO::PARAM_INT);
+    $statement->bindValue(':acl_group_id_td', (int) $idTD, \PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**
@@ -607,10 +619,13 @@ function duplicateActions($idTD, $acl_id, $pearDB)
 function duplicateMenus($idTD, $acl_id, $pearDB)
 {
     $request = "INSERT INTO acl_group_topology_relations (acl_topology_id, acl_group_id) "
-        . "SELECT acl_topology_id, '$acl_id' AS acl_group_id "
+        . "SELECT acl_topology_id, :acl_group_id AS acl_group_id "
         . "FROM acl_group_topology_relations "
-        . "WHERE acl_group_id = '$idTD'";
-    $pearDB->query($request);
+        . "WHERE acl_group_id = :acl_group_id_td";
+    $statement = $pearDB->prepare($request);
+    $statement->bindValue(':acl_group_id', (int) $acl_id, \PDO::PARAM_INT);
+    $statement->bindValue(':acl_group_id_td', (int) $idTD, \PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**


### PR DESCRIPTION
## Description

Sanitinzing and binding ACL group list queries using PDO to avoid any sql injections attacks and cleaning legacy code.

Preview:
![image](https://user-images.githubusercontent.com/97593234/171141465-8e96200c-2260-442e-8faa-dfc316350e81.png)


**Fixes** # MON-13310

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
