### PR TITLE
fix(acl) remove wizard poller steps options from acl menu

### DIFF
--- a/www/install/insertTopology.sql
+++ b/www/install/insertTopology.sql
@@ -170,15 +170,6 @@ INSERT INTO `topology` (`topology_id`, `topology_name`, `topology_parent`, `topo
 INSERT INTO `topology` (`topology_id`, `topology_name`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_url`, `topology_url_opt`, `topology_popup`, `topology_modules`, `topology_show`, `topology_style_class`, `topology_style_id`, `topology_OnClick`, `readonly`) VALUES (NULL,'Chart split',20401,2040101,1,1,'./include/views/graphs/graph-split.php',NULL,'0','0','0',NULL,NULL,NULL,'1');
 INSERT INTO `topology` (`topology_id`, `topology_name`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_url`, `topology_url_opt`, `topology_popup`, `topology_modules`, `topology_show`, `topology_style_class`, `topology_style_id`, `topology_OnClick`, `readonly`) VALUES (NULL,'Chart periods',20401,2040102,1,1,'./include/views/graphs/graph-periods.php',NULL,'0','0','0',NULL,NULL,NULL,'1');
 
--- Insert Multi-step Wizard into Topology
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Poller/Remote Wizard', '/poller-wizard/1', 60901, 60959, 1, '0', '0', '1');
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Remote Wizard Step 2', '/poller-wizard/2', 60901, 60959, 1, '0', '0', '1');
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Remote Wizard Step 3', '/poller-wizard/3', 60901, 60959, 1, '0', '0', '1');
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Remote Wizard Final Step', '/poller-wizard/4', 60901, 60959, 1, '0', '0', '1');
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Poller Wizard Step 2', '/poller-wizard/5', 60901, 60959, 1, '0', '0', '1');
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Poller Wizard Step 3', '/poller-wizard/6', 60901, 60959, 1, '0', '0', '1');
-INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_page, topology_group, topology_show, readonly, is_react) VALUES ('Poller Wizard Final Step', '/poller-wizard/7', 60901, 60959, 1, '0', '0', '1');
-
 -- Insert Extensions Manager entry
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`) VALUES ('Manager', '/administration/extensions/manager', '1', '1', 507, 50709, 1);
 

--- a/www/install/php/Update-22.04.1.php
+++ b/www/install/php/Update-22.04.1.php
@@ -33,8 +33,13 @@ try {
     $errorMessage = "Unable to update 'custom_configuration' column on 'provider_configuration' table";
     updateOpenIdConfiguration($pearDB);
 
-    $errorMessage = "Unable to update poller wizard ACL";
-    removePollerWizardAcl($pearDB);
+    $errorMessage = "Unable to remove poller wizard ACL options";
+    $pearDB->query(
+        "DELETE acl_topology_relations, topology
+        FROM acl_topology_relations
+        INNER JOIN topology on topology.topology_id = acl_topology_relations.topology_topology_id
+        WHERE topology.topology_parent = 60901"
+    );
 
     $pearDB->commit();
 } catch (\Exception $e) {
@@ -79,24 +84,4 @@ function updateOpenIdConfiguration(CentreonDB $pearDB): void
     } else {
         throw new \Exception('No custom_configuration for open_id has been found');
     }
-}
-
-/**
- * Remove ACL menu access to poller wizard individual steps
- *
- * @param CentreonDB $pearDB
- * @throws \Exception
- */
-function removePollerWizardAcl(CentreonDB $pearDB): void
-{
-    $statement = $pearDB->query("SELECT topology_id FROM topology WHERE topology_parent = 60901");
-    if ($statement !== false && $topologyIds = $statement->fetchAll(\PDO::FETCH_COLUMN, 0)) {
-        $statement = $pearDB->prepare(
-            "DELETE FROM acl_topology_relations WHERE topology_topology_id IN (:topologyIds)"
-        );
-        $statement->bindValue(':topologyIds', implode(',', $topologyIds), \PDO::PARAM_STR);
-        $statement->execute();
-    }
-
-    $pearDB->query("DELETE FROM topology WHERE topology_parent = 60901");
 }

--- a/www/install/php/Update-22.04.1.php
+++ b/www/install/php/Update-22.04.1.php
@@ -91,7 +91,7 @@ function removePollerWizardAcl(CentreonDB $pearDB): void
 {
     $statement = $pearDB->query("SELECT topology_id FROM topology WHERE topology_parent = 60901");
     if ($statement !== false && $topologyIds = $statement->fetchAll(\PDO::FETCH_COLUMN, 0)) {
-         $statement = $pearDB->prepare(
+        $statement = $pearDB->prepare(
             "DELETE FROM acl_topology_relations WHERE topology_topology_id IN (:topologyIds)"
         );
         $statement->bindValue(':topologyIds', implode(',', $topologyIds), \PDO::PARAM_STR);

--- a/www/install/php/Update-22.04.1.php
+++ b/www/install/php/Update-22.04.1.php
@@ -33,14 +33,6 @@ try {
     $errorMessage = "Unable to update 'custom_configuration' column on 'provider_configuration' table";
     updateOpenIdConfiguration($pearDB);
 
-    $errorMessage = "Unable to remove poller wizard ACL options";
-    $pearDB->query(
-        "DELETE acl_topology_relations, topology
-        FROM acl_topology_relations
-        INNER JOIN topology on topology.topology_id = acl_topology_relations.topology_topology_id
-        WHERE topology.topology_parent = 60901"
-    );
-
     $pearDB->commit();
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {

--- a/www/install/sql/centreon/Update-DB-22.04.1.sql
+++ b/www/install/sql/centreon/Update-DB-22.04.1.sql
@@ -1,0 +1,1 @@
+DELETE FROM topology WHERE topology_parent = 60901;

--- a/www/install/sql/centreon/Update-DB-22.04.1.sql
+++ b/www/install/sql/centreon/Update-DB-22.04.1.sql
@@ -1,1 +1,0 @@
-DELETE FROM topology WHERE topology_parent = '60901';

--- a/www/install/sql/centreon/Update-DB-22.04.1.sql
+++ b/www/install/sql/centreon/Update-DB-22.04.1.sql
@@ -1,0 +1,1 @@
+DELETE FROM topology WHERE topology_parent = '60901';


### PR DESCRIPTION
## Description
Remove useless wizard menu access:
![image](https://user-images.githubusercontent.com/88387848/173359519-07383e3b-60dc-414f-b972-19bff7e7eafe.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
