### PR TITLE
fix(topology) fix wizard poller access

### DIFF
--- a/src/Centreon/Application/Webservice/TopologyWebservice.php
+++ b/src/Centreon/Application/Webservice/TopologyWebservice.php
@@ -220,9 +220,9 @@ class TopologyWebservice extends Webservice\WebServiceAbstract implements
     }
 
     /**
-     * @return Topology|null
+     * @return Topology
      */
-    private function createPollerWizardTopology(): ?Topology
+    private function createPollerWizardTopology(): Topology
     {
         $topology = new Topology();
         $topology->setTopologyUrl("/poller-wizard/1");

--- a/src/Centreon/Application/Webservice/TopologyWebservice.php
+++ b/src/Centreon/Application/Webservice/TopologyWebservice.php
@@ -214,15 +214,14 @@ class TopologyWebservice extends Webservice\WebServiceAbstract implements
             return null;
         }
 
-        $entity = new Topology();
-        $entity->setTopologyUrl("/poller-wizard/1");
-        $entity->setTopologyPage('60959');
-        $entity->setTopologyParent('60901');
-        $entity->setTopologyName("Poller Wizard Page");
-        $entity->setTopologyShow('0');
-        $entity->setIsReact('1');
-        $entities[] = $entity;
+        $topology = new Topology();
+        $topology->setTopologyUrl("/poller-wizard/1");
+        $topology->setTopologyPage('60959');
+        $topology->setTopologyParent('60901');
+        $topology->setTopologyName("Poller Wizard Page");
+        $topology->setTopologyShow('0');
+        $topology->setIsReact('1');
 
-        return $entity;
+        return $topology;
     }
 }

--- a/src/Centreon/Application/Webservice/TopologyWebservice.php
+++ b/src/Centreon/Application/Webservice/TopologyWebservice.php
@@ -205,7 +205,7 @@ class TopologyWebservice extends Webservice\WebServiceAbstract implements
 
     /**
      * @param \CentreonUser $user
-     * @return Topology|null
+     * @return bool
      */
     private function isPollerWizardAccessible(\CentreonUser $user): bool
     {
@@ -219,6 +219,9 @@ class TopologyWebservice extends Webservice\WebServiceAbstract implements
         return false;
     }
 
+    /**
+     * @return Topology|null
+     */
     private function createPollerWizardTopology(): ?Topology
     {
         $topology = new Topology();

--- a/src/Centreon/Application/Webservice/TopologyWebservice.php
+++ b/src/Centreon/Application/Webservice/TopologyWebservice.php
@@ -189,8 +189,8 @@ class TopologyWebservice extends Webservice\WebServiceAbstract implements
             ->getRepository(TopologyRepository::class)
             ->getTopologyList($user);
 
-        if ($pollerWizardEntities = $this->determinePollerWizardAccess($user)) {
-            $dbResult[] = $pollerWizardEntities;
+        if ($pollerWizardEntity = $this->determinePollerWizardAccess($user)) {
+            $dbResult[] = $pollerWizardEntity;
         }
 
         $status = true;

--- a/src/Centreon/Application/Webservice/TopologyWebservice.php
+++ b/src/Centreon/Application/Webservice/TopologyWebservice.php
@@ -210,13 +210,11 @@ class TopologyWebservice extends Webservice\WebServiceAbstract implements
     private function isPollerWizardAccessible(\CentreonUser $user): bool
     {
         $userTopologyAccess = $user->access->getTopology();
-        if (
+
+        return (
             isset($userTopologyAccess[self::POLLER_PAGE])
             && (int) $userTopologyAccess[self::POLLER_PAGE] === \CentreonACL::ACL_ACCESS_READ_WRITE
-        ) {
-            return true;
-        }
-        return false;
+        );
     }
 
     /**

--- a/src/Centreon/Tests/Application/Webservice/TopologyWebserviceTest.php
+++ b/src/Centreon/Tests/Application/Webservice/TopologyWebserviceTest.php
@@ -64,7 +64,7 @@ class TopologyWebserviceTest extends TestCase
         // dependencies
         $this->container = new Container;
         $this->db = new CentreonDB;
-        
+
         $this->setUpCentreonDbManager($this->container);
 
         $this->webservice = $this->createPartialMock(TopologyWebservice::class, [
@@ -153,12 +153,21 @@ class TopologyWebserviceTest extends TestCase
                 return [];
             }));
 
+        $centreonAclMock = $this->createMock(\CentreonACL::class);
+        $centreonAclMock->method('getTopology')
+            ->will($this->returnCallback(function () {
+                return [];
+            }));
+
+        $userMock = $this->createMock(CentreonUser::class);
+        $userMock->access = $centreonAclMock;
+
         // register mocked repository in DB manager
         $this->container[ServiceProvider::CENTREON_DB_MANAGER]
             ->addRepositoryMock(TopologyRepository::class, $repository);
 
         // mock user service
-        $this->container[ServiceProvider::CENTREON_USER] = $this->createMock(CentreonUser::class);
+        $this->container[ServiceProvider::CENTREON_USER] = $userMock;
         $this->container[ServiceProvider::YML_CONFIG] = [
             'navigation' => [],
         ];
@@ -180,12 +189,21 @@ class TopologyWebserviceTest extends TestCase
                 return [];
             }));
 
+        $centreonAclMock = $this->createMock(\CentreonACL::class);
+        $centreonAclMock->method('getTopology')
+            ->will($this->returnCallback(function () {
+                return [];
+            }));
+
+        $userMock = $this->createMock(CentreonUser::class);
+        $userMock->access = $centreonAclMock;
+
         // register mocked repository in DB manager
         $this->container[ServiceProvider::CENTREON_DB_MANAGER]
             ->addRepositoryMock(TopologyRepository::class, $repository);
 
         // mock user service
-        $this->container[ServiceProvider::CENTREON_USER] = $this->createMock(CentreonUser::class);
+        $this->container[ServiceProvider::CENTREON_USER] = $userMock;
         $this->container[ServiceProvider::YML_CONFIG] = [
             'navigation' => [],
         ];


### PR DESCRIPTION
## Description

Removing poller wizard steps from topology table result in the poller wizard page being inaccessible ('you are not allowed to see this page')
When user has read/write access on the poller page, the necessary data to allow access the poller wizard page is added to the response of the 'getNavigationList' API call.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
