### PR TITLE
enh(acl) add poller access acl config

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -4324,5 +4324,5 @@ msgstr "Ejecuta el comando definido en la configuración del recopilador (Config
 #  msgid "Allows user to delete pollers."
 #  msgstr ""
 
-#  msgid "Allows user to generate and export configuration, and restart poller."
+#  msgid "Allows user to generate and export configuration."
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -4315,7 +4315,7 @@ msgstr "Ejecuta el comando definido en la configuración del recopilador (Config
 #  msgid "Deploy configuration"
 #  msgstr ""
 
-#  msgid "Poller configuration actions / Poller management"
+#  msgid "Poller Configuration Actions / Poller Management"
 #  msgstr ""
 
 #  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."

--- a/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -4324,5 +4324,5 @@ msgstr "Ejecuta el comando definido en la configuración del recopilador (Config
 #  msgid "Allows user to delete pollers."
 #  msgstr ""
 
-#  msgid "Allows user to generate and export configuration."
+#  msgid "Allows user to deploy configuration."
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -4305,3 +4305,24 @@ msgstr "Ejecuta el comando definido en la configuración del recopilador (Config
 
 #~ msgid "Additional Remote Server to which this server will be attached"
 #~ msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""
+
+#  msgid "Poller configuration actions / Poller management"
+#  msgstr ""
+
+#  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
+#  msgstr ""
+
+#  msgid "Allows user to delete pollers."
+#  msgstr ""
+
+#  msgid "Allows user to generate and export configuration, and restart poller."
+#  msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7219,3 +7219,24 @@ msgid "Mode used to retrieve information displayed in Resource Status page."
 "The optimized mode will only be available and functional when using the BBDO 3.0.0 protocol for the collect engine."
 msgstr "Mode utilisé pour récupérer les données affichées dans la page Resource Status."
 "Le mode optimisé pourra être utilisé et fonctionnel que si le moteur de supervision utilise le protocole BBDO 3.0.0"
+
+msgid "Poller configuration actions / Poller management"
+msgstr "Gestion des serveurs de collecte/collecteurs"
+
+msgid "Create and edit pollers"
+msgstr "Créer et modifier des collecteurs"
+
+msgid "Delete pollers"
+msgstr "Supprimer des collecteurs"
+
+msgid "Deploy configuration"
+msgstr "Déployer la configuration"
+
+msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
+msgstr "Permet aux utilisateurs de créer des collecteurs (boutons “Ajouter”, Ajouter (avancé)” et “Dupliquer”)"
+
+msgid "Allows user to delete pollers."
+msgstr "Permet aux utilisateurs de supprimer des collecteurs"
+
+msgid "Allows user to generate and export configuration, and restart poller."
+msgstr "Permet aux utilisateurs de déployer la configuration de la supervision sur les collecteurs."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7239,4 +7239,4 @@ msgid "Allows user to delete pollers."
 msgstr "Permet à l'utilisateur de supprimer des collecteurs."
 
 msgid "Allows user to deploy configuration."
-msgstr "Permet aux utilisateurs de déployer la configuration de la supervision sur les collecteurs."
+msgstr "Permet à l'utilisateur de déployer la configuration."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7220,8 +7220,8 @@ msgid "Mode used to retrieve information displayed in Resource Status page."
 msgstr "Mode utilisé pour récupérer les données affichées dans la page Resource Status."
 "Le mode optimisé pourra être utilisé et fonctionnel que si le moteur de supervision utilise le protocole BBDO 3.0.0"
 
-msgid "Poller configuration actions / Poller management"
-msgstr "Gestion des serveurs de collecte/collecteurs"
+msgid "Poller Configuration Actions / Poller Management"
+msgstr "Actions de configuration du collecteur / Gestion du collecteur"
 
 msgid "Create and edit pollers"
 msgstr "Créer et modifier des collecteurs"
@@ -7233,10 +7233,10 @@ msgid "Deploy configuration"
 msgstr "Déployer la configuration"
 
 msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
-msgstr "Permet aux utilisateurs de créer des collecteurs (boutons “Ajouter”, Ajouter (avancé)” et “Dupliquer”)"
+msgstr "Permet aux utilisateurs de créer des collecteurs (boutons Ajouter, Ajouter (avancé) et Dupliquer)."
 
 msgid "Allows user to delete pollers."
-msgstr "Permet aux utilisateurs de supprimer des collecteurs"
+msgstr "Permet aux utilisateurs de supprimer des collecteurs."
 
 msgid "Allows user to deploy configuration."
 msgstr "Permet aux utilisateurs de déployer la configuration de la supervision sur les collecteurs."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7238,5 +7238,5 @@ msgstr "Permet aux utilisateurs de créer des collecteurs (boutons “Ajouter”
 msgid "Allows user to delete pollers."
 msgstr "Permet aux utilisateurs de supprimer des collecteurs"
 
-msgid "Allows user to generate and export configuration."
+msgid "Allows user to deploy configuration."
 msgstr "Permet aux utilisateurs de déployer la configuration de la supervision sur les collecteurs."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7233,7 +7233,7 @@ msgid "Deploy configuration"
 msgstr "Déployer la configuration"
 
 msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
-msgstr "Permet aux utilisateurs de créer des collecteurs (boutons Ajouter, Ajouter (avancé) et Dupliquer)."
+msgstr "Permet à l'utilisateur de créer des collecteurs (boutons Ajouter, Ajouter (avancé) et Dupliquer)."
 
 msgid "Allows user to delete pollers."
 msgstr "Permet aux utilisateurs de supprimer des collecteurs."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7238,5 +7238,5 @@ msgstr "Permet aux utilisateurs de créer des collecteurs (boutons “Ajouter”
 msgid "Allows user to delete pollers."
 msgstr "Permet aux utilisateurs de supprimer des collecteurs"
 
-msgid "Allows user to generate and export configuration, and restart poller."
+msgid "Allows user to generate and export configuration."
 msgstr "Permet aux utilisateurs de déployer la configuration de la supervision sur les collecteurs."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7236,7 +7236,7 @@ msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate�
 msgstr "Permet à l'utilisateur de créer des collecteurs (boutons Ajouter, Ajouter (avancé) et Dupliquer)."
 
 msgid "Allows user to delete pollers."
-msgstr "Permet aux utilisateurs de supprimer des collecteurs."
+msgstr "Permet à l'utilisateur de supprimer des collecteurs."
 
 msgid "Allows user to deploy configuration."
 msgstr "Permet aux utilisateurs de déployer la configuration de la supervision sur les collecteurs."

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -6657,7 +6657,7 @@ msgstr ""
 #~ msgstr ""
 
 
-#  msgid "Poller configuration actions / Poller management"
+#  msgid "Poller Configuration Actions / Poller Management"
 #  msgstr ""
 
 #  msgid "Create and edit pollers"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -6675,5 +6675,5 @@ msgstr ""
 #  msgid "Allows user to delete pollers."
 #  msgstr ""
 
-#  msgid "Allows user to generate and export configuration."
+#  msgid "Allows user to deploy configuration."
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -6675,5 +6675,5 @@ msgstr ""
 #  msgid "Allows user to delete pollers."
 #  msgstr ""
 
-#  msgid "Allows user to generate and export configuration, and restart poller."
+#  msgid "Allows user to generate and export configuration."
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -6655,3 +6655,25 @@ msgstr ""
 
 #~ msgid "Additional Remote Server to which this server will be attached"
 #~ msgstr ""
+
+
+#  msgid "Poller configuration actions / Poller management"
+#  msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""
+
+#  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
+#  msgstr ""
+
+#  msgid "Allows user to delete pollers."
+#  msgstr ""
+
+#  msgid "Allows user to generate and export configuration, and restart poller."
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -4794,5 +4794,5 @@ msgstr ""
 #  msgid "Allows user to delete pollers."
 #  msgstr ""
 
-#  msgid "Allows user to generate and export configuration, and restart poller."
+#  msgid "Allows user to generate and export configuration."
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -4794,5 +4794,5 @@ msgstr ""
 #  msgid "Allows user to delete pollers."
 #  msgstr ""
 
-#  msgid "Allows user to generate and export configuration."
+#  msgid "Allows user to deploy configuration."
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -4775,3 +4775,24 @@ msgstr ""
 
 #  msgid "Disacknowledgement command sent"
 #  msgid ""
+
+#  msgid "Poller configuration actions / Poller management"
+#  msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""
+
+#  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
+#  msgstr ""
+
+#  msgid "Allows user to delete pollers."
+#  msgstr ""
+
+#  msgid "Allows user to generate and export configuration, and restart poller."
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -4776,7 +4776,7 @@ msgstr ""
 #  msgid "Disacknowledgement command sent"
 #  msgid ""
 
-#  msgid "Poller configuration actions / Poller management"
+#  msgid "Poller Configuration Actions / Poller Management"
 #  msgstr ""
 
 #  msgid "Create and edit pollers"

--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -50,7 +50,7 @@
         <tr class="ToolbarTR">
             <td>
                 {if !$isRemote}
-                    {if $mode_access == 'w'}
+                    {if $mode_access == 'w' && $can_create_edit == 1}
                         <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" isreact="true" target="_top">
                             {$wizardAddBtn.icon} {$wizardAddBtn.text}
                         </a>
@@ -58,19 +58,23 @@
                             {$addBtn.icon} {$addBtn.text}
                         </a>
                     {/if}
-                    {if $is_admin == 1 || $can_generate == 1}
+                    {if $can_generate == 1}
                          <button type="button" class="{$exportBtn.class}" name="{$exportBtn.name}"
                              onClick="{$exportBtn.onClickAction}">
                              {$exportBtn.icon} {$exportBtn.text}
                          </button>
                     {/if}
                     {if $mode_access == 'w'}
-                        <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
-                            {$duplicateBtn.icon} {$duplicateBtn.text}
-                        </button>
-                        <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
-                            {$deleteBtn.icon} {$deleteBtn.text}
-                        </button>
+                        {if $can_create_edit == 1}
+                            <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
+                                {$duplicateBtn.icon} {$duplicateBtn.text}
+                            </button>
+                        {/if}
+                        {if $can_delete == 1}
+                            <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
+                                {$deleteBtn.icon} {$deleteBtn.text}
+                            </button>
+                        {/if}
                     {/if}
                 {/if}
             </td>

--- a/www/include/configuration/configServers/listServers.php
+++ b/www/include/configuration/configServers/listServers.php
@@ -65,15 +65,9 @@ if ($search) {
 }
 
 // Get Authorized Actions
-if ($is_admin == 0) {
-    if ($centreon->user->access->checkAction('generate_cfg')) {
-        $can_generate = 1;
-    } else {
-        $can_generate = 0;
-    }
-} else {
-    $can_generate = 0;
-}
+$can_generate = $centreon->user->access->checkAction('generate_cfg');
+$can_create_edit = $centreon->user->access->checkAction('create_edit_poller_cfg');
+$can_delete = $centreon->user->access->checkAction('delete_poller_cfg');
 
 /*
  * nagios servers comes from DB
@@ -382,6 +376,8 @@ if (!$isRemote) {
 $tpl->assign('limit', $limit);
 $tpl->assign('searchP', $search);
 $tpl->assign("can_generate", $can_generate);
+$tpl->assign("can_create_edit", $can_create_edit);
+$tpl->assign("can_delete", $can_delete);
 $tpl->assign("is_admin", $is_admin);
 $tpl->assign("isRemote", $isRemote);
 

--- a/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -411,6 +411,8 @@ function listActions()
     $actions[] = "global_host_obsess";
     $actions[] = "global_perf_data";
 
+    $actions[] = "create_edit_poller_cfg";
+    $actions[] = "delete_poller_cfg";
     $actions[] = "generate_cfg";
     $actions[] = "generate_trap";
 

--- a/www/include/options/accessLists/actionsACL/formActionsAccess.ihtml
+++ b/www/include/options/accessLists/actionsACL/formActionsAccess.ihtml
@@ -19,7 +19,7 @@
           <td class="FormHeader" colspan="2">
             <h3>| {$form.header.title}</h3>
           </td>
-        </tr>	 	
+        </tr>
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$form.header.information}</h4>
@@ -34,7 +34,7 @@
           </td>
         </tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="tip_linked_groups">{$form.acl_groups.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.acl_groups.html}</p></td></tr>
-	 	
+
 	 	<!-- Global -->
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
@@ -48,12 +48,29 @@
 		<!-- Config -->
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
-            <h4>{t}Configuration Actions{/t}</h4>
+            <h4>{$form.header.poller_cfg_access}</h4>
           </td>
         </tr>
-	 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="tip_display_generate_cfg">{$form.generate_cfg.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.generate_cfg.html}</p></td></tr>
+		<tr class="list_one">
+			<td class="FormRowField"><img class="helpTooltip" name="create_edit_pollers">{$form.create_edit_poller_cfg.label}</td>
+			<td class="FormRowValue">
+				<p class="oreonbutton">{$form.create_edit_poller_cfg.html}</p>
+			</td>
+		</tr>
+		<tr class="list_two">
+			<td class="FormRowField"><img class="helpTooltip" name="delete_pollers">{$form.delete_poller_cfg.label}</td>
+			<td class="FormRowValue">
+				<p class="oreonbutton">{$form.delete_poller_cfg.html}</p>
+			</td>
+		</tr>
+		<tr class="list_one">
+			<td class="FormRowField"><img class="helpTooltip" name="deploy_pollers">{$form.generate_cfg.label}</td>
+			<td class="FormRowValue">
+				<p class="oreonbutton">{$form.generate_cfg.html}</p>
+			</td>
+		</tr>
 	 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="tip_display_generate_trap">{$form.generate_trap.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.generate_trap.html}</p></td></tr>
-	 	
+
 		<!-- Global External Command -->
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="1">
@@ -75,7 +92,7 @@
 	 	<tr class="list_two engineCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_enable_obsessive_service_checks">{$form.global_service_obsess.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.global_service_obsess.html}</p></td></tr>
 	 	<tr class="list_one engineCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_enable_obsessive_host_checks">{$form.global_host_obsess.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.global_host_obsess.html}</p></td></tr>
 	 	<tr class="list_two engineCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_enable_performance_data">{$form.global_perf_data.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.global_perf_data.html}</p></td></tr>
-	 	
+
 	 	<!-- Services -->
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="1">
@@ -102,7 +119,7 @@
 		{/if}
 		<tr class="list_two serviceCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_submit_result_for_a_service">{$form.service_submit_result.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.service_submit_result.html}</p></td></tr>
         <tr class="list_one serviceCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_display_command_for_a_service">{$form.service_display_command.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.service_display_command.html}</p></td></tr>
-		 
+
 		<!-- Hosts -->
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="1">
@@ -117,9 +134,9 @@
 			<tr class="list_two hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_enable_disable_notifications_for_a_host">{$form.host_notifications.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_notifications.html}</p></td></tr>
 	 	{/if}
 		<tr class="list_one hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_acknowledge_a_host">{$form.host_acknowledgement.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_acknowledgement.html}</p></td></tr>
-        <tr class="list_two hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_disacknowledge_a_host">{$form.host_disacknowledgement.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_disacknowledgement.html}</p></td></tr>	
-		<tr class="list_one hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_schedule_the_check_for_a_host">{$form.host_schedule_check.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_schedule_check.html}</p></td></tr>	
-		<tr class="list_two hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_schedule_the_check_for_a_host_forced">{$form.host_schedule_forced_check.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_schedule_forced_check.html}</p></td></tr>	
+        <tr class="list_two hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_disacknowledge_a_host">{$form.host_disacknowledgement.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_disacknowledgement.html}</p></td></tr>
+		<tr class="list_one hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_schedule_the_check_for_a_host">{$form.host_schedule_check.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_schedule_check.html}</p></td></tr>
+		<tr class="list_two hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_schedule_the_check_for_a_host_forced">{$form.host_schedule_forced_check.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_schedule_forced_check.html}</p></td></tr>
 		<tr class="list_one hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_schedule_downtime_for_a_host">{$form.host_schedule_downtime.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_schedule_downtime.html}</p></td></tr>
 		<tr class="list_two hostCheckbox"><td class="FormRowField"><img class="helpTooltip" name="tip_add_delete_a_comment_for_a_host">{$form.host_comment.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.host_comment.html}</p></td></tr>
 	 	{if $serverIsMaster}
@@ -136,7 +153,7 @@
           </td>
         </tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="tip_status">{$form.acl_action_activate.label}</td><td class="FormRowValue">{$form.acl_action_activate.html}</td></tr>
-		
+
 		{if $o == "a" || $o == "c"}
 			<tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">
                 {if isset($form.required)}

--- a/www/include/options/accessLists/actionsACL/formActionsAccess.php
+++ b/www/include/options/accessLists/actionsACL/formActionsAccess.php
@@ -173,7 +173,9 @@ $form->addElement('checkbox', 'poller_stats', _("Display Top Counter pollers sta
 $form->addElement('checkbox', 'poller_listing', _("Display Poller Listing"));
 
 // Configuration Actions
-$form->addElement('checkbox', 'generate_cfg', _("Generate Configuration Files"));
+$form->addElement('checkbox', 'create_edit_poller_cfg', _("Create and edit pollers"));
+$form->addElement('checkbox', 'delete_poller_cfg', _("Delete pollers"));
+$form->addElement('checkbox', 'generate_cfg', _("Deploy configuration Files"));
 $form->addElement('checkbox', 'generate_trap', _("Generate SNMP Trap configuration"));
 
 $form->addElement('checkbox', 'all_service', "");
@@ -189,6 +191,7 @@ $form->addElement('header', 'service_actions', _("Services Actions Access"));
 $form->addElement('header', 'host_actions', _("Hosts Actions Access"));
 $form->addElement('header', 'global_actions', _("Global Monitoring Engine Actions (External Process Commands)"));
 $form->addElement('header', 'global_access', _("Global Functionalities Access"));
+$form->addElement('header', 'poller_cfg_access', _("Poller configuration actions / Poller management"));
 
 $ams1 = $form->addElement('advmultiselect', 'acl_groups', _("Linked Groups"), $groups, $attrsAdvSelect, SORT_ASC);
 $ams1->setButtonAttributes('add', array('value' => _("Add"), "class" => "btc bt_success"));

--- a/www/include/options/accessLists/actionsACL/formActionsAccess.php
+++ b/www/include/options/accessLists/actionsACL/formActionsAccess.php
@@ -191,7 +191,7 @@ $form->addElement('header', 'service_actions', _("Services Actions Access"));
 $form->addElement('header', 'host_actions', _("Hosts Actions Access"));
 $form->addElement('header', 'global_actions', _("Global Monitoring Engine Actions (External Process Commands)"));
 $form->addElement('header', 'global_access', _("Global Functionalities Access"));
-$form->addElement('header', 'poller_cfg_access', _("Poller configuration actions / Poller management"));
+$form->addElement('header', 'poller_cfg_access', _("Poller Configuration Actions / Poller Management"));
 
 $ams1 = $form->addElement('advmultiselect', 'acl_groups', _("Linked Groups"), $groups, $attrsAdvSelect, SORT_ASC);
 $ams1->setButtonAttributes('add', array('value' => _("Add"), "class" => "btc bt_success"));

--- a/www/include/options/accessLists/actionsACL/help.php
+++ b/www/include/options/accessLists/actionsACL/help.php
@@ -44,7 +44,7 @@ $help['delete_pollers'] = dgettext(
 );
 $help['deploy_pollers'] = dgettext(
     'help',
-    'Allows user to generate and export configuration, and restart poller.'
+    'Allows user to generate and export configuration.'
 );
 $help['tip_display_generate_trap'] = dgettext(
     'help',

--- a/www/include/options/accessLists/actionsACL/help.php
+++ b/www/include/options/accessLists/actionsACL/help.php
@@ -44,7 +44,7 @@ $help['delete_pollers'] = dgettext(
 );
 $help['deploy_pollers'] = dgettext(
     'help',
-    'Allows user to generate and export configuration.'
+    'Allows user to deploy configuration.'
 );
 $help['tip_display_generate_trap'] = dgettext(
     'help',

--- a/www/include/options/accessLists/actionsACL/help.php
+++ b/www/include/options/accessLists/actionsACL/help.php
@@ -32,9 +32,17 @@ $help['tip_display_poller_listing'] = dgettext(
 );
 
 /**
- * Generation of files
+ * Poller configuration - Generation of configuration files
  */
-$help['tip_display_generate_cfg'] = dgettext(
+$help['create_edit_pollers'] = dgettext(
+    'help',
+    'Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers.'
+);
+$help['delete_pollers'] = dgettext(
+    'help',
+    'Allows user to delete pollers.'
+);
+$help['deploy_pollers'] = dgettext(
     'help',
     'Allows user to generate and export configuration, and restart poller.'
 );


### PR DESCRIPTION
## Description

Adapt ACL granularity to allow non-admin users to delete, export config, create/edit pollers.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
