### PR TITLE
fix(UI): Fix width when federatedModule is in state not ready and not failed

### DIFF
--- a/www/front_src/src/federatedModules/Load/index.tsx
+++ b/www/front_src/src/federatedModules/Load/index.tsx
@@ -92,7 +92,7 @@ const LoadComponent = ({
   return (
     <Suspense
       fallback={
-        isFederatedModule ? <MenuSkeleton width={29} /> : <PageSkeleton />
+        isFederatedModule ? <MenuSkeleton width={27} /> : <PageSkeleton />
       }
     >
       <Component {...props} />


### PR DESCRIPTION
## Description

Fix width when federatedModule is in state not ready and nor failed , the with is different than Bam top counter

**Fixes** # (issue)

Fix width of Skeleton into Federated Module

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install Bam with valid licence , and log on Centreon
