### PR TITLE
enh(resources): handle severities in the listing

### DIFF
--- a/config/packages/Centreon.yaml
+++ b/config/packages/Centreon.yaml
@@ -10,6 +10,9 @@ jms_serializer:
             infrastructure:
                 namespace_prefix: "Centreon\\Infrastructure"
                 path: '%kernel.project_dir%/config/packages/serializer/Infrastructure'
+            core:
+                namespace_prefix: "Core\\"
+                path: '%kernel.project_dir%/config/packages/serializer/Core'
 parameters:
     api.header: "Api-Version"
     api.version.latest: "22.04"

--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -123,3 +123,7 @@ Centreon\Domain\Monitoring\Resource:
             type: bool
             groups:
                 - 'resource_main'
+        severity:
+            type: Core\Severity\RealTime\Domain\Model\Severity
+            groups:
+                - 'resource_main'

--- a/config/packages/serializer/Centreon/Monitoring.ResourceFilter.yml
+++ b/config/packages/serializer/Centreon/Monitoring.ResourceFilter.yml
@@ -12,6 +12,14 @@ Centreon\Domain\Monitoring\ResourceFilter:
             type: array<string>
         monitoringServerNames:
             type: array<string>
+        serviceSeverityNames:
+            type: array<string>
+        hostSeverityNames:
+            type: array<string>
+        serviceSeverityLevels:
+            type: array<integer>
+        hostSeverityLevels:
+            type: array<integer>
         statusTypes:
             type: array<string>
         onlyWithPerformanceData:

--- a/config/packages/serializer/Core/Domain.RealTime.Model.Icon.yml
+++ b/config/packages/serializer/Core/Domain.RealTime.Model.Icon.yml
@@ -1,0 +1,14 @@
+Core\Domain\RealTime\Model\Icon:
+    properties:
+        id:
+            type: integer
+            groups:
+                - 'core_icon_main'
+        name:
+            type: string
+            groups:
+                - 'core_icon_main'
+        url:
+            type: string
+            groups:
+                - 'core_icon_main'

--- a/config/packages/serializer/Core/Severity.RealTime.Domain.Model.Severity.yml
+++ b/config/packages/serializer/Core/Severity.RealTime.Domain.Model.Severity.yml
@@ -1,0 +1,25 @@
+Core\Severity\RealTime\Domain\Model\Severity:
+    virtual_properties:
+        getTypeAsString:
+            name: getTypeAsString
+            serialized_name: type
+            type: string
+            groups:
+                - 'severity_main'
+    properties:
+        id:
+            type: integer
+            groups:
+                - 'severity_main'
+        name:
+            type: string
+            groups:
+                - 'severity_main'
+        level:
+            type: integer
+            groups:
+                - 'severity_main'
+        icon:
+            type: Core\Domain\RealTime\Model\Icon
+            groups:
+                - 'severity_main'

--- a/config/packages/validator/validation.yaml
+++ b/config/packages/validator/validation.yaml
@@ -247,6 +247,38 @@ Centreon\Domain\Monitoring\ResourceFilter:
                 - Type:
                     type: string
                     groups: [Default]
+        serviceSeverityNames:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: string
+                    groups: [Default]
+        hostSeverityNames:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: string
+                    groups: [Default]
+        serviceSeverityLevels:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: integer
+                    groups: [Default]
+        hostSeverityLevels:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: integer
+                    groups: [Default]
         statusTypes:
             - Type:
                 type: array

--- a/config/routes/Centreon/monitoring/severity.yaml
+++ b/config/routes/Centreon/monitoring/severity.yaml
@@ -1,7 +1,14 @@
 ---
-centreon_application_monitoring_find_severities:
+centreon.severity.realtime.findHostSeverities:
     methods: "GET"
-    path: "/monitoring/severities"
+    path: "/monitoring/severities/host"
     controller: >-
-        Core\Severity\RealTime\Infrastructure\API\FindSeverityController
+        Core\Severity\RealTime\Infrastructure\API\FindSeverity\FindHostSeverityController
+    condition: "request.attributes.get('version') >= 22.04"
+
+centreon.severity.realtime.findServiceSeverities:
+    methods: "GET"
+    path: "/monitoring/severities/service"
+    controller: >-
+        Core\Severity\RealTime\Infrastructure\API\FindSeverity\FindServiceSeverityController
     condition: "request.attributes.get('version') >= 22.04"

--- a/config/routes/Centreon/monitoring/severity.yaml
+++ b/config/routes/Centreon/monitoring/severity.yaml
@@ -1,0 +1,7 @@
+---
+centreon_application_monitoring_find_severities:
+    methods: "GET"
+    path: "/monitoring/severities"
+    controller: >-
+        Core\Severity\RealTime\Infrastructure\API\FindSeverityController
+    condition: "request.attributes.get('version') >= 22.04"

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -1611,17 +1611,52 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/severities:
+  /monitoring/severities/service:
     get:
       tags:
         - Severity
-      summary: "List all severities from the realtime"
+      summary: "List all service severities from the realtime"
       description: |
-        List all the severities in real-time monitoring.
+        List all the service severities in real-time monitoring.
 
         The available parameters to **search** / **sort_by** are:
 
-        * id
+        * name
+        * level
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: '#/components/schemas/Monitoring.Severity'
+                  meta:
+                    $ref: '#/components/schemas/Meta'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /monitoring/severities/host:
+    get:
+      tags:
+        - Severity
+      summary: "List all host severities from the realtime"
+      description: |
+        List all the host severities in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
         * name
         * level
       parameters:
@@ -6428,6 +6463,11 @@ components:
           format: int64
           description: "Level defined for the severity"
           example: 50
+        type:
+          type: string
+          enum: [host, service]
+          description: "Type of the severity"
+          example: "host|service"
         icon:
           type: object
           properties:

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -1233,6 +1233,10 @@ paths:
         - $ref: '#/components/parameters/ResourceFilterStatus'
         - $ref: '#/components/parameters/ResourceFilterHostgroupName'
         - $ref: '#/components/parameters/ResourceFilterServicegroupName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
         - $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
         - $ref: '#/components/parameters/ResourceFilterStatusTypes'
       responses:
@@ -4071,6 +4075,46 @@ components:
         items:
           type: string
         example: '["Memory-Services", "Ping-Services"]'
+    ResourceFilterServiceSeverityName:
+      in: query
+      name: service_severity_names
+      required: false
+      description: "Filter the resources by service severity names (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: string
+        example: '["High", "Low"]'
+    ResourceFilterHostSeverityName:
+      in: query
+      name: host_severity_names
+      required: false
+      description: "Filter the resources by host severity names (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: string
+        example: '["High", "Low"]'
+    ResourceFilterHostSeverityLevel:
+      in: query
+      name: host_severity_levels
+      required: false
+      description: "Filter the resources by host severity levels (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: integer
+        example: '[50, 75]'
+    ResourceFilterServiceSeverityLevel:
+      in: query
+      name: service_severity_levels
+      required: false
+      description: "Filter the resources by service severity levels (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: integer
+        example: '[50, 75]'
     ResourceFilterMonitoringServerName:
       in: query
       name: monitoring_server_names

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -61,6 +61,7 @@ tags:
   - name: Proxy
   - name: Service
   - name: Service group
+  - name: Severity
   - name: Topology
 security:
   - Token: []
@@ -263,31 +264,6 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Configuration.Host.Template'
-                  meta:
-                    $ref: '#/components/schemas/Meta'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/hosts/categories:
-    get:
-      tags:
-        - Host category
-      summary: "List all host categories"
-      description: |
-        List of all host category configurations
-      responses:
-        "200":
-          description: "OK"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Configuration.Host.Category'
                   meta:
                     $ref: '#/components/schemas/Meta'
         '403':
@@ -1629,6 +1605,43 @@ paths:
                     items:
                       allOf:
                         - $ref: '#/components/schemas/Monitoring.ServiceGroup'
+                  meta:
+                    $ref: '#/components/schemas/Meta'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /monitoring/severities:
+    get:
+      tags:
+        - Severity
+      summary: "List all severities from the realtime"
+      description: |
+        List all the severities in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * level
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: '#/components/schemas/Monitoring.Severity'
                   meta:
                     $ref: '#/components/schemas/Meta'
         '403':
@@ -6398,6 +6411,34 @@ components:
           type: string
           description: "Name of the service group"
           example: "MySG"
+    Monitoring.Severity:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: "ID of the severity"
+          example: 13
+        name:
+          type: string
+          description: "Name of the severity"
+          example: "severity-name"
+        level:
+          type: integer
+          format: int64
+          description: "Level defined for the severity"
+          example: 50
+        icon:
+          type: object
+          properties:
+            name:
+              type: string
+              description: "Name of the icon"
+              example: "centreon.png"
+            url:
+              type: string
+              description: "URL of the icon"
+              example: "img/centreon.png"
     Monitoring.ServiceMin:
       type: object
       properties:

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -31,6 +31,8 @@ use Centreon\Domain\Entity\EntityValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Centreon\Domain\Monitoring\ResourceFilter;
 use Centreon\Domain\Monitoring\ResourceStatus;
+use Core\Severity\RealTime\Domain\Model\Severity;
+use Core\Domain\RealTime\Model\Icon as NewIconModel;
 use Centreon\Application\Normalizer\IconUrlNormalizer;
 use JMS\Serializer\Exception\ValidationFailedException;
 use Centreon\Domain\RequestParameters\RequestParameters;
@@ -60,6 +62,10 @@ class MonitoringResourceController extends AbstractController
         'hostgroup_names',
         'servicegroup_names',
         'monitoring_server_names',
+        'service_severity_names',
+        'host_severity_names',
+        'host_severity_levels',
+        'service_severity_levels',
         'status_types',
     ];
 
@@ -121,6 +127,8 @@ class MonitoringResourceController extends AbstractController
         ResourceEntity::SERIALIZER_GROUP_PARENT,
         Icon::SERIALIZER_GROUP_MAIN,
         ResourceStatus::SERIALIZER_GROUP_MAIN,
+        NewIconModel::SERIALIZER_GROUP_MAIN,
+        Severity::SERIALIZER_GROUP_MAIN,
     ];
 
     // Groups for validation
@@ -235,6 +243,10 @@ class MonitoringResourceController extends AbstractController
 
             if ($resource->getParent() !== null && $resource->getParent()->getIcon() instanceof Icon) {
                 $this->iconUrlNormalizer->normalize($resource->getParent()->getIcon());
+            }
+
+            if ($resource->getSeverity() !== null && $resource->getSeverity()->getIcon() instanceof NewIconModel) {
+                $this->iconUrlNormalizer->normalize($resource->getSeverity()->getIcon());
             }
 
             // add shortcuts

--- a/src/Centreon/Domain/Common/Assertion/AssertionException.php
+++ b/src/Centreon/Domain/Common/Assertion/AssertionException.php
@@ -212,12 +212,12 @@ class AssertionException extends \InvalidArgumentException
     /**
      * Exception when the value is not expected.
      *
-     * @param string|null $propertyPath Property's path (ex: Host::name)
-     * @param string $value
+     * @param mixed $value
      * @param mixed[] $expectedValues
+     * @param string|null $propertyPath Property's path (ex: Host::name)
      * @return self
      */
-    public static function inArray(string $value, array $expectedValues, string $propertyPath = null): self
+    public static function inArray($value, array $expectedValues, string $propertyPath = null): self
     {
         return new self(
             sprintf(

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -28,6 +28,7 @@ use Centreon\Domain\Downtime\Downtime;
 use Centreon\Domain\Monitoring\ResourceGroup;
 use Centreon\Domain\Monitoring\ResourceLinks;
 use Centreon\Domain\Monitoring\ResourceStatus;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Centreon\Domain\Acknowledgement\Acknowledgement;
 
 /**
@@ -55,6 +56,11 @@ class Resource
     public const TYPE_SERVICE = 'service';
     public const TYPE_HOST = 'host';
     public const TYPE_META = 'metaservice';
+
+    /**
+     * @var int|null
+     */
+    private $resourceId;
 
     /**
      * @var int|null
@@ -266,6 +272,11 @@ class Resource
      * @var bool
      */
     private $hasGraph = false;
+
+    /**
+    * @var Severity|null
+    */
+    private $severity;
 
     /**
      * Resource constructor.
@@ -1103,5 +1114,43 @@ class Resource
     public function hasGraph(): bool
     {
         return $this->hasGraph;
+    }
+
+    /**
+     * @param integer|null $resourceId
+     * @return self
+     */
+    public function setResourceId(?int $resourceId): self
+    {
+        $this->resourceId = $resourceId;
+
+        return $this;
+    }
+
+    /**
+     * @return integer|null
+     */
+    public function getResourceId(): ?int
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * @param Severity|null $severity
+     * @return self
+     */
+    public function setSeverity(?Severity $severity): self
+    {
+        $this->severity = $severity;
+
+        return $this;
+    }
+
+    /**
+     * @return Severity|null
+     */
+    public function getSeverity(): ?Severity
+    {
+        return $this->severity;
     }
 }

--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -149,6 +149,26 @@ class ResourceFilter
     private $statusTypes = [];
 
     /**
+     * @var string[]
+     */
+    private array $serviceSeverityNames = [];
+
+    /**
+     * @var string[]
+     */
+    private array $hostSeverityNames = [];
+
+    /**
+     * @var int[]
+     */
+    private array $serviceSeverityLevels = [];
+
+    /**
+     * @var int[]
+     */
+    private array $hostSeverityLevels = [];
+
+    /**
      * Transform result by map
      *
      * @param array<mixed, mixed> $list
@@ -420,5 +440,81 @@ class ResourceFilter
     {
         $this->statusTypes = $statusTypes;
         return $this;
+    }
+
+    /**
+     * @param string[] $serviceSeverityNames
+     * @return self
+     */
+    public function setServiceSeverityNames(array $serviceSeverityNames): self
+    {
+        $this->serviceSeverityNames = $serviceSeverityNames;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getServiceSeverityNames(): array
+    {
+        return $this->serviceSeverityNames;
+    }
+
+    /**
+     * @param string[] $hostSeverityNames
+     * @return self
+     */
+    public function setHostSeverityNames(array $hostSeverityNames): self
+    {
+        $this->hostSeverityNames = $hostSeverityNames;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHostSeverityNames(): array
+    {
+        return $this->hostSeverityNames;
+    }
+
+    /**
+     * @param int[] $serviceSeverityLevels
+     * @return self
+     */
+    public function setServiceSeverityLevels(array $serviceSeverityLevels): self
+    {
+        $this->serviceSeverityLevels = $serviceSeverityLevels;
+
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getServiceSeverityLevels(): array
+    {
+        return $this->serviceSeverityLevels;
+    }
+
+    /**
+     * @param int[] $hostSeverityLevels
+     * @return self
+     */
+    public function setHostSeverityLevels(array $hostSeverityLevels): self
+    {
+        $this->hostSeverityLevels = $hostSeverityLevels;
+
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getHostSeverityLevels(): array
+    {
+        return $this->hostSeverityLevels;
     }
 }

--- a/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
@@ -35,10 +35,17 @@ use Centreon\Domain\Monitoring\Interfaces\ResourceRepositoryInterface;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Centreon\Infrastructure\RequestParameters\RequestParametersTranslatorException;
 use Centreon\Domain\Monitoring\Resource as ResourceEntity;
+use Core\Infrastructure\RealTime\Repository\Icon\DbIconFactory;
+use Core\Severity\RealTime\Domain\Model\Severity;
 
 class DbReadResourceRepository extends AbstractRepositoryDRB implements ResourceRepositoryInterface
 {
     use LoggerTrait;
+
+    /**
+     * @var ResourceEntity[]
+     */
+    private array $resources = [];
 
     private const RESOURCE_TYPE_SERVICE = 0,
                   RESOURCE_TYPE_HOST = 1,
@@ -133,10 +140,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
      */
     public function findResources(ResourceFilter $filter): array
     {
-        $resources = [];
-
         if ($this->hasNotEnoughRightsToContinue()) {
-            return $resources;
+            return $this->resources;
         }
 
         $collector = new StatementCollector();
@@ -155,7 +160,11 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
             parent_resource.status AS `parent_status`,
             parent_resource.alias AS `parent_alias`,
             parent_resource.status_ordered AS `parent_status_ordered`,
+            severities.id AS `severity_id`,
             severities.level AS `severity_level`,
+            severities.name AS `severity_name`,
+            severities.type AS `severity_type`,
+            severities.icon_id AS `severity_icon_id`,
             resources.type,
             resources.status,
             resources.status_ordered,
@@ -177,7 +186,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
             resources.has_graph,
             instances.name AS `monitoring_server_name`,
             resources.enabled,
-            resources.icon_id
+            resources.icon_id,
+            resources.severity_id
         FROM `:dbstg`.`resources`
         LEFT JOIN `:dbstg`.`resources` parent_resource
             ON parent_resource.id = resources.parent_id
@@ -255,6 +265,11 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
         $request .= $this->addMonitoringServerSubRequest($filter, $collector);
 
         /**
+         * Severity filter (levels and/or names)
+         */
+        $request .= $this->addSeveritySubRequest($filter, $collector);
+
+        /**
          * Resource tag filter by name
          * - servicegroups
          * - hostgroups
@@ -292,15 +307,210 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
         }
 
         while ($resourceRecord = $statement->fetch(\PDO::FETCH_ASSOC)) {
-            $resources[] = DbResourceFactory::createFromRecord($resourceRecord);
+            $this->resources[] = DbResourceFactory::createFromRecord($resourceRecord);
         }
 
-        /**
-         * Loop on resources on a private method to get icon ids and add them to the entity
-         */
-        $resources = $this->getIconsForResources($resources);
+        $iconIds = $this->getIconIdsFromResources();
+        $icons = $this->getIconsDataForResources($iconIds);
+        $this->completeResourcesWithIcons($icons);
 
-        return $resources;
+        return $this->resources;
+    }
+
+    /**
+     * @param array<int, array<string, string>> $icons
+     * @return void
+     */
+    private function completeResourcesWithIcons(array $icons): void
+    {
+        foreach ($this->resources as $resource) {
+            if ($resource->getIcon() !== null) {
+                $resourceIconId = $resource->getIcon()->getId();
+                $resource->getIcon()
+                    ->setName($icons[$resourceIconId]['name'])
+                    ->setUrl($icons[$resourceIconId]['url']);
+            }
+
+            if ($resource->getSeverity() !== null) {
+                $resourceSeverityIconId = $resource->getSeverity()->getIcon()->getId();
+                $resource->getSeverity()->getIcon()
+                    ->setName($icons[$resourceSeverityIconId]['name'])
+                    ->setUrl($icons[$resourceSeverityIconId]['url']);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, int|null>
+     */
+    private function getIconIdsFromResources(): array
+    {
+        $resourceIconIds = $this->getResourceIconIdsFromResources();
+        $severityIconIds = $this->getSeverityIconIdsFromResources();
+
+        return array_unique(array_merge($resourceIconIds, $severityIconIds));
+    }
+
+    /**
+     * @return array<int, int|null>
+     */
+    private function getResourceIconIdsFromResources(): array
+    {
+        $resourcesWithIcons = array_filter(
+            $this->resources,
+            fn (ResourceEntity $resource) => $resource->getIcon() !== null
+        );
+
+        /**
+         * @todo replace by foreach
+         */
+        return array_map(
+            fn (ResourceEntity $resource) => $resource->getIcon()?->getId(),
+            $resourcesWithIcons
+        );
+    }
+
+    /**
+     * @return array<int, int|null>
+     */
+    private function getSeverityIconIdsFromResources(): array
+    {
+        $resourcesWithSeverities = array_filter(
+            $this->resources,
+            fn (ResourceEntity $resource) => $resource->getSeverity() !== null
+        );
+
+        /**
+         * @todo replace by foreach
+         */
+        return array_map(
+            fn (ResourceEntity $resource) => $resource->getSeverity()?->getIcon()?->getId(),
+            $resourcesWithSeverities
+        );
+    }
+
+    /**
+     * @param ResourceFilter $filter
+     * @return int[]
+     */
+    private function getSeverityLevelsFromFilter(ResourceFilter $filter): array
+    {
+        $levels = [];
+        if (! empty($filter->getHostSeverityLevels())) {
+            foreach ($filter->getHostSeverityLevels() as $level) {
+                $levels[] = $level;
+            }
+        }
+
+        if (! empty($filter->getServiceSeverityLevels())) {
+            foreach ($filter->getServiceSeverityLevels() as $level) {
+                $levels[] = $level;
+            }
+        }
+        return array_unique($levels);
+    }
+
+    /**
+     * @param ResourceFilter $filter
+     * @return int[]
+     */
+    private function getSeverityTypesFromFilter(ResourceFilter $filter): array
+    {
+        $types = [];
+        if (
+            ! empty($filter->getHostSeverityLevels())
+            || ! empty($filter->getHostSeverityNames())
+        ) {
+            $types[] = Severity::HOST_SEVERITY_TYPE_ID;
+        }
+
+        if (
+            ! empty($filter->getServiceSeverityLevels())
+            || ! empty($filter->getServiceSeverityNames())
+        ) {
+            $types[] = Severity::SERVICE_SEVERITY_TYPE_ID;
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param ResourceFilter $filter
+     * @return string[]
+     */
+    private function getSeverityNamesFromFilter(ResourceFilter $filter): array
+    {
+        $names = [];
+        if (! empty($filter->getHostSeverityNames())) {
+            foreach ($filter->getHostSeverityNames() as $hostSeverityName) {
+                $names[] = $hostSeverityName;
+            }
+        }
+
+        if (! empty($filter->getServiceSeverityNames())) {
+            foreach ($filter->getServiceSeverityNames() as $serviceSeverityName) {
+                $names[] = $serviceSeverityName;
+            }
+        }
+
+        return array_unique($names);
+    }
+
+    /**
+     * @param ResourceFilter $filter
+     * @param StatementCollector $collector
+     * @return string
+     */
+    private function addSeveritySubRequest(ResourceFilter $filter, StatementCollector $collector): string
+    {
+        $subRequest = '';
+        $filteredNames = [];
+        $filteredTypes = [];
+        $filteredLevels = [];
+
+        $names = $this->getSeverityNamesFromFilter($filter);
+        $levels = $this->getSeverityLevelsFromFilter($filter);
+        $types = $this->getSeverityTypesFromFilter($filter);
+
+        foreach ($names as $index => $name) {
+            $key = ":severityName_{$index}";
+            $filteredNames[] = $key;
+            $collector->addValue($key, $name, \PDO::PARAM_STR);
+        }
+
+        foreach ($levels as $index => $level) {
+            $key = ":severityLevel_{$index}";
+            $filteredLevels[] = $key;
+            $collector->addValue($key, $level, \PDO::PARAM_INT);
+        }
+
+        foreach ($types as $index => $type) {
+            $key = ":severityType_{$index}";
+            $filteredTypes[] = $key;
+            $collector->addValue($key, $type, \PDO::PARAM_INT);
+        }
+
+        if (
+            ! empty($filteredNames)
+            || ! empty($filteredLevels)
+        ) {
+            $subRequest = ' AND EXISTS (
+                SELECT 1 FROM `:dbstg`.severities
+                WHERE severities.severity_id = resources.severity_id
+                    AND severities.type IN (' . implode(', ', $filteredTypes) . ')';
+
+            $subRequest .= ! empty($filteredNames)
+                ? ' AND severities.name IN (' . implode(', ', $filteredNames) . ')'
+                : '';
+
+            $subRequest .= ! empty($filteredLevels)
+                ? ' AND severities.level IN (' . implode(', ', $filteredLevels) . ')'
+                : '';
+
+            $subRequest .= ' LIMIT 1)';
+        }
+
+        return $subRequest;
     }
 
     /**
@@ -520,18 +730,12 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
     /**
      * Get icons for resources
      *
-     * @param ResourceEntity[] $resources
-     * @return ResourceEntity[]
+     * @param array<int, int|null> $iconIds
+     * @return array<int, array<string, string>>
      */
-    private function getIconsForResources(array $resources): array
+    private function getIconsDataForResources(array $iconIds): array
     {
-        $iconIds = [];
-        foreach ($resources as $index => $resource) {
-            if ($resource->getIcon() !== null) {
-                $iconIds[$index] = $resource->getIcon()->getId();
-            }
-        }
-
+        $icons = [];
         if (! empty($iconIds)) {
             $request = 'SELECT
                 img_id AS `icon_id`,
@@ -549,16 +753,13 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
             $statement->execute(array_values($iconIds));
 
             while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                $resourceIndexes = array_keys($iconIds, (int) $record['icon_id']);
-
-                foreach ($resourceIndexes as $resourceIndex) {
-                    $resources[$resourceIndex]->getIcon()
-                        ?->setName($record['icon_name'])
-                        ->setUrl($record['icon_directory'] . DIRECTORY_SEPARATOR . $record['icon_path']);
-                }
+                $icons[(int) $record['icon_id']] = [
+                    'name' => $record['icon_name'],
+                    'url' => $record['icon_directory'] . DIRECTORY_SEPARATOR . $record['icon_path']
+                ];
             }
         }
 
-        return $resources;
+        return $icons;
     }
 }

--- a/src/Core/Domain/RealTime/Model/Icon.php
+++ b/src/Core/Domain/RealTime/Model/Icon.php
@@ -24,6 +24,13 @@ namespace Core\Domain\RealTime\Model;
 
 class Icon
 {
+    public const SERIALIZER_GROUP_MAIN = 'core_icon_main';
+
+    /**
+     * @var int|null
+     */
+    private $id;
+
     /**
      * @var string|null
      */
@@ -68,5 +75,24 @@ class Icon
     {
         $this->url = $url;
         return $this;
+    }
+
+    /**
+     * @param integer|null $id
+     * @return self
+     */
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return integer|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
     }
 }

--- a/src/Core/Severity/RealTime/Application/Repository/ReadSeverityRepositoryInterface.php
+++ b/src/Core/Severity/RealTime/Application/Repository/ReadSeverityRepositoryInterface.php
@@ -27,8 +27,10 @@ use Core\Severity\RealTime\Domain\Model\Severity;
 interface ReadSeverityRepositoryInterface
 {
     /**
-     * Returns all the severities from the RealTime
+     * Returns all the severities from the RealTime of provided type id
+     *
+     * @param integer $typeId
      * @return Severity[]
      */
-    public function findAll(): array;
+    public function findAllByTypeId(int $typeId): array;
 }

--- a/src/Core/Severity/RealTime/Application/Repository/ReadSeverityRepositoryInterface.php
+++ b/src/Core/Severity/RealTime/Application/Repository/ReadSeverityRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Application\Repository;
+
+use Core\Severity\RealTime\Domain\Model\Severity;
+
+interface ReadSeverityRepositoryInterface
+{
+    /**
+     * Returns all the severities from the RealTime
+     * @return Severity[]
+     */
+    public function findAll(): array;
+}

--- a/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverity.php
+++ b/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverity.php
@@ -41,18 +41,20 @@ class FindSeverity
     }
 
     /**
+     * @param integer $severityTypeId
      * @param FindSeverityPresenterInterface $presenter
      */
-    public function __invoke(FindSeverityPresenterInterface $presenter): void
+    public function __invoke(int $severityTypeId, FindSeverityPresenterInterface $presenter): void
     {
-        $this->info('Searching for severities in the realtime');
+        $this->info('Searching for severities in the realtime', ['typeId' => $severityTypeId]);
         $severities = [];
         try {
-            $severities = $this->repository->findAll();
+            $severities = $this->repository->findAllByTypeId($severityTypeId);
         } catch (\Throwable $ex) {
             $this->error(
-                'An error occured while retrieving severities',
+                'An error occured while retrieving severities from the realtime',
                 [
+                    'typeId' => $severityTypeId,
                     'trace' => $ex->getTraceAsString()
                 ]
             );
@@ -60,6 +62,7 @@ class FindSeverity
             $presenter->setResponseStatus(
                 new ErrorResponse('An error occured while retrieving severities')
             );
+            return;
         }
 
         $presenter->present($this->createResponse($severities));

--- a/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverity.php
+++ b/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverity.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Application\UseCase\FindSeverity;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Severity\RealTime\Domain\Model\Severity;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityPresenterInterface;
+use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
+
+class FindSeverity
+{
+    use LoggerTrait;
+
+    /**
+     * @param ReadSeverityRepositoryInterface $repository
+     */
+    public function __construct(private ReadSeverityRepositoryInterface $repository)
+    {
+    }
+
+    /**
+     * @param FindSeverityPresenterInterface $presenter
+     */
+    public function __invoke(FindSeverityPresenterInterface $presenter): void
+    {
+        $this->info('Searching for severities in the realtime');
+        $severities = [];
+        try {
+            $severities = $this->repository->findAll();
+        } catch (\Throwable $ex) {
+            $this->error(
+                'An error occured while retrieving severities',
+                [
+                    'trace' => $ex->getTraceAsString()
+                ]
+            );
+
+            $presenter->setResponseStatus(
+                new ErrorResponse('An error occured while retrieving severities')
+            );
+        }
+
+        $presenter->present($this->createResponse($severities));
+    }
+
+    /**
+     * @param Severity[] $severities
+     * @return FindSeverityResponse
+     */
+    private function createResponse(array $severities): FindSeverityResponse
+    {
+        return new FindSeverityResponse($severities);
+    }
+}

--- a/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityPresenterInterface.php
+++ b/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityPresenterInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Application\UseCase\FindSeverity;
+
+use Core\Application\Common\UseCase\PresenterInterface;
+
+interface FindSeverityPresenterInterface extends PresenterInterface
+{
+}

--- a/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityResponse.php
+++ b/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityResponse.php
@@ -54,6 +54,7 @@ class FindSeverityResponse
                 'id' => $severity->getId(),
                 'name' => $severity->getName(),
                 'level' => $severity->getLevel(),
+                'type' => $severity->getTypeAsString(),
                 'icon' => $this->iconToArray($severity->getIcon()),
             ],
             $severities

--- a/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityResponse.php
+++ b/src/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityResponse.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Application\UseCase\FindSeverity;
+
+use Core\Application\RealTime\Common\RealTimeResponseTrait;
+use Core\Severity\RealTime\Domain\Model\Severity;
+
+class FindSeverityResponse
+{
+    use RealTimeResponseTrait;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $severities;
+
+    /**
+     * @param Severity[] $severities
+     */
+    public function __construct(array $severities)
+    {
+        $this->severities = $this->severitiesToArray($severities);
+    }
+
+    /**
+     * @param Severity[] $severities
+     * @return array<int, array<string, mixed>>
+     */
+    private function severitiesToArray(array $severities): array
+    {
+        return array_map(
+            fn (Severity $severity) => [
+                'id' => $severity->getId(),
+                'name' => $severity->getName(),
+                'level' => $severity->getLevel(),
+                'icon' => $this->iconToArray($severity->getIcon()),
+            ],
+            $severities
+        );
+    }
+}

--- a/src/Core/Severity/RealTime/Domain/Model/Severity.php
+++ b/src/Core/Severity/RealTime/Domain/Model/Severity.php
@@ -28,6 +28,7 @@ use Centreon\Domain\Common\Assertion\Assertion;
 
 class Severity
 {
+    public const SERIALIZER_GROUP_MAIN = 'severity_main';
     public const MAX_NAME_LENGTH = 255;
 
     public const SERVICE_SEVERITY_TYPE_ID = 0,

--- a/src/Core/Severity/RealTime/Domain/Model/Severity.php
+++ b/src/Core/Severity/RealTime/Domain/Model/Severity.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Domain\Model;
+
+use Core\Domain\RealTime\Model\Icon;
+use Centreon\Domain\Common\Assertion\Assertion;
+
+class Severity
+{
+    public const MAX_NAME_LENGTH = 255;
+
+    /**
+     * @param integer $id
+     * @param string $name
+     * @param integer $level
+     * @param Icon $icon
+     * @throws \Assert\AssertionFailedException
+     */
+    public function __construct(
+        private int $id,
+        private string $name,
+        private int $level,
+        private Icon $icon
+    ) {
+        Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'Severity::name');
+        Assertion::notEmpty($name, 'Severity::name');
+        Assertion::min($level, 0, 'Severity::level');
+        Assertion::max($level, 100, 'Severity::level');
+    }
+
+    /**
+     * @return integer
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    /**
+     * @return Icon
+     */
+    public function getIcon(): Icon
+    {
+        return $this->icon;
+    }
+}

--- a/src/Core/Severity/RealTime/Domain/Model/Severity.php
+++ b/src/Core/Severity/RealTime/Domain/Model/Severity.php
@@ -30,10 +30,19 @@ class Severity
 {
     public const MAX_NAME_LENGTH = 255;
 
+    public const SERVICE_SEVERITY_TYPE_ID = 0,
+                 HOST_SEVERITY_TYPE_ID = 1;
+
+    public const TYPES_AS_STRING = [
+        self::HOST_SEVERITY_TYPE_ID => 'host',
+        self::SERVICE_SEVERITY_TYPE_ID => 'service'
+    ];
+
     /**
      * @param integer $id
      * @param string $name
      * @param integer $level
+     * @param integer $type
      * @param Icon $icon
      * @throws \Assert\AssertionFailedException
      */
@@ -41,12 +50,18 @@ class Severity
         private int $id,
         private string $name,
         private int $level,
+        private int $type,
         private Icon $icon
     ) {
         Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'Severity::name');
         Assertion::notEmpty($name, 'Severity::name');
         Assertion::min($level, 0, 'Severity::level');
         Assertion::max($level, 100, 'Severity::level');
+        Assertion::inArray(
+            $type,
+            [self::HOST_SEVERITY_TYPE_ID, self::SERVICE_SEVERITY_TYPE_ID],
+            'Severity::type'
+        );
     }
 
     /**
@@ -79,5 +94,21 @@ class Severity
     public function getIcon(): Icon
     {
         return $this->icon;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypeAsString(): string
+    {
+        return self::TYPES_AS_STRING[$this->type];
     }
 }

--- a/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindHostSeverityController.php
+++ b/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindHostSeverityController.php
@@ -18,31 +18,27 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
-namespace Core\Severity\RealTime\Infrastructure\Repository;
+namespace Core\Severity\RealTime\Infrastructure\API\FindSeverity;
 
-use Core\Domain\RealTime\Model\Icon;
 use Core\Severity\RealTime\Domain\Model\Severity;
+use Centreon\Application\Controller\AbstractController;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverity;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityPresenterInterface;
 
-class DbSeverityFactory
+class FindHostSeverityController extends AbstractController
 {
     /**
-     * @param array<string, mixed> $record
-     * @return Severity
+     * @param FindSeverity $useCase
+     * @param FindSeverityPresenterInterface $presenter
+     * @return object
      */
-    public static function createFromRecord(array $record): Severity
+    public function __invoke(FindSeverity $useCase, FindSeverityPresenterInterface $presenter): object
     {
-        $icon = (new Icon())
-            ->setName($record['icon_name'])
-            ->setUrl($record['icon_directory'] . DIRECTORY_SEPARATOR . $record['icon_path']);
-
-        return new Severity(
-            (int) $record['id'],
-            $record['name'],
-            (int) $record['level'],
-            (int) $record['type'],
-            $icon
-        );
+        $this->denyAccessUnlessGrantedForApiRealtime();
+        $useCase(Severity::HOST_SEVERITY_TYPE_ID, $presenter);
+        return $presenter->show();
     }
 }

--- a/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindServiceSeverityController.php
+++ b/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindServiceSeverityController.php
@@ -23,11 +23,12 @@ declare(strict_types=1);
 
 namespace Core\Severity\RealTime\Infrastructure\API\FindSeverity;
 
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Centreon\Application\Controller\AbstractController;
 use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverity;
 use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityPresenterInterface;
 
-class FindSeverityController extends AbstractController
+class FindServiceSeverityController extends AbstractController
 {
     /**
      * @param FindSeverity $useCase
@@ -37,7 +38,7 @@ class FindSeverityController extends AbstractController
     public function __invoke(FindSeverity $useCase, FindSeverityPresenterInterface $presenter): object
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-        $useCase($presenter);
+        $useCase(Severity::SERVICE_SEVERITY_TYPE_ID, $presenter);
         return $presenter->show();
     }
 }

--- a/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindSeverityController.php
+++ b/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindSeverityController.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Infrastructure\API\FindSeverity;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverity;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityPresenterInterface;
+
+class FindSeverityController extends AbstractController
+{
+    /**
+     * @param FindSeverity $useCase
+     * @param FindSeverityPresenterInterface $presenter
+     * @return object
+     */
+    public function __invoke(FindSeverity $useCase, FindSeverityPresenterInterface $presenter): object
+    {
+        $this->denyAccessUnlessGrantedForApiRealtime();
+        $useCase($presenter);
+        return $presenter->show();
+    }
+}

--- a/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindSeverityPresenter.php
+++ b/src/Core/Severity/RealTime/Infrastructure/API/FindSeverity/FindSeverityPresenter.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Infrastructure\API\FindSeverity;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityPresenterInterface;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+
+class FindSeverityPresenter extends AbstractPresenter implements FindSeverityPresenterInterface
+{
+    /**
+     * @param RequestParametersInterface $requestParameters
+     * @param PresenterFormatterInterface $presenterFormatter
+     */
+    public function __construct(
+        private RequestParametersInterface $requestParameters,
+        protected PresenterFormatterInterface $presenterFormatter,
+    ) {
+    }
+
+    /**
+     * @param mixed $data
+     */
+    public function present(mixed $data): void
+    {
+        parent::present([
+            'result' => $data->severities,
+            'meta' => $this->requestParameters->toArray()
+        ]);
+    }
+}

--- a/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
+++ b/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
@@ -22,16 +22,97 @@ declare(strict_types=1);
 
 namespace Core\Severity\RealTime\Infrastructure\Repository;
 
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Infrastructure\DatabaseConnection;
+use Centreon\Domain\RequestParameters\RequestParameters;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
 
 class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeverityRepositoryInterface
 {
+    use LoggerTrait;
+
+    /**
+     * @var SqlRequestParametersTranslator
+     */
+    private SqlRequestParametersTranslator $sqlRequestTranslator;
+
+    /**
+     * @param DatabaseConnection $db
+     * @param SqlRequestParametersTranslator $sqlRequestTranslator
+     */
+    public function __construct(DatabaseConnection $db, SqlRequestParametersTranslator $sqlRequestTranslator)
+    {
+        $this->db = $db;
+        $this->sqlRequestTranslator = $sqlRequestTranslator;
+        $this->sqlRequestTranslator
+            ->getRequestParameters()
+            ->setConcordanceStrictMode(RequestParameters::CONCORDANCE_MODE_STRICT);
+        $this->sqlRequestTranslator->setConcordanceArray([
+            'name' => 's.name',
+            'level' => 's.level'
+        ]);
+    }
+
     /**
      * @inheritDoc
      */
-    public function findAll(): array
+    public function findAllByTypeId(int $typeId): array
     {
-        return [];
+        $this->info('Fetching severities from the database');
+
+        $request = 'SELECT SQL_CALC_FOUND_ROWS
+            severity_id,
+            s.id,
+            s.name,
+            s.type,
+            s.level,
+            s.icon_id,
+            img_id AS `icon_id`,
+            img_name AS `icon_name`,
+            img_path AS `icon_path`,
+            imgd.dir_name AS `icon_directory`
+        FROM `:dbstg`.severities s
+        INNER JOIN `:db`.view_img img
+            ON s.icon_id = img.img_id
+        LEFT JOIN `:db`.view_img_dir_relation imgdr
+            ON imgdr.img_img_id = img.img_id
+        INNER JOIN `:db`.view_img_dir imgd
+            ON imgd.dir_id = imgdr.dir_dir_parent_id';
+
+        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
+        $request .= $searchRequest === null ? ' WHERE ' : $searchRequest . ' AND ';
+        $request .= 's.type = :typeId AND img.img_id = s.icon_id';
+
+        // Handle sort
+        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
+        $request .= $sortRequest !== null ? $sortRequest : ' ORDER BY name ASC';
+
+        // Handle pagination
+        $request .= $this->sqlRequestTranslator->translatePaginationToSql();
+        $statement = $this->db->prepare($this->translateDbName($request));
+
+        foreach ($this->sqlRequestTranslator->getSearchValues() as $key => $data) {
+            $type = key($data);
+            $value = $data[$type];
+            $statement->bindValue($key, $value, $type);
+        }
+
+        $statement->bindValue(':typeId', $typeId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        // Set total
+        $result = $this->db->query('SELECT FOUND_ROWS()');
+        if ($result !== false && ($total = $result->fetchColumn()) !== false) {
+            $this->sqlRequestTranslator->getRequestParameters()->setTotal((int) $total);
+        }
+
+        $severities = [];
+        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $severities[] = DbSeverityFactory::createFromRecord($record);
+        }
+
+        return $severities;
     }
 }

--- a/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
+++ b/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Infrastructure\Repository;
+
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
+
+class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeverityRepositoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function findAll(): array
+    {
+        return [];
+    }
+}

--- a/src/Core/Severity/RealTime/Infrastructure/Repository/DbSeverityFactory.php
+++ b/src/Core/Severity/RealTime/Infrastructure/Repository/DbSeverityFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Severity\RealTime\Infrastructure\Repository;
+
+use Core\Domain\RealTime\Model\Icon;
+use Core\Severity\RealTime\Domain\Model\Severity;
+
+class DbSeverityFactory
+{
+    /**
+     * @param array<string, mixed> $data
+     * @return Severity
+     */
+    public static function createFromRecord(array $data): Severity
+    {
+        $icon = (new Icon())
+            ->setName($data['icon_name'])
+            ->setUrl($data['icon_url']);
+
+        return new Severity((int) $data['id'], $data['name'], (int) $data['level'], $icon);
+    }
+}

--- a/tests/php/Centreon/Infrastructure/Monitoring/Resource/DbResourceFactoryTest.php
+++ b/tests/php/Centreon/Infrastructure/Monitoring/Resource/DbResourceFactoryTest.php
@@ -23,101 +23,92 @@ declare(strict_types=1);
 
 namespace Tests\Centreon\Infrastructure\Monitoring\Resource;
 
-use PHPUnit\Framework\TestCase;
 use Centreon\Domain\Monitoring\Resource as ResourceEntity;
 use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Infrastructure\Monitoring\Resource\DbResourceFactory;
 
-class DbResourceFactoryTest extends TestCase
-{
-    /**
-     * @var array<string, string|null>
-     */
-    private array $record;
+use function PHPUnit\Framework\assertNotNull;
 
-    public function setUp(): void
-    {
-        $this->record = [
-            'resource_id' => '9',
-            'name' => 'Ping',
-            'alias' => null,
-            'address' => null,
-            'id' => '104',
-            'internal_id' => null,
-            'parent_id' => '14',
-            'parent_name' => 'Database',
-            'parent_status' => '2',
-            'parent_alias' => 'Database',
-            'parent_status_ordered' => '2',
-            'severity_level' => '10',
-            'type' => '0',
-            'status' => '0',
-            'status_ordered' => '0',
-            'status_confirmed' => '1',
-            'in_downtime' => '0',
-            'acknowledged' => '0',
-            'passive_checks_enabled' => '0',
-            'active_checks_enabled' => '1',
-            'notifications_enabled' => '1',
-            'last_check' => '1651218259',
-            'last_status_change' => '1651211193',
-            'check_attempts' => '1',
-            'max_check_attempts' => '3',
-            'notes' => 'Notes label',
-            'notes_url' => 'https://www.centreon.com',
-            'action_url' => 'https://www.centreon.com',
-            'output' => 'OK - localhost rta 0.257ms lost 0%',
-            'poller_id' => '1',
-            'has_graph' => '1',
-            'monitoring_server_name' => 'Central',
-            'enabled' => '1',
-            'icon_id' => '0'
-        ];
-    }
+beforeEach(function () {
+    $this->record = [
+        'resource_id' => '9',
+        'name' => 'Ping',
+        'alias' => null,
+        'address' => null,
+        'id' => '104',
+        'internal_id' => null,
+        'parent_id' => '14',
+        'parent_name' => 'Database',
+        'parent_status' => '2',
+        'parent_alias' => 'Database',
+        'parent_status_ordered' => '2',
+        'type' => '0',
+        'status' => '0',
+        'status_ordered' => '0',
+        'status_confirmed' => '1',
+        'in_downtime' => '0',
+        'acknowledged' => '0',
+        'passive_checks_enabled' => '0',
+        'active_checks_enabled' => '1',
+        'notifications_enabled' => '1',
+        'last_check' => '1651218259',
+        'last_status_change' => '1651211193',
+        'check_attempts' => '1',
+        'max_check_attempts' => '3',
+        'notes' => 'Notes label',
+        'notes_url' => 'https://www.centreon.com',
+        'action_url' => 'https://www.centreon.com',
+        'output' => 'OK - localhost rta 0.257ms lost 0%',
+        'poller_id' => '1',
+        'has_graph' => '1',
+        'monitoring_server_name' => 'Central',
+        'enabled' => '1',
+        'icon_id' => '0',
+        'severity_id' => '10',
+        'severity_name' => 'High',
+        'severity_level' => '50',
+        'severity_icon_id' => '1',
+        'severity_type' => '0',
+    ];
+});
 
-    /**
-     * Test that resource is properly created
-     */
-    public function testResourceCreation(): void
-    {
-        $resource = DbResourceFactory::createFromRecord($this->record);
+it('should create a resource model from record', function () {
+    $resource = DbResourceFactory::createFromRecord($this->record);
+    expect($resource->getId())->toBe((int) $this->record['id']);
+    expect($resource->getParent()?->getId())->toBe((int) $this->record['parent_id']);
+    expect($resource->getName())->toBe($this->record['name']);
+    expect($resource->getAlias())->toBeNull();
+    expect($resource->getFqdn())->toBeNull();
+    expect($resource->getParent()?->getName())->toBe($this->record['parent_name']);
+    expect($resource->getParent()?->getStatus()?->getCode())->toBe((int) $this->record['parent_status']);
+    expect(ResourceStatus::SEVERITY_LOW)->toBe($resource->getParent()?->getStatus()?->getSeverityCode());
+    expect($this->record['parent_alias'])->toBe($resource->getParent()?->getAlias());
+    expect(ResourceEntity::TYPE_SERVICE)->toBe($resource->getType());
+    expect(ResourceStatus::STATUS_NAME_OK)->toBe($resource->getStatus()?->getName());
+    expect((int) $this->record['status'])->toBe($resource->getStatus()?->getCode());
+    expect(ResourceStatus::SEVERITY_OK)->toBe($resource->getStatus()?->getSeverityCode());
 
-        $this->assertEquals((int) $this->record['id'], $resource->getId());
-        $this->assertEquals((int) $this->record['parent_id'], $resource->getParent()->getId());
-        $this->assertEquals($this->record['name'], $resource->getName());
-        $this->assertNull($resource->getAlias());
-        $this->assertNull($resource->getFqdn());
-        $this->assertEquals($this->record['parent_name'], $resource->getParent()->getName());
-        $this->assertEquals((int) $this->record['parent_status'], $resource->getParent()->getStatus()->getCode());
-        $this->assertEquals(ResourceStatus::SEVERITY_LOW, $resource->getParent()->getStatus()->getSeverityCode());
-        $this->assertEquals($this->record['parent_alias'], $resource->getParent()->getAlias());
-        $this->assertEquals((int) $this->record['severity_level'], $resource->getSeverityLevel());
-        $this->assertEquals(ResourceEntity::TYPE_SERVICE, $resource->getType());
-        $this->assertEquals(ResourceStatus::STATUS_NAME_OK, $resource->getStatus()->getName());
-        $this->assertEquals((int) $this->record['status'], $resource->getStatus()->getCode());
-        $this->assertEquals(ResourceStatus::SEVERITY_OK, $resource->getStatus()->getSeverityCode());
+    $statusConfirmedAsString = (int) $this->record['status_confirmed'] === 1 ? 'H' : 'S';
+    $tries = $this->record['check_attempts']
+        . '/' . $this->record['max_check_attempts'] . ' (' . $statusConfirmedAsString . ')';
 
-        $statusConfirmedAsString = (int) $this->record['status_confirmed'] === 1 ? 'H' : 'S';
-        $tries = $this->record['check_attempts']
-            . '/' . $this->record['max_check_attempts'] . ' (' . $statusConfirmedAsString . ')';
-
-        $this->assertEquals($tries, $resource->getTries());
-        $this->assertFalse($resource->getInDowntime());
-        $this->assertFalse($resource->getAcknowledged());
-        $this->assertFalse($resource->getPassiveChecks());
-        $this->assertTrue($resource->getActiveChecks());
-        $this->assertTrue($resource->isNotificationEnabled());
-        $this->assertEquals((int) $this->record['last_check'], $resource->getLastCheck()->getTimestamp());
-        $this->assertEquals(
-            (int) $this->record['last_status_change'],
-            $resource->getLastStatusChange()->getTimestamp()
-        );
-
-        $this->assertEquals($this->record['notes'], $resource->getLinks()->getExternals()->getNotes()->getLabel());
-        $this->assertEquals($this->record['notes_url'], $resource->getLinks()->getExternals()->getNotes()->getUrl());
-        $this->assertEquals($this->record['action_url'], $resource->getLinks()->getExternals()->getActionUrl());
-        $this->assertEquals($this->record['output'], $resource->getInformation());
-        $this->assertEquals($this->record['monitoring_server_name'], $resource->getMonitoringServerName());
-        $this->assertTrue($resource->hasGraph());
-    }
-}
+    expect($resource->getTries())->toBe($tries);
+    expect($resource->getInDowntime())->toBeFalse();
+    expect($resource->getAcknowledged())->toBeFalse();
+    expect($resource->getPassiveChecks())->toBeFalse();
+    expect($resource->getActiveChecks())->toBeTrue();
+    expect($resource->isNotificationEnabled())->toBeTrue();
+    expect($resource->getLastCheck()?->getTimestamp())->toBe((int) $this->record['last_check']);
+    expect($resource->getLastStatusChange()?->getTimestamp())->toBe((int) $this->record['last_status_change']);
+    expect($resource->getLinks()->getExternals()->getNotes()?->getLabel())->toBe($this->record['notes']);
+    expect($resource->getLinks()->getExternals()->getNotes()?->getUrl())->toBe($this->record['notes_url']);
+    expect($resource->getLinks()->getExternals()->getActionUrl())->toBe($this->record['action_url']);
+    expect($resource->getInformation())->toBe($this->record['output']);
+    expect($resource->getMonitoringServerName())->toBe($this->record['monitoring_server_name']);
+    expect($resource->hasGraph())->toBeTrue();
+    expect($resource->getSeverity()?->getName())->toBe($this->record['severity_name']);
+    expect($resource->getSeverity()?->getId())->toBe((int) $this->record['severity_id']);
+    expect($resource->getSeverity()?->getLevel())->toBe((int) $this->record['severity_level']);
+    expect($resource->getSeverity()?->getType())->toBe((int) $this->record['severity_type']);
+    expect($resource->getSeverity()?->getIcon()->getId())->toBe((int) $this->record['severity_icon_id']);
+});

--- a/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityPresenterStub.php
+++ b/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityPresenterStub.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Severity\RealTime\Application\UseCase\FindSeverity;
+
+use Symfony\Component\HttpFoundation\Response;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityResponse;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityPresenterInterface;
+
+class FindSeverityPresenterStub extends AbstractPresenter implements
+    FindSeverityPresenterInterface
+{
+    /**
+     * @var FindSeverityResponse
+     */
+    public $response;
+
+    /**
+     * @param FindSeverityResponse $response
+     */
+    public function present(mixed $response): void
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response
+     */
+    public function show(): Response
+    {
+        return new Response();
+    }
+}

--- a/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
+++ b/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
@@ -40,11 +40,12 @@ it('should present an ErrorResponse when an exception is thrown', function () {
     $useCase = new FindSeverity($this->repository);
     $this->repository
         ->expects($this->once())
-        ->method('findAll')
+        ->method('findAllByTypeId')
+        ->with(Severity::HOST_SEVERITY_TYPE_ID)
         ->willThrowException(new \Exception());
 
     $presenter = new FindSeverityPresenterStub($this->presenterFormatter);
-    $useCase($presenter);
+    $useCase(Severity::HOST_SEVERITY_TYPE_ID, $presenter);
 
     expect($presenter->getResponseStatus())->toBeInstanceOf(ErrorResponse::class)
         ->and($presenter->getResponseStatus()?->getMessage())
@@ -58,15 +59,15 @@ it('should present a FindSeverityResponse', function () {
         ->setName('icon-name')
         ->setUrl('ppm/icon-name.png');
 
-    $severity = new Severity(1, 'name', 50, $icon);
+    $severity = new Severity(1, 'name', 50, Severity::HOST_SEVERITY_TYPE_ID, $icon);
 
     $this->repository
         ->expects($this->once())
-        ->method('findAll')
+        ->method('findAllByTypeId')
         ->willReturn([$severity]);
 
     $presenter = new FindSeverityPresenterStub($this->presenterFormatter);
-    $useCase($presenter);
+    $useCase(Severity::HOST_SEVERITY_TYPE_ID, $presenter);
     expect($presenter->response)
         ->toBeInstanceOf(FindSeverityResponse::class)
         ->and($presenter->response->severities[0])->toBe(
@@ -74,6 +75,7 @@ it('should present a FindSeverityResponse', function () {
                 'id' => 1,
                 'name' => 'name',
                 'level' => 50,
+                'type' => 'host',
                 'icon' => [
                     'name' => 'icon-name',
                     'url' => 'ppm/icon-name.png'

--- a/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
+++ b/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Severity\RealTime\Application\UseCase\FindSeverity;
+
+use Core\Domain\RealTime\Model\Icon;
+use Core\Severity\RealTime\Domain\Model\Severity;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverity;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
+use Core\Severity\RealTime\Application\UseCase\FindSeverity\FindSeverityResponse;
+
+beforeEach(function () {
+    $this->repository = $this->createMock(ReadSeverityRepositoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+});
+
+it('should present an ErrorResponse when an exception is thrown', function () {
+    $useCase = new FindSeverity($this->repository);
+    $this->repository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willThrowException(new \Exception());
+
+    $presenter = new FindSeverityPresenterStub($this->presenterFormatter);
+    $useCase($presenter);
+
+    expect($presenter->getResponseStatus())->toBeInstanceOf(ErrorResponse::class)
+        ->and($presenter->getResponseStatus()?->getMessage())
+            ->toBe('An error occured while retrieving severities');
+});
+
+it('should present a FindSeverityResponse', function () {
+    $useCase = new FindSeverity($this->repository);
+
+    $icon = (new Icon())
+        ->setName('icon-name')
+        ->setUrl('ppm/icon-name.png');
+
+    $severity = new Severity(1, 'name', 50, $icon);
+
+    $this->repository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willReturn([$severity]);
+
+    $presenter = new FindSeverityPresenterStub($this->presenterFormatter);
+    $useCase($presenter);
+    expect($presenter->response)
+        ->toBeInstanceOf(FindSeverityResponse::class)
+        ->and($presenter->response->severities[0])->toBe(
+            [
+                'id' => 1,
+                'name' => 'name',
+                'level' => 50,
+                'icon' => [
+                    'name' => 'icon-name',
+                    'url' => 'ppm/icon-name.png'
+                ]
+            ]
+        );
+});

--- a/tests/php/Core/Severity/RealTime/Domain/Model/SeverityTest.php
+++ b/tests/php/Core/Severity/RealTime/Domain/Model/SeverityTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Tests\Core\Severity\RealTime\Domain\Model;
+
+use Core\Domain\RealTime\Model\Icon;
+use Core\Severity\RealTime\Domain\Model\Severity;
+use Centreon\Domain\Common\Assertion\AssertionException;
+
+beforeEach(function () {
+    $this->icon = (new Icon())
+        ->setName('icon-name')
+        ->setUrl('ppm/icon-name.png');
+});
+
+it('should throw an exception when severity name is empty', function () {
+    new Severity(1, '', 50, $this->icon);
+})->throws(
+    \Assert\InvalidArgumentException::class,
+    AssertionException::notEmpty('Severity::name')
+        ->getMessage()
+);
+
+it('should throw an exception when severity name is too long', function () {
+    new Severity(1, str_repeat('a', Severity::MAX_NAME_LENGTH + 1), 50, $this->icon);
+})->throws(
+    \Assert\InvalidArgumentException::class,
+    AssertionException::maxLength(
+        str_repeat('a', Severity::MAX_NAME_LENGTH + 1),
+        Severity::MAX_NAME_LENGTH + 1,
+        Severity::MAX_NAME_LENGTH,
+        'Severity::name'
+    )->getMessage()
+);
+
+it('should throw an exception when severity level is lower than 0', function () {
+    new Severity(1, 'name', -1, $this->icon);
+})->throws(\Assert\InvalidArgumentException::class, AssertionException::min(-1, 0, 'Severity::level')->getMessage());
+
+it('should throw an exception when severity level is greater than 100', function () {
+    new Severity(1, 'name', 200, $this->icon);
+})->throws(\Assert\InvalidArgumentException::class, AssertionException::max(200, 100, 'Severity::level')->getMessage());

--- a/tests/php/Core/Severity/RealTime/Domain/Model/SeverityTest.php
+++ b/tests/php/Core/Severity/RealTime/Domain/Model/SeverityTest.php
@@ -33,7 +33,7 @@ beforeEach(function () {
 });
 
 it('should throw an exception when severity name is empty', function () {
-    new Severity(1, '', 50, $this->icon);
+    new Severity(1, '', 50, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
 })->throws(
     \Assert\InvalidArgumentException::class,
     AssertionException::notEmpty('Severity::name')
@@ -41,7 +41,7 @@ it('should throw an exception when severity name is empty', function () {
 );
 
 it('should throw an exception when severity name is too long', function () {
-    new Severity(1, str_repeat('a', Severity::MAX_NAME_LENGTH + 1), 50, $this->icon);
+    new Severity(1, str_repeat('a', Severity::MAX_NAME_LENGTH + 1), 50, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
 })->throws(
     \Assert\InvalidArgumentException::class,
     AssertionException::maxLength(
@@ -53,9 +53,20 @@ it('should throw an exception when severity name is too long', function () {
 );
 
 it('should throw an exception when severity level is lower than 0', function () {
-    new Severity(1, 'name', -1, $this->icon);
+    new Severity(1, 'name', -1, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
 })->throws(\Assert\InvalidArgumentException::class, AssertionException::min(-1, 0, 'Severity::level')->getMessage());
 
 it('should throw an exception when severity level is greater than 100', function () {
-    new Severity(1, 'name', 200, $this->icon);
+    new Severity(1, 'name', 200, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
 })->throws(\Assert\InvalidArgumentException::class, AssertionException::max(200, 100, 'Severity::level')->getMessage());
+
+it('should throw an exception when severity type is not handled', function () {
+    new Severity(1, 'name', 60, 2, $this->icon);
+})->throws(
+    \Assert\InvalidArgumentException::class,
+    AssertionException::inArray(
+        2,
+        [Severity::HOST_SEVERITY_TYPE_ID, Severity::SERVICE_SEVERITY_TYPE_ID],
+        'Severity::type'
+    )->getMessage()
+);


### PR DESCRIPTION
## Description

This PR adds everything to handle severities in Resource Status listing
- Adds support for service|host_severity_names filter
- Adds support for service|host_severity_levels filter
- Returns new key `severity` with more information regarding the severity attached to the resource

<img width="892" alt="image" src="https://user-images.githubusercontent.com/31647811/175043054-23e1a1ad-3a30-47fa-a61a-89176bbcf968.png">


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
