### PR TITLE
Bugfix/purgeengine regex

### DIFF
--- a/www/class/centreonPurgeEngine.class.php
+++ b/www/class/centreonPurgeEngine.class.php
@@ -156,7 +156,7 @@ class CentreonPurgeEngine
             $row = $DBRESULT->fetchRow();
             $matches = [];
             // dont care of MAXVALUE
-            if (preg_match_all('/PARTITION `(.*?)` VALUES LESS THAN \((.*?)\)/', $row['Create Table'], $matches)) {
+            if (preg_match_all('/PARTITION (.*?) VALUES LESS THAN \((.*?)\)/', $row['Create Table'], $matches)) {
                 $this->tablesToPurge[$name]['is_partitioned'] = true;
                 $this->tablesToPurge[$name]['partitions'] = [];
                 for ($i = 0; isset($matches[1][$i]); $i++) {


### PR DESCRIPTION
## Description

When running the cron script to purge centstorage data, the partitions are not being detected.

This is fixed on the regex that has extra backticks and does not recognize properly the values for the last created partition.

**Fixes**
#11122

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. On any install execute the script : /usr/share/centreon/cron/centstorage_purge.php
2. The log should show many entries with "Partition will be delete"

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
