### PR TITLE
fix(conf) add warning when max length is exceeded for url, url action or notes

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15179,5 +15179,5 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15178,3 +15178,6 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
+
+#  msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+#  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15179,5 +15179,5 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15179,5 +15179,5 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15179,5 +15179,5 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
 #  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15179,5 +15179,5 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16923,3 +16923,6 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
+
+msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+msgstr "Attention, taille maximale dépassées pour le champ #input#, il sera tronqué à l'enregistrement."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16924,5 +16924,5 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
 
-msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
-msgstr "Attention, taille maximale dépassée pour le champ #input#, il sera tronqué à l'enregistrement."
+msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
+msgstr "Attention, taille maximale dépassée pour le champ #input# (max: #maxLength#), il sera tronqué à l'enregistrement."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16924,5 +16924,5 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
 
-msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
-msgstr "Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera tronqué à l'enregistrement."
+msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
+msgstr "Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera tronqué à l'enregistrement"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16924,5 +16924,5 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
 
-msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
 msgstr "Attention, taille maximale dépassée pour le champ #input#, il sera tronqué à l'enregistrement."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16924,5 +16924,5 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
 
-msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
-msgstr "Attention, taille maximale dépassée pour le champ #input# (max: #maxLength#), il sera tronqué à l'enregistrement."
+msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
+msgstr "Attention, taille maximale dépassée pour le champ '#input#' (max: #maxLength#), il sera tronqué à l'enregistrement."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16925,4 +16925,4 @@ msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
 
 msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
-msgstr "Attention, taille maximale dépassées pour le champ #input#, il sera tronqué à l'enregistrement."
+msgstr "Attention, taille maximale dépassée pour le champ #input#, il sera tronqué à l'enregistrement."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16924,5 +16924,5 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
 
-msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
-msgstr "Attention, taille maximale dépassée pour le champ '#input#' (max: #maxLength#), il sera tronqué à l'enregistrement."
+msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
+msgstr "Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera tronqué à l'enregistrement."

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15630,5 +15630,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15630,5 +15630,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
 
-#  msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15630,5 +15630,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
 
-#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15630,5 +15630,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15630,5 +15630,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15629,3 +15629,6 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
+
+#  msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15618,5 +15618,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15617,3 +15617,6 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
+
+#  msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15618,5 +15618,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15618,5 +15618,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15618,5 +15618,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving."
 #  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15618,5 +15618,5 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
 
-#  msgid "Warning, maximum size exceeded for input #input#, it will be be truncated upon saving."
+#  msgid "Warning, maximum size exceeded for input #input#, it will be truncated upon saving."
 #  msgstr ""

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -252,12 +252,20 @@ function myTrim($str)
     return (trim($str));
 }
 
-function limitNotesLength($value)
+/**
+ * @param string $value
+ * @return string
+ */
+function limitNotesLength(string $value): string
 {
     return substr($value, 0, 512);
 }
 
-function limitUrlLength($value)
+/**
+ * @param string $value
+ * @return string
+ */
+function limitUrlLength(string $value): string
 {
     return substr($value, 0, 2048);
 }

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -252,6 +252,16 @@ function myTrim($str)
     return (trim($str));
 }
 
+function limitNotesLength($value)
+{
+    return substr($value, 0, 512);
+}
+
+function limitUrlLength($value)
+{
+    return substr($value, 0, 2048);
+}
+
 /*
  * Hosts Functions
  */

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -540,21 +540,17 @@ jQuery('input[name=host_check_interval]').change(function(){
     }
 });
 
-jQuery('input[name=ehi_notes_url]').change(function () {
-	if (jQuery(this).val().length > 2048) {
-		alert(alert_max_length_exceeded.replace('#input#', 'notes_url (max: 2048)'));
+$('input[name=ehi_notes_url], input[name=ehi_action_url]').change(function () {
+	inputName = $(this).parent('td').prev().text();
+	if ($(this).val().length > 2048) {
+		alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '2048'));
 	}
 });
 
-jQuery('input[name=ehi_action_url]').change(function () {
-	if (jQuery(this).val().length > 2048) {
-		alert(alert_max_length_exceeded.replace('#input#', 'action_url (max: 2048)'));
-	}
-});
-
-jQuery('input[name=ehi_notes]').change(function () {
-	if (jQuery(this).val().length > 512) {
-		alert(alert_max_length_exceeded.replace('#input#', 'notes (max: 512)'));
+$('input[name=ehi_notes]').change(function () {
+	inputName = $(this).parent('td').prev().text();
+	if ($(this).val().length > 512) {
+		alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '512'));
 	}
 });
 

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -529,9 +529,9 @@
 	{if isset($alert_check_interval)}
 	alert_check_interval = "{$alert_check_interval}";
 	{/if}
-	var alert_max_size_exceeded = null;
-	{ if isset($alert_max_size_exceeded)}
-		alert_max_size_exceeded = "{$alert_max_size_exceeded}";
+	var alert_max_length_exceeded = null;
+	{ if isset($alert_max_length_exceeded)}
+		alert_max_length_exceeded = "{$alert_max_length_exceeded}";
 	{/if}
 {literal}
 jQuery('input[name=host_check_interval]').change(function(){
@@ -542,23 +542,21 @@ jQuery('input[name=host_check_interval]').change(function(){
 
 jQuery('input[name=ehi_notes_url]').change(function () {
 	if (jQuery(this).val().length > 2048) {
-		alert(alert_max_size_exceeded.replace('#input#', 'notes_url (max: 2048)'));
+		alert(alert_max_length_exceeded.replace('#input#', 'notes_url (max: 2048)'));
 	}
 });
 
 jQuery('input[name=ehi_action_url]').change(function () {
 	if (jQuery(this).val().length > 2048) {
-		alert(alert_max_size_exceeded.replace('#input#', 'action_url (max: 2048)'));
+		alert(alert_max_length_exceeded.replace('#input#', 'action_url (max: 2048)'));
 	}
 });
 
 jQuery('input[name=ehi_notes]').change(function () {
 	if (jQuery(this).val().length > 512) {
-		alert(alert_max_size_exceeded.replace('#input#', 'notes (max: 512)'));
+		alert(alert_max_length_exceeded.replace('#input#', 'notes (max: 512)'));
 	}
 });
-
-// .replace('N/A, ', '');
 
 jQuery(function() {
     setListener(jQuery('select[name=command_command_id]'));

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -543,14 +543,14 @@ jQuery('input[name=host_check_interval]').change(function(){
 $('input[name=ehi_notes_url], input[name=ehi_action_url]').change(function () {
 	inputName = $(this).parent('td').prev().text();
 	if ($(this).val().length > 2048) {
-		alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '2048'));
+		alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '2048'));
 	}
 });
 
 $('input[name=ehi_notes]').change(function () {
 	inputName = $(this).parent('td').prev().text();
 	if ($(this).val().length > 512) {
-		alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '512'));
+		alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '512'));
 	}
 });
 

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -91,7 +91,7 @@
 				<td class="FormRowValue">{$form.host_location.html}</td>
 			</tr>
 			{if $o == "mc"}
-			<tr class="list_two">	
+			<tr class="list_two">
 				<td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_tplp.label}</td>
 				<td class="FormRowValue">{$form.mc_mod_tplp.html}</td>
 			</tr>
@@ -423,7 +423,7 @@
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="flap_detection_enabled"> {$form.host_flap_detection_enabled.label}</td><td class="FormRowValue">{$form.host_flap_detection_enabled.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="low_flap_threshold"> {$form.host_low_flap_threshold.label}</td><td class="FormRowValue">{$form.host_low_flap_threshold.html}&nbsp;%</td></tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="high_flap_threshold"> {$form.host_high_flap_threshold.label}</td><td class="FormRowValue">{$form.host_high_flap_threshold.html}&nbsp;%</td></tr>
-	
+
 	<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
       <h4>{$History_Options}</h4>
     </td></tr>
@@ -527,7 +527,11 @@
 <script>
 	var alert_check_interval = null;
 	{if isset($alert_check_interval)}
-		alert_check_interval = "{$alert_check_interval}";
+	alert_check_interval = "{$alert_check_interval}";
+	{/if}
+	var alert_max_size_exceeded = null;
+	{ if isset($alert_max_size_exceeded)}
+		alert_max_size_exceeded = "{$alert_max_size_exceeded}";
 	{/if}
 {literal}
 jQuery('input[name=host_check_interval]').change(function(){
@@ -535,6 +539,26 @@ jQuery('input[name=host_check_interval]').change(function(){
         alert(alert_check_interval);
     }
 });
+
+jQuery('input[name=ehi_notes_url]').change(function () {
+	if (jQuery(this).val().length > 2048) {
+		alert(alert_max_size_exceeded.replace('#input#', 'notes_url (max: 2048)'));
+	}
+});
+
+jQuery('input[name=ehi_action_url]').change(function () {
+	if (jQuery(this).val().length > 2048) {
+		alert(alert_max_size_exceeded.replace('#input#', 'action_url (max: 2048)'));
+	}
+});
+
+jQuery('input[name=ehi_notes]').change(function () {
+	if (jQuery(this).val().length > 512) {
+		alert(alert_max_size_exceeded.replace('#input#', 'notes (max: 512)'));
+	}
+});
+
+// .replace('N/A, ', '');
 
 jQuery(function() {
     setListener(jQuery('select[name=command_command_id]'));
@@ -671,7 +695,7 @@ function setListener(elem){
     }
 
     elem.on('change',function(event,data){
-        if(typeof data != "undefined" && typeof data.origin !=undefined 
+        if(typeof data != "undefined" && typeof data.origin !=undefined
             && data.origin == "select2defaultinit"){
             return false;
         }
@@ -688,7 +712,7 @@ function clonerefreshListener(el){
     setListener(el.find('select[name^=tpSelect]'));
 }
 
-{/literal}{if $o != "mc"}{literal}    
+{/literal}{if $o != "mc"}{literal}
     function doAjaxLoad(elems) {
             jQuery.ajax({
                 url: "./include/configuration/configObject/host/refreshMacroAjax.php",
@@ -701,7 +725,7 @@ function clonerefreshListener(el){
                     jQuery("#clone-values-macro").data("clone-values-macro",json.macros);
                     sheepIt.removeAllForms();
                     for (i = 0; i < jQuery("#clone-count-macro").data("clone-count-macro"); i++) {
-                        sheepIt.addForm();	
+                        sheepIt.addForm();
                     }
 
                     sheepIt.inject(jQuery("#clone-values-macro").data("clone-values-macro"));

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1050,6 +1050,11 @@ function myReplace()
 }
 
 $form->applyFilter('__ALL__', 'myTrim');
+
+$form->applyFilter('ehi_notes', 'limitNotesLength');
+$form->applyFilter('ehi_notes_url', 'limitUrlLength');
+$form->applyFilter('ehi_action_url', 'limitUrlLength');
+
 $from_list_menu = false;
 if ($o !== HOST_MASSIVE_CHANGE) {
     $form->applyFilter('host_name', 'myReplace');
@@ -1114,7 +1119,7 @@ $tpl->assign(
 );
 
 $tpl->assign(
-    'alert_max_size_exceeded',
+    'alert_max_length_exceeded',
     _("Warning, maximum size exceeded for input #input#, it will be be truncated upon saving")
 );
 

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1120,7 +1120,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input #input#, it will be be truncated upon saving")
+    _("Warning, maximum size exceeded for input #input#, it will be truncated upon saving")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1120,7 +1120,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input #input#, it will be truncated upon saving")
+    _("Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving.")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1120,7 +1120,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving.")
+    _("Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving.")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1120,7 +1120,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving.")
+    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -118,7 +118,7 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
 
     // Set Host Category Parents
     $statement = $pearDB->prepare(
-        'SELECT DISTINCT hostcategories_hc_id 
+        'SELECT DISTINCT hostcategories_hc_id
         FROM hostcategories_relation hcr
         INNER JOIN hostcategories hc
             ON hcr.hostcategories_hc_id = hc.hc_id
@@ -146,7 +146,7 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
 
     // Set critically
     $statement = $pearDB->prepare(
-        'SELECT hc.hc_id 
+        'SELECT hc.hc_id
         FROM hostcategories hc
         INNER JOIN hostcategories_relation hcr
             ON hcr.hostcategories_hc_id = hc.hc_id
@@ -1111,6 +1111,11 @@ $tpl->assign(
     'alert_check_interval',
     _("Warning, unconventional use of interval check. You should prefer to use an interval lower than 24h,"
         . " if needed, pair this configuration with the use of timeperiods")
+);
+
+$tpl->assign(
+    'alert_max_size_exceeded',
+    _("Warning, maximum size exceeded for input #input#, it will be be truncated upon saving")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -1120,7 +1120,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving.")
+    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving.")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/service/formService.ihtml
+++ b/www/include/configuration/configObject/service/formService.ihtml
@@ -441,21 +441,17 @@ jQuery('input[name=service_normal_check_interval]').change(function() {
     }
 });
 
-jQuery('input[name=esi_notes_url]').change(function () {
-    if (jQuery(this).val().length > 2048) {
-        alert(alert_max_length_exceeded.replace('#input#', 'notes_url (max: 2048)'));
+$('input[name=esi_notes_url], input[name=esi_action_url]').change(function () {
+    inputName = $(this).parent('td').prev().text();
+    if ($(this).val().length > 2048) {
+        alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '2048'));
     }
 });
 
-jQuery('input[name=esi_action_url]').change(function () {
-    if (jQuery(this).val().length > 2048) {
-        alert(alert_max_length_exceeded.replace('#input#', 'action_url (max: 2048)'));
-    }
-});
-
-jQuery('input[name=esi_notes]').change(function () {
-    if (jQuery(this).val().length > 512) {
-        alert(alert_max_length_exceeded.replace('#input#', 'notes (max: 512)'));
+$('input[name=esi_notes]').change(function () {
+    inputName = $(this).parent('td').prev().text();
+    if ($(this).val().length > 512) {
+        alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '512'));
     }
 });
 

--- a/www/include/configuration/configObject/service/formService.ihtml
+++ b/www/include/configuration/configObject/service/formService.ihtml
@@ -16,8 +16,8 @@
         <li class="a" id='c1'><a href="#" onclick="javascript:montre('1');">{t}General Information{/t}</a></li>
         <li class="b" id='c2'><a href="#" onclick="javascript:montre('2');">{t}Notifications{/t}</a></li>
         <li class="b" id='c3'><a href="#" onclick="javascript:montre('3');">{t}Relations{/t}</a></li>
-        <li class="b" id='c4'><a href="#" onclick="javascript:montre('4');">{t}Data Processing{/t}</a></li>     
-        <li class="b" id='c5'><a href="#" onclick="javascript:montre('5');">{t}Extended Info{/t}</a></li>       
+        <li class="b" id='c4'><a href="#" onclick="javascript:montre('4');">{t}Data Processing{/t}</a></li>
+        <li class="b" id='c5'><a href="#" onclick="javascript:montre('5');">{t}Extended Info{/t}</a></li>
     </ul>
     <div id="validFormTop">
     {if $o == "a" || $o == "c" || $o == "mc"}
@@ -299,7 +299,7 @@
             <h3>| {$form.header.title3}</h3>
           </td>
         </tr>
-        
+
         <tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$form.header.treatment}</h4>
@@ -312,7 +312,7 @@
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$Freshness_Control_options}</h4>
           </td>
-        </tr>   
+        </tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="check_freshness"> {$form.service_check_freshness.label}</td><td class="FormRowValue">{$form.service_check_freshness.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="freshness_threshold"> {$form.service_freshness_threshold.label}</td><td class="FormRowValue">{$form.service_freshness_threshold.html}&nbsp;{$seconds}</td></tr>
 
@@ -320,7 +320,7 @@
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$Flapping_Options}</h4>
           </td>
-        </tr>       
+        </tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="flap_detection_enabled"> {$form.service_flap_detection_enabled.label}</td><td class="FormRowValue">{$form.service_flap_detection_enabled.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="low_flap_threshold"> {$form.service_low_flap_threshold.label}</td><td class="FormRowValue">{$form.service_low_flap_threshold.html}&nbsp;%</td></tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="high_flap_threshold"> {$form.service_high_flap_threshold.label}</td><td class="FormRowValue">{$form.service_high_flap_threshold.html}&nbsp;%</td></tr>
@@ -349,7 +349,7 @@
                 {/if}
             </td>
         </tr>
-        {if $v > "1"}       
+        {if $v > "1"}
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="event_handler_args"> {$form.command_command_id_arg2.label}</td><td class="FormRowValue">{$form.command_command_id_arg2.html}
         {if $o == "a" || $o == "c"}
         &nbsp;<img src="./img/icons/arrow-left.png" class="ico-14" style='cursor: pointer;margin: 0 6px;vertical-align: middle;' alt="*" onClick="set_arg('example2','command_command_id_arg2');"><input type="text" name="example2" disabled>
@@ -372,7 +372,7 @@
           </td>
         </tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="graph_template"> {$form.graph_id.label}</td><td class="FormRowValue">{$form.graph_id.html}</td></tr>
-        
+
         {if $o == "mc"}
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_sc.label}</td><td class="FormRowValue">{$form.mc_mod_sc.html}</td></tr>
         {/if}
@@ -429,10 +429,33 @@ var alert_check_interval = null;
     var alert_check_interval = "{$alert_check_interval}";
 {/if}
 
+var alert_max_length_exceeded = null;
+{ if isset($alert_max_length_exceeded)}
+alert_max_length_exceeded = "{$alert_max_length_exceeded}";
+{/if}
+
 {literal}
 jQuery('input[name=service_normal_check_interval]').change(function() {
     if (parseInt(jQuery(this).val()) >= 1440) {
         alert(alert_check_interval);
+    }
+});
+
+jQuery('input[name=esi_notes_url]').change(function () {
+    if (jQuery(this).val().length > 2048) {
+        alert(alert_max_length_exceeded.replace('#input#', 'notes_url (max: 2048)'));
+    }
+});
+
+jQuery('input[name=esi_action_url]').change(function () {
+    if (jQuery(this).val().length > 2048) {
+        alert(alert_max_length_exceeded.replace('#input#', 'action_url (max: 2048)'));
+    }
+});
+
+jQuery('input[name=esi_notes]').change(function () {
+    if (jQuery(this).val().length > 512) {
+        alert(alert_max_length_exceeded.replace('#input#', 'notes (max: 512)'));
     }
 });
 

--- a/www/include/configuration/configObject/service/formService.ihtml
+++ b/www/include/configuration/configObject/service/formService.ihtml
@@ -444,14 +444,14 @@ jQuery('input[name=service_normal_check_interval]').change(function() {
 $('input[name=esi_notes_url], input[name=esi_action_url]').change(function () {
     inputName = $(this).parent('td').prev().text();
     if ($(this).val().length > 2048) {
-        alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '2048'));
+        alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '2048'));
     }
 });
 
 $('input[name=esi_notes]').change(function () {
     inputName = $(this).parent('td').prev().text();
     if ($(this).val().length > 512) {
-        alert(alert_max_length_exceeded.replace('#input#', $.trim(inputName)).replace('#maxLength#', '512'));
+        alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '512'));
     }
 });
 

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1093,7 +1093,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving.")
+    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving.")
 );
 
 // Just watch a host information

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1093,7 +1093,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving.")
+    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving")
 );
 
 // Just watch a host information

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1093,7 +1093,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input #input#, it will be truncated upon saving")
+    _("Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving.")
 );
 
 // Just watch a host information

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1093,7 +1093,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input #input#, it will be be truncated upon saving")
+    _("Warning, maximum size exceeded for input #input#, it will be truncated upon saving")
 );
 
 // Just watch a host information

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -90,7 +90,7 @@ $macroPasswords = [];
 
 if (($o == SERVICE_MODIFY || $o == SERVICE_WATCH) && $service_id) {
     $statement = $pearDB->prepare(
-        'SELECT * 
+        'SELECT *
         FROM service
         LEFT JOIN extended_service_information esi
             ON esi.service_service_id = service_id
@@ -126,7 +126,7 @@ if (($o == SERVICE_MODIFY || $o == SERVICE_WATCH) && $service_id) {
      * Set criticality
      */
     $statement = $pearDB->prepare(
-        'SELECT sc.sc_id 
+        'SELECT sc.sc_id
         FROM service_categories sc
         INNER JOIN service_categories_relation scr
             ON scr.sc_id = sc.sc_id
@@ -1017,6 +1017,10 @@ if (is_array($select)) {
  * Form Rules
  */
 $form->applyFilter('__ALL__', 'myTrim');
+$form->applyFilter('esi_notes', 'limitNotesLength');
+$form->applyFilter('esi_notes_url', 'limitUrlLength');
+$form->applyFilter('esi_action_url', 'limitUrlLength');
+
 $from_list_menu = false;
 if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->addRule('service_description', _("Compulsory Name"), 'required');
@@ -1085,6 +1089,11 @@ $tpl->assign(
     'alert_check_interval',
     _("Warning, unconventional use of interval check. You should prefer to use an interval lower than 24h, "
         . "if needed, pair this configuration with the use of timeperiods")
+);
+
+$tpl->assign(
+    'alert_max_length_exceeded',
+    _("Warning, maximum size exceeded for input #input#, it will be be truncated upon saving")
 );
 
 // Just watch a host information

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -1093,7 +1093,7 @@ $tpl->assign(
 
 $tpl->assign(
     'alert_max_length_exceeded',
-    _("Warning, maximum size exceeded for input #input# (max: #maxLength#), it will be truncated upon saving.")
+    _("Warning, maximum size exceeded for input '#input#' (max: #maxLength#), it will be truncated upon saving.")
 );
 
 // Just watch a host information


### PR DESCRIPTION
## Description

 Display a warning message when max length of input url, action url or notes are exceeded in host configuration form and limit data length at save
<img width="800" alt="image" src="https://user-images.githubusercontent.com/88387848/174771522-f75aeb11-5364-4a69-9e49-81838d34d710.png">

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
