### PR TITLE
enh(parameters): return new parameter to indicate repository used by …

### DIFF
--- a/src/Centreon/Application/Controller/Administration/ParametersController.php
+++ b/src/Centreon/Application/Controller/Administration/ParametersController.php
@@ -50,6 +50,9 @@ class ParametersController extends AbstractController
                   DEFAULT_ACKNOWLEDGEMENT_FORCE_ACTIVE_CHECKS = 'monitoring_ack_active_checks',
                   DEFAULT_DOWNTIME_FIXED = 'monitoring_dwt_fixed',
                   DEFAULT_DOWNTIME_WITH_SERVICES = 'monitoring_dwt_svc';
+
+    private const RESOURCE_STATUS_OPTIMIZED_REPOSITORY = 'optimized';
+
     /**
      * Needed to make response "more readable"
      */
@@ -161,6 +164,9 @@ class ParametersController extends AbstractController
             $isAcknowledgementForceActiveChecks;
         $parameters[self::KEY_NAME_CONCORDANCE[self::DEFAULT_DOWNTIME_FIXED]] = $isDowntimeFixed;
         $parameters[self::KEY_NAME_CONCORDANCE[self::DEFAULT_DOWNTIME_WITH_SERVICES]] = $isDowntimeWithServices;
+
+        $parameters['monitoring_resource_status_optimized_mode'] =
+            $this->getParameter('resource.status.repository') === self::RESOURCE_STATUS_OPTIMIZED_REPOSITORY;
 
         return $this->view($parameters);
     }


### PR DESCRIPTION
…Resource Status

This PR intends to add a new entry to the `/administration/parameters` endpoint to indicate the "mode" used by Resource Status - legacy or optimized

<img width="569" alt="image" src="https://user-images.githubusercontent.com/31647811/171568788-67868373-cb36-461a-946a-f61eeeb78e29.png">


## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira details

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
