### PR TITLE
Sanitize and bind queries in virtual metrics configuration

### DIFF
--- a/www/include/views/virtualMetrics/DB-Func.php
+++ b/www/include/views/virtualMetrics/DB-Func.php
@@ -486,7 +486,7 @@ function &disableVirtualMetric($v_id = null, $force = 0)
     $repB = array("\\\\*", "\\\\+", "\\\\-", "\\\\?", "\\\\^", "\\\\$");
     $l_where = ($force == 0) ? " AND `vmetric_activate` = '1'" : "";
     $statement = $pearDB->prepare(
-        "SELECT index_id, vmetric_name FROM `virtual_metrics` WHERE `vmetric_id`=:vmetric_id$l_where;"
+        "SELECT index_id, vmetric_name FROM `virtual_metrics` WHERE `vmetric_id`=:vmetric_id$l_where"
     );
     $statement->bindValue(':vmetric_id', (int) $v_id, \PDO::PARAM_INT);
     $statement->execute();


### PR DESCRIPTION
## Description

Sanitizing and binding virtual metrics queries to avoid any sql injections attacks in the future and cleaning legacy code.

Preview:
![image](https://user-images.githubusercontent.com/97593234/174691605-101e40d0-4d63-4bda-a845-db27293c73d4.png)


**Fixes** # MON-13944

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
