### PR TITLE
enh(Resources/legend): Do not display brackets when a metric does not have unit

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -312,7 +312,7 @@ const LegendContent = ({
                       component="p"
                       variant="caption"
                     >
-                      {`(${line.unit})`}
+                      {!isNil(line.unit) ? `(${line.unit})` : null}
                     </Typography>
                   </div>
                   {formattedValue ? (

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -2,7 +2,17 @@
 import { MouseEvent } from 'react';
 
 import clsx from 'clsx';
-import { equals, find, gt, includes, isNil, length, slice, split } from 'ramda';
+import {
+  equals,
+  find,
+  gt,
+  includes,
+  isNil,
+  length,
+  slice,
+  split,
+  isEmpty,
+} from 'ramda';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue } from 'jotai/utils';
 
@@ -312,7 +322,7 @@ const LegendContent = ({
                       component="p"
                       variant="caption"
                     >
-                      {!isNil(line.unit) ? `(${line.unit})` : null}
+                      {!isEmpty(line?.unit) ? `(${line.unit})` : null}
                     </Typography>
                   </div>
                   {formattedValue ? (

--- a/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Legend/index.tsx
@@ -322,7 +322,7 @@ const LegendContent = ({
                       component="p"
                       variant="caption"
                     >
-                      {!isEmpty(line?.unit) ? `(${line.unit})` : null}
+                      {!isEmpty(line?.unit) && `(${line.unit})`}
                     </Typography>
                   </div>
                   {formattedValue ? (


### PR DESCRIPTION
Do not display brackets when a metric does not have unit
**some screens :** 

![unitShow](https://user-images.githubusercontent.com/97687698/173846018-2623723b-6e23-4c22-a23d-828ac6ba5408.PNG)

![unitoo](https://user-images.githubusercontent.com/97687698/173846060-de51f7e4-b9f3-498c-a15b-5375b820247d.PNG)

