### PR TITLE
fix (ui)  : Fixed bug icones svg are not supported in browser firefox

### DIFF
--- a/www/include/common/javascript/xslt.js
+++ b/www/include/common/javascript/xslt.js
@@ -378,3 +378,23 @@ function browserSupportsXSLT() {
     }
     return support;
 }
+
+/**
+ * Displaying SVGs on browsers other than chrome.
+ *
+ * @return void
+ */
+
+function displaySvgOnXSL()
+{
+    if (!browserSupportsXSLT()) {
+        return;
+    }
+    if (navigator.userAgent.indexOf("Chrome") === -1) {
+        var nodes = document.getElementsByClassName("svgs");
+        for (var i = nodes.length - 1; i >= 0; i--) {
+
+            nodes[i].innerHTML = nodes[i].textContent;
+        }
+    }
+}

--- a/www/include/common/javascript/xslt.js
+++ b/www/include/common/javascript/xslt.js
@@ -384,7 +384,6 @@ function browserSupportsXSLT() {
  *
  * @return void
  */
-
 function displaySvgOnXSL()
 {
     if (!browserSupportsXSLT()) {

--- a/www/include/common/javascript/xslt.js
+++ b/www/include/common/javascript/xslt.js
@@ -391,8 +391,8 @@ function displaySvgOnXSL()
         return;
     }
     if (navigator.userAgent.indexOf("Chrome") === -1) {
-        var nodes = document.getElementsByClassName("svgs");
-        for (var i = nodes.length - 1; i >= 0; i--) {
+        let nodes = document.getElementsByClassName("svgs");
+        for (let i = nodes.length - 1; i >= 0; i--) {
 
             nodes[i].innerHTML = nodes[i].textContent;
         }

--- a/www/include/common/javascript/xslt.js
+++ b/www/include/common/javascript/xslt.js
@@ -392,7 +392,6 @@ function displaySvgOnXSL()
     if (navigator.userAgent.indexOf("Chrome") === -1) {
         let nodes = document.getElementsByClassName("svgs");
         for (let i = nodes.length - 1; i >= 0; i--) {
-
             nodes[i].innerHTML = nodes[i].textContent;
         }
     }

--- a/www/include/monitoring/status/Hosts/xsl/host.xsl
+++ b/www/include/monitoring/status/Hosts/xsl/host.xsl
@@ -179,7 +179,10 @@
 			</xsl:if>
 			<xsl:element name="a">
 				<xsl:attribute name="href">./main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+				<xsl:element name="span">
+					<xsl:attribute name="class">svgs</xsl:attribute>
+					<xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+				</xsl:element>
 			</xsl:element>
 			
 		</td>
@@ -205,5 +208,8 @@
 </xsl:for-each>
 </table>
 <div id="div_popup" class="popup_volante"><div class="container-load"></div><div id="popup-container-display"></div></div>
+<script type="text/javascript">
+	$(displaySvgOnXSL());
+</script>
 </xsl:template>
 </xsl:stylesheet>

--- a/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/www/include/monitoring/status/Services/xsl/service.xsl
@@ -297,7 +297,10 @@
             <xsl:if test="svc_index &gt; 0">
                 <xsl:element name="a">
                     <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>
+                    <xsl:element name="span">
+                        <xsl:attribute name="class">svgs</xsl:attribute>
                         <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                    </xsl:element>
                 </xsl:element>
             </xsl:if>
         </td>
@@ -339,5 +342,8 @@
 </table>
 <div id="div_img" class="img_volante"></div>
 <div id="div_popup" class="popup_volante"><div class="container-load"></div><div id="popup-container-display"></div></div>
+<script type="text/javascript">
+    $(displaySvgOnXSL());
+</script>
 </xsl:template>
 </xsl:stylesheet>

--- a/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
@@ -42,7 +42,10 @@
                         </xsl:element>
                         <xsl:element name="a">
                             <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                            <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                            <xsl:element name="span">
+                                <xsl:attribute name="class">svgs</xsl:attribute>
+                                <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                            </xsl:element>
                         </xsl:element>
                     </td>
                     <xsl:if test="//i/s = 1">
@@ -77,5 +80,8 @@
             <div class="container-load"></div>
             <div id="popup-container-display"></div>
         </div>
+        <script type="text/javascript">
+            $(displaySvgOnXSL());
+        </script>
     </xsl:template>
 </xsl:stylesheet>

--- a/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
@@ -36,7 +36,10 @@
 			</xsl:element>
 			<xsl:element name="a">
 			  	<xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                <xsl:element name="span">
+                    <xsl:attribute name="class">svgs</xsl:attribute>
+                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                </xsl:element>
 			</xsl:element>
 		</td>
 		<td class='ListColCenter'>
@@ -101,5 +104,8 @@
 </xsl:for-each>
 </table>
 <div id="div_popup" class="popup_volante"><div class="container-load"></div><div id="popup-container-display"></div></div>
+<script type="text/javascript">
+    $(displaySvgOnXSL());
+</script>
 </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
## Description
Firefox is replacing icons svg  with strange symbols
**Fixes** # MON-13441

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
