### PR TITLE
Sanitize and bind "timeperiod" configuration queries

### DIFF
--- a/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -97,8 +97,7 @@ function testTPExistence($name = null)
     #Modif case
     if ($statement->rowCount() >= 1 && $tp["tp_id"] == $id) {
         return true;
-    } #Duplicate entry
-    elseif ($statement->rowCount() >= 1 && $tp["tp_id"] != $id) {
+    } elseif ($statement->rowCount() >= 1 && $tp["tp_id"] != $id) { #Duplicate entry
         return false;
     } else {
         return true;

--- a/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -317,7 +317,7 @@ function insertTimeperiod($ret = array(), $exceptions = null)
     if (isset($my_tab['nbOfExceptions'])) {
         $already_stored = array();
         $query = "INSERT INTO timeperiod_exceptions (`timeperiod_id`, `days`, `timerange`) " .
-                 "VALUES (:timeperiod_id, LOWER(:days), :timerange)";
+                 "VALUES (:timeperiod_id, :days, :timerange)";
         $statement = $pearDB->prepare($query);
         for ($i = 0; $i <= $my_tab['nbOfExceptions']; $i++) {
             $exInput = "exceptionInput_" . $i;
@@ -326,7 +326,7 @@ function insertTimeperiod($ret = array(), $exceptions = null)
                 $my_tab[$exInput]
             ) {
                 $statement->bindValue(':timeperiod_id', (int) $tp_id['MAX(tp_id)'], \PDO::PARAM_INT);
-                $statement->bindValue(':days', $my_tab[$exInput], \PDO::PARAM_STR);
+                $statement->bindValue(':days', strtolower($my_tab[$exInput]), \PDO::PARAM_STR);
                 $statement->bindValue(':timerange', $my_tab[$exValue], \PDO::PARAM_STR);
                 $statement->execute();
                 $fields[$my_tab[$exInput]] = $my_tab[$exValue];

--- a/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -158,7 +158,7 @@ function multipleTimeperiodInDB($timeperiods = array(), $nbrDup = array())
                     'values' => $val,
                     'timeperiod_id' => $key
                 ];
-                $tpId = duplicateTimePeriods($params);
+                $tpId = duplicateTimePeriod($params);
                 $centreon->CentreonLogAction->insertLog("timeperiod", $tpId, $tp_name, "a", $fields);
             }
         }
@@ -472,7 +472,7 @@ function testTemplateLoop($value)
  * @param array $params
  * @return int
  */
-function duplicateTimePeriods(array $params): int
+function duplicateTimePeriod(array $params): int
 {
     global $pearDB;
 

--- a/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -137,15 +137,13 @@ function multipleTimeperiodInDB($timeperiods = array(), $nbrDup = array())
         $row = $dbResult->fetch();
         $row["tp_id"] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
+            $val = [];
             foreach ($row as $key2 => $value2) {
                 if ($key2 == "tp_name") {
                     $value2 .= "_" . $i;
                 }
                 $key2 == "tp_name" ? ($tp_name = $value2) : "";
-                $val
-                    ? $val .= ($value2 != null ? (", " . $value2) : ", NULL")
-                    : $val .= ($value2 != null ? ($value2) : "NULL");
+                $val[] = $value2 ?: null;
                 if ($key2 != "tp_id") {
                     $fields[$key2] = $value2;
                 }
@@ -322,7 +320,8 @@ function insertTimeperiod($ret = array(), $exceptions = null)
         for ($i = 0; $i <= $my_tab['nbOfExceptions']; $i++) {
             $exInput = "exceptionInput_" . $i;
             $exValue = "exceptionTimerange_" . $i;
-            if (isset($my_tab[$exInput]) && !isset($already_stored[strtolower($my_tab[$exInput])]) &&
+            if (
+                isset($my_tab[$exInput]) && !isset($already_stored[strtolower($my_tab[$exInput])]) &&
                 $my_tab[$exInput]
             ) {
                 $statement->bindValue(':timeperiod_id', (int) $tp_id['MAX(tp_id)'], \PDO::PARAM_INT);
@@ -506,9 +505,8 @@ function createTimePeriod(array $params): int
 {
     global $pearDB;
 
-    $valuesExploded = array_map('convertNullStringToNull', explode(', ', $params['values']));
     $queryBindValues = [];
-    foreach ($valuesExploded as $index => $value) {
+    foreach ($params['values'] as $index => $value) {
         $queryBindValues[':value_' . $index] = $value;
     }
     $bindValues = implode(', ', array_keys($queryBindValues));
@@ -576,15 +574,4 @@ function createTimePeriodsExceptions(array $params): void
     $statement->bindValue(':tp_id', $params['tp_id'], \PDO::PARAM_INT);
     $statement->bindValue(':timeperiod_id', (int) $params['timeperiod_id'], \PDO::PARAM_INT);
     $statement->execute();
-}
-
-/**
- * Converts a string null value to a null.
- *
- * @param string $value
- * @return string|null
- */
-function convertNullStringToNull(string $value)
-{
-    return $value === "NULL" ? null : $value;
 }

--- a/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -514,7 +514,7 @@ function createTimePeriod(array $params): int
     $bindValues = implode(', ', array_keys($queryBindValues));
     $statement = $pearDB->prepare("INSERT INTO timeperiod VALUES ($bindValues)");
     foreach ($queryBindValues as $bindKey => $bindValue) {
-        if(array_key_first($queryBindValues) === $bindKey) {
+        if (array_key_first($queryBindValues) === $bindKey) {
             $statement->bindValue($bindKey, (int) $bindValue, \PDO::PARAM_INT);
         } else {
             $statement->bindValue($bindKey, $bindValue, \PDO::PARAM_STR);

--- a/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -506,7 +506,7 @@ function createTimePeriod(array $params): int
 {
     global $pearDB;
 
-    $valuesExploded = array_map('notConvertNullToString', explode(', ', $params['values']));
+    $valuesExploded = array_map('convertNullStringToNull', explode(', ', $params['values']));
     $queryBindValues = [];
     foreach ($valuesExploded as $index => $value) {
         $queryBindValues[':value_' . $index] = $value;
@@ -584,7 +584,7 @@ function createTimePeriodsExceptions(array $params): void
  * @param string $value
  * @return string|null
  */
-function notConvertNullToString(string $value)
+function convertNullStringToNull(string $value)
 {
     return $value === "NULL" ? null : $value;
 }


### PR DESCRIPTION
## Description

Sanitizing and binding timeperiod queries to avoid any sql injections attacks in the future + cleaning up legacy code.

**Fixes** # MON-13314

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
