### PR TITLE
fix(ui): Tooltip in PPM is not visible in dark mode

### DIFF
--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -133,8 +133,8 @@
     --WzBodyI-font-color: var(--color-white);
     --WzTtDi-border-color: var(--body-color);
     --wzclose-font-color: var(--color-primary-light);
-    --wzclose-background-color : var(--wzclose-font-color);
-    --wzclose-border-color : var(--body-background);
+    --wzclose-background-color : var(--body-background);
+    --wzclose-border-color : var(--wzclose-font-color);
     --pluginpack-block-h2-font-color: var(--body-color);
     --pp-can-be-installed-border-color: var(--body-color);
     --pp-bottom-border-top-color: var(--pp-can-be-installed-border-color);
@@ -171,7 +171,7 @@
     --ui-timepicker-minute-cell-background-color: var(--color-cinder);
     --ui-timepicker-minute-cell-border-color: var(--body-color);
     --ui-timepicker-minute-cell-font-color: var(--color-white);
-    --jquery-ui-widget-content-background-color: var(--body-color);
+    --jquery-ui-widget-content-background-color: var(--body-background);
     --view-body-ui-widget-header-font-color: var(--color-white);
     --update-font-color: var(--color-black);
     --tabs-periods-background-color: var(--body-background);


### PR DESCRIPTION
## Description

Some hover tooltips were invisible because they shared the same color as foreground color, this should take care of it.
Preview:
Before
![image](https://user-images.githubusercontent.com/97593234/174103747-f6b45741-10f9-473e-9c8f-065464a8b741.png)
After
![image](https://user-images.githubusercontent.com/97593234/174103961-7510b9d7-4862-4576-94de-ad089d061cd1.png)


**Fixes** # MON-13984

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
