### PR TITLE
fix(upgrade): check mariadb prerequisites only if db connection is up

### DIFF
--- a/www/install/steps/process/process_step6.php
+++ b/www/install/steps/process/process_step6.php
@@ -83,6 +83,7 @@ try {
         $parameters['root_password']
     );
     checkMariaDBPrerequisite($link);
+    $link = null;
 } catch (\Exception $e) {
     if ($e instanceof \PDOException && (int) $e->getCode() === SQL_ERROR_CODE_ACCESS_DENIED) {
         $err['connection'] =
@@ -94,8 +95,6 @@ try {
         $err['connection'] = $e->getMessage();
     }
 }
-
-$link = null;
 
 if (!count($err['required']) && $err['password'] && trim($err['connection']) == '') {
     $step = new \CentreonLegacy\Core\Install\Step\Step6($dependencyInjector);

--- a/www/install/steps/process/process_step6.php
+++ b/www/install/steps/process/process_step6.php
@@ -67,6 +67,8 @@ if (!in_array('db_password', $err['required']) && !in_array('db_password_confirm
     $err['password'] = false;
 }
 
+$link = null;
+
 try {
     if ($parameters['address'] == "") {
         $parameters['address'] = "localhost";
@@ -94,12 +96,13 @@ try {
     }
 }
 
-try {
-    checkMariaDBPrerequisite($link);
-} catch (\Exception $e) {
-    $err['connection'] = $e->getMessage();
+if ($link !== null) {
+    try {
+        checkMariaDBPrerequisite($link);
+    } catch (\Exception $e) {
+        $err['connection'] = $e->getMessage();
+    }
 }
-
 
 $link = null;
 

--- a/www/install/steps/process/process_step6.php
+++ b/www/install/steps/process/process_step6.php
@@ -67,8 +67,6 @@ if (!in_array('db_password', $err['required']) && !in_array('db_password_confirm
     $err['password'] = false;
 }
 
-$link = null;
-
 try {
     if ($parameters['address'] == "") {
         $parameters['address'] = "localhost";
@@ -84,22 +82,15 @@ try {
         $parameters['root_user'],
         $parameters['root_password']
     );
-} catch (\PDOException $e) {
-    if ((int) $e->getCode() === SQL_ERROR_CODE_ACCESS_DENIED) {
+    checkMariaDBPrerequisite($link);
+} catch (\Exception $e) {
+    if ($e instanceof \PDOException && (int) $e->getCode() === SQL_ERROR_CODE_ACCESS_DENIED) {
         $err['connection'] =
             'Please check the root database username and password. '
             . 'If the problem persists, check that you have properly '
             . '<a target="_blank" href="https://docs.centreon.com/docs/installation'
             . '/installation-of-a-central-server/using-packages/#secure-the-database">secured your DBMS</a>';
     } else {
-        $err['connection'] = $e->getMessage();
-    }
-}
-
-if ($link !== null) {
-    try {
-        checkMariaDBPrerequisite($link);
-    } catch (\Exception $e) {
         $err['connection'] = $e->getMessage();
     }
 }


### PR DESCRIPTION
## Description

check mariadb prerequisites only if db connection is up

**Fixes** MON-13322

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)