### PR TITLE
enh(upgrade): do not enable delay before password creation on upgrade

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -459,7 +459,7 @@ function updateSecurityPolicyConfiguration(CentreonDB $pearDB): void
             "attempts" => 5,
             "blocking_duration" => 900,
             "password_expiration_delay" => 15552000,
-            "delay_before_new_password" => 3600,
+            "delay_before_new_password" => null,
             "can_reuse_passwords" => false,
         ],
     ]);


### PR DESCRIPTION
## Description

do not enable delay before password creation on upgrade

**Fixes** MON-13390

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)