### PR TITLE
enh(resources): handle severities in the listing

### DIFF
--- a/config/packages/Centreon.yaml
+++ b/config/packages/Centreon.yaml
@@ -10,6 +10,9 @@ jms_serializer:
             infrastructure:
                 namespace_prefix: "Centreon\\Infrastructure"
                 path: '%kernel.project_dir%/config/packages/serializer/Infrastructure'
+            core:
+                namespace_prefix: "Core\\"
+                path: '%kernel.project_dir%/config/packages/serializer/Core'
 parameters:
     api.header: "Api-Version"
     api.version.latest: "22.10"

--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -123,3 +123,7 @@ Centreon\Domain\Monitoring\Resource:
             type: bool
             groups:
                 - 'resource_main'
+        severity:
+            type: Core\Severity\RealTime\Domain\Model\Severity
+            groups:
+                - 'resource_main'

--- a/config/packages/serializer/Centreon/Monitoring.ResourceFilter.yml
+++ b/config/packages/serializer/Centreon/Monitoring.ResourceFilter.yml
@@ -16,6 +16,14 @@ Centreon\Domain\Monitoring\ResourceFilter:
             type: array<string>
         monitoringServerNames:
             type: array<string>
+        serviceSeverityNames:
+            type: array<string>
+        hostSeverityNames:
+            type: array<string>
+        serviceSeverityLevels:
+            type: array<integer>
+        hostSeverityLevels:
+            type: array<integer>
         statusTypes:
             type: array<string>
         onlyWithPerformanceData:

--- a/config/packages/serializer/Core/Domain.RealTime.Model.Icon.yml
+++ b/config/packages/serializer/Core/Domain.RealTime.Model.Icon.yml
@@ -1,0 +1,14 @@
+Core\Domain\RealTime\Model\Icon:
+    properties:
+        id:
+            type: integer
+            groups:
+                - 'core_icon_main'
+        name:
+            type: string
+            groups:
+                - 'core_icon_main'
+        url:
+            type: string
+            groups:
+                - 'core_icon_main'

--- a/config/packages/serializer/Core/Severity.RealTime.Domain.Model.Severity.yml
+++ b/config/packages/serializer/Core/Severity.RealTime.Domain.Model.Severity.yml
@@ -1,0 +1,25 @@
+Core\Severity\RealTime\Domain\Model\Severity:
+    virtual_properties:
+        getTypeAsString:
+            name: getTypeAsString
+            serialized_name: type
+            type: string
+            groups:
+                - 'severity_main'
+    properties:
+        id:
+            type: integer
+            groups:
+                - 'severity_main'
+        name:
+            type: string
+            groups:
+                - 'severity_main'
+        level:
+            type: integer
+            groups:
+                - 'severity_main'
+        icon:
+            type: Core\Domain\RealTime\Model\Icon
+            groups:
+                - 'severity_main'

--- a/config/packages/validator/validation.yaml
+++ b/config/packages/validator/validation.yaml
@@ -263,6 +263,38 @@ Centreon\Domain\Monitoring\ResourceFilter:
                 - Type:
                     type: string
                     groups: [Default]
+        serviceSeverityNames:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: string
+                    groups: [Default]
+        hostSeverityNames:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: string
+                    groups: [Default]
+        serviceSeverityLevels:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: integer
+                    groups: [Default]
+        hostSeverityLevels:
+            - Type:
+                type: array
+                groups: [Default]
+            - All:
+                - Type:
+                    type: integer
+                    groups: [Default]
         statusTypes:
             - Type:
                 type: array

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -1285,15 +1285,12 @@ paths:
         - $ref: '#/components/parameters/ResourceFilterStatus'
         - $ref: '#/components/parameters/ResourceFilterHostgroupName'
         - $ref: '#/components/parameters/ResourceFilterServicegroupName'
-<<<<<<< HEAD
         - $ref: '#/components/parameters/ResourceFilterServiceCategoryName'
         - $ref: '#/components/parameters/ResourceFilterHostCategoryName'
-=======
         - $ref: '#/components/parameters/ResourceFilterHostSeverityName'
         - $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
         - $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
         - $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
->>>>>>> 9dfca04fda (enh(resources): handle severities in the listing)
         - $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
         - $ref: '#/components/parameters/ResourceFilterStatusTypes'
       responses:
@@ -4162,11 +4159,6 @@ components:
       name: service_category_names
       required: false
       description: "Filter the resources by service category names"
-    ResourceFilterServiceSeverityName:
-      in: query
-      name: service_severity_names
-      required: false
-      description: "Filter the resources by service severity names (only functional with optimized mod)"
       schema:
         type: array
         items:
@@ -4177,7 +4169,21 @@ components:
       name: host_category_names
       required: false
       description: "Filter the resources by host category names"
-        example: '["High", "Low"]'
+      schema:
+        type: array
+        items:
+          type: string
+        example: '["Linux", "Windows"]'
+    ResourceFilterServiceSeverityName:
+      in: query
+      name: service_severity_names
+      required: false
+      description: "Filter the resources by service severity names (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: string
+        example: '["Ping", "CPUs"]'
     ResourceFilterHostSeverityName:
       in: query
       name: host_severity_names
@@ -4188,7 +4194,6 @@ components:
         items:
           type: string
         example: '["Linux", "Windows"]'
-        example: '["High", "Low"]'
     ResourceFilterHostSeverityLevel:
       in: query
       name: host_severity_levels

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -1285,8 +1285,15 @@ paths:
         - $ref: '#/components/parameters/ResourceFilterStatus'
         - $ref: '#/components/parameters/ResourceFilterHostgroupName'
         - $ref: '#/components/parameters/ResourceFilterServicegroupName'
+<<<<<<< HEAD
         - $ref: '#/components/parameters/ResourceFilterServiceCategoryName'
         - $ref: '#/components/parameters/ResourceFilterHostCategoryName'
+=======
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
+>>>>>>> 9dfca04fda (enh(resources): handle severities in the listing)
         - $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
         - $ref: '#/components/parameters/ResourceFilterStatusTypes'
       responses:
@@ -4155,6 +4162,11 @@ components:
       name: service_category_names
       required: false
       description: "Filter the resources by service category names"
+    ResourceFilterServiceSeverityName:
+      in: query
+      name: service_severity_names
+      required: false
+      description: "Filter the resources by service severity names (only functional with optimized mod)"
       schema:
         type: array
         items:
@@ -4165,11 +4177,38 @@ components:
       name: host_category_names
       required: false
       description: "Filter the resources by host category names"
+        example: '["High", "Low"]'
+    ResourceFilterHostSeverityName:
+      in: query
+      name: host_severity_names
+      required: false
+      description: "Filter the resources by host severity names (only functional with optimized mod)"
       schema:
         type: array
         items:
           type: string
         example: '["Linux", "Windows"]'
+        example: '["High", "Low"]'
+    ResourceFilterHostSeverityLevel:
+      in: query
+      name: host_severity_levels
+      required: false
+      description: "Filter the resources by host severity levels (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: integer
+        example: '[50, 75]'
+    ResourceFilterServiceSeverityLevel:
+      in: query
+      name: service_severity_levels
+      required: false
+      description: "Filter the resources by service severity levels (only functional with optimized mod)"
+      schema:
+        type: array
+        items:
+          type: integer
+        example: '[50, 75]'
     ResourceFilterMonitoringServerName:
       in: query
       name: monitoring_server_names

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -4178,7 +4178,7 @@ components:
       in: query
       name: service_severity_names
       required: false
-      description: "Filter the resources by service severity names (only functional with optimized mod)"
+      description: "Filter the resources by service severity names"
       schema:
         type: array
         items:
@@ -4188,7 +4188,7 @@ components:
       in: query
       name: host_severity_names
       required: false
-      description: "Filter the resources by host severity names (only functional with optimized mod)"
+      description: "Filter the resources by host severity names"
       schema:
         type: array
         items:
@@ -4198,7 +4198,7 @@ components:
       in: query
       name: host_severity_levels
       required: false
-      description: "Filter the resources by host severity levels (only functional with optimized mod)"
+      description: "Filter the resources by host severity levels"
       schema:
         type: array
         items:
@@ -4208,7 +4208,7 @@ components:
       in: query
       name: service_severity_levels
       required: false
-      description: "Filter the resources by service severity levels (only functional with optimized mod)"
+      description: "Filter the resources by service severity levels"
       schema:
         type: array
         items:

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -129,12 +129,14 @@ class MonitoringResourceController extends AbstractController
         ResourceEntity::SERIALIZER_GROUP_PARENT,
         Icon::SERIALIZER_GROUP_MAIN,
         ResourceStatus::SERIALIZER_GROUP_MAIN,
-        NewIconModel::SERIALIZER_GROUP_MAIN,
-        Severity::SERIALIZER_GROUP_MAIN,
+        self::ICON_GROUP_MAIN,
+        self::SEVERITY_GROUP_MAIN,
     ];
 
     // Groups for validation
     public const VALIDATION_GROUP_MAIN = 'resource_id_main';
+    public const SEVERITY_GROUP_MAIN = 'severity_main';
+    public const ICON_GROUP_MAIN = 'core_icon_main';
 
     /**
      * @var ResourceServiceInterface

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -31,6 +31,8 @@ use Centreon\Domain\Entity\EntityValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Centreon\Domain\Monitoring\ResourceFilter;
 use Centreon\Domain\Monitoring\ResourceStatus;
+use Core\Severity\RealTime\Domain\Model\Severity;
+use Core\Domain\RealTime\Model\Icon as NewIconModel;
 use Centreon\Application\Normalizer\IconUrlNormalizer;
 use JMS\Serializer\Exception\ValidationFailedException;
 use Centreon\Domain\RequestParameters\RequestParameters;
@@ -62,6 +64,10 @@ class MonitoringResourceController extends AbstractController
         'monitoring_server_names',
         'service_category_names',
         'host_category_names',
+        'service_severity_names',
+        'host_severity_names',
+        'host_severity_levels',
+        'service_severity_levels',
         'status_types',
     ];
 
@@ -123,6 +129,8 @@ class MonitoringResourceController extends AbstractController
         ResourceEntity::SERIALIZER_GROUP_PARENT,
         Icon::SERIALIZER_GROUP_MAIN,
         ResourceStatus::SERIALIZER_GROUP_MAIN,
+        NewIconModel::SERIALIZER_GROUP_MAIN,
+        Severity::SERIALIZER_GROUP_MAIN,
     ];
 
     // Groups for validation
@@ -237,6 +245,10 @@ class MonitoringResourceController extends AbstractController
 
             if ($resource->getParent() !== null && $resource->getParent()->getIcon() instanceof Icon) {
                 $this->iconUrlNormalizer->normalize($resource->getParent()->getIcon());
+            }
+
+            if ($resource->getSeverity() !== null && $resource->getSeverity()->getIcon() instanceof NewIconModel) {
+                $this->iconUrlNormalizer->normalize($resource->getSeverity()->getIcon());
             }
 
             // add shortcuts

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -28,6 +28,7 @@ use Centreon\Domain\Downtime\Downtime;
 use Centreon\Domain\Monitoring\ResourceGroup;
 use Centreon\Domain\Monitoring\ResourceLinks;
 use Centreon\Domain\Monitoring\ResourceStatus;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Centreon\Domain\Acknowledgement\Acknowledgement;
 
 /**
@@ -55,6 +56,11 @@ class Resource
     public const TYPE_SERVICE = 'service';
     public const TYPE_HOST = 'host';
     public const TYPE_META = 'metaservice';
+
+    /**
+     * @var int|null
+     */
+    private $resourceId;
 
     /**
      * @var int|null
@@ -266,6 +272,11 @@ class Resource
      * @var bool
      */
     private $hasGraph = false;
+
+    /**
+    * @var Severity|null
+    */
+    private $severity;
 
     /**
      * Resource constructor.
@@ -1103,5 +1114,43 @@ class Resource
     public function hasGraph(): bool
     {
         return $this->hasGraph;
+    }
+
+    /**
+     * @param integer|null $resourceId
+     * @return self
+     */
+    public function setResourceId(?int $resourceId): self
+    {
+        $this->resourceId = $resourceId;
+
+        return $this;
+    }
+
+    /**
+     * @return integer|null
+     */
+    public function getResourceId(): ?int
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * @param Severity|null $severity
+     * @return self
+     */
+    public function setSeverity(?Severity $severity): self
+    {
+        $this->severity = $severity;
+
+        return $this;
+    }
+
+    /**
+     * @return Severity|null
+     */
+    public function getSeverity(): ?Severity
+    {
+        return $this->severity;
     }
 }

--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -159,6 +159,26 @@ class ResourceFilter
     private $statusTypes = [];
 
     /**
+     * @var string[]
+     */
+    private array $serviceSeverityNames = [];
+
+    /**
+     * @var string[]
+     */
+    private array $hostSeverityNames = [];
+
+    /**
+     * @var int[]
+     */
+    private array $serviceSeverityLevels = [];
+
+    /**
+     * @var int[]
+     */
+    private array $hostSeverityLevels = [];
+
+    /**
      * Transform result by map
      *
      * @param array<mixed, mixed> $list
@@ -439,6 +459,18 @@ class ResourceFilter
     public function setServiceCategoryNames(array $serviceCategoryNames): self
     {
         $this->serviceCategoryNames = $serviceCategoryNames;
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $serviceSeverityNames
+     * @return self
+     */
+    public function setServiceSeverityNames(array $serviceSeverityNames): self
+    {
+        $this->serviceSeverityNames = $serviceSeverityNames;
+
         return $this;
     }
 
@@ -457,6 +489,26 @@ class ResourceFilter
     public function setHostCategoryNames(array $hostCategoryNames): self
     {
         $this->hostCategoryNames = $hostCategoryNames;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getServiceSeverityNames(): array
+    {
+        return $this->serviceSeverityNames;
+    }
+
+    /**
+     * @param string[] $hostSeverityNames
+     * @return self
+     */
+    public function setHostSeverityNames(array $hostSeverityNames): self
+    {
+        $this->hostSeverityNames = $hostSeverityNames;
+
         return $this;
     }
 
@@ -466,5 +518,51 @@ class ResourceFilter
     public function getHostCategoryNames(): array
     {
         return $this->hostCategoryNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHostSeverityNames(): array
+    {
+        return $this->hostSeverityNames;
+    }
+
+    /**
+     * @param int[] $serviceSeverityLevels
+     * @return self
+     */
+    public function setServiceSeverityLevels(array $serviceSeverityLevels): self
+    {
+        $this->serviceSeverityLevels = $serviceSeverityLevels;
+
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getServiceSeverityLevels(): array
+    {
+        return $this->serviceSeverityLevels;
+    }
+
+    /**
+     * @param int[] $hostSeverityLevels
+     * @return self
+     */
+    public function setHostSeverityLevels(array $hostSeverityLevels): self
+    {
+        $this->hostSeverityLevels = $hostSeverityLevels;
+
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getHostSeverityLevels(): array
+    {
+        return $this->hostSeverityLevels;
     }
 }

--- a/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
@@ -141,6 +141,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
      */
     public function findResources(ResourceFilter $filter): array
     {
+        $this->resources = [];
+
         if ($this->hasNotEnoughRightsToContinue()) {
             return $this->resources;
         }

--- a/src/Core/Domain/RealTime/Model/Icon.php
+++ b/src/Core/Domain/RealTime/Model/Icon.php
@@ -24,8 +24,6 @@ namespace Core\Domain\RealTime\Model;
 
 class Icon
 {
-    public const SERIALIZER_GROUP_MAIN = 'core_icon_main';
-
     /**
      * @var int|null
      */

--- a/src/Core/Domain/RealTime/Model/Icon.php
+++ b/src/Core/Domain/RealTime/Model/Icon.php
@@ -24,6 +24,13 @@ namespace Core\Domain\RealTime\Model;
 
 class Icon
 {
+    public const SERIALIZER_GROUP_MAIN = 'core_icon_main';
+
+    /**
+     * @var int|null
+     */
+    private $id;
+
     /**
      * @var string|null
      */
@@ -68,5 +75,24 @@ class Icon
     {
         $this->url = $url;
         return $this;
+    }
+
+    /**
+     * @param integer|null $id
+     * @return self
+     */
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return integer|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
     }
 }

--- a/src/Core/Severity/RealTime/Domain/Model/Severity.php
+++ b/src/Core/Severity/RealTime/Domain/Model/Severity.php
@@ -28,6 +28,7 @@ use Centreon\Domain\Common\Assertion\Assertion;
 
 class Severity
 {
+    public const SERIALIZER_GROUP_MAIN = 'severity_main';
     public const MAX_NAME_LENGTH = 255;
 
     public const SERVICE_SEVERITY_TYPE_ID = 0,

--- a/src/Core/Severity/RealTime/Domain/Model/Severity.php
+++ b/src/Core/Severity/RealTime/Domain/Model/Severity.php
@@ -28,7 +28,6 @@ use Centreon\Domain\Common\Assertion\Assertion;
 
 class Severity
 {
-    public const SERIALIZER_GROUP_MAIN = 'severity_main';
     public const MAX_NAME_LENGTH = 255;
 
     public const SERVICE_SEVERITY_TYPE_ID = 0,

--- a/tests/php/Centreon/Infrastructure/Monitoring/Resource/DbResourceFactoryTest.php
+++ b/tests/php/Centreon/Infrastructure/Monitoring/Resource/DbResourceFactoryTest.php
@@ -23,101 +23,92 @@ declare(strict_types=1);
 
 namespace Tests\Centreon\Infrastructure\Monitoring\Resource;
 
-use PHPUnit\Framework\TestCase;
 use Centreon\Domain\Monitoring\Resource as ResourceEntity;
 use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Infrastructure\Monitoring\Resource\DbResourceFactory;
 
-class DbResourceFactoryTest extends TestCase
-{
-    /**
-     * @var array<string, string|null>
-     */
-    private array $record;
+use function PHPUnit\Framework\assertNotNull;
 
-    public function setUp(): void
-    {
-        $this->record = [
-            'resource_id' => '9',
-            'name' => 'Ping',
-            'alias' => null,
-            'address' => null,
-            'id' => '104',
-            'internal_id' => null,
-            'parent_id' => '14',
-            'parent_name' => 'Database',
-            'parent_status' => '2',
-            'parent_alias' => 'Database',
-            'parent_status_ordered' => '2',
-            'severity_level' => '10',
-            'type' => '0',
-            'status' => '0',
-            'status_ordered' => '0',
-            'status_confirmed' => '1',
-            'in_downtime' => '0',
-            'acknowledged' => '0',
-            'passive_checks_enabled' => '0',
-            'active_checks_enabled' => '1',
-            'notifications_enabled' => '1',
-            'last_check' => '1651218259',
-            'last_status_change' => '1651211193',
-            'check_attempts' => '1',
-            'max_check_attempts' => '3',
-            'notes' => 'Notes label',
-            'notes_url' => 'https://www.centreon.com',
-            'action_url' => 'https://www.centreon.com',
-            'output' => 'OK - localhost rta 0.257ms lost 0%',
-            'poller_id' => '1',
-            'has_graph' => '1',
-            'monitoring_server_name' => 'Central',
-            'enabled' => '1',
-            'icon_id' => '0'
-        ];
-    }
+beforeEach(function () {
+    $this->record = [
+        'resource_id' => '9',
+        'name' => 'Ping',
+        'alias' => null,
+        'address' => null,
+        'id' => '104',
+        'internal_id' => null,
+        'parent_id' => '14',
+        'parent_name' => 'Database',
+        'parent_status' => '2',
+        'parent_alias' => 'Database',
+        'parent_status_ordered' => '2',
+        'type' => '0',
+        'status' => '0',
+        'status_ordered' => '0',
+        'status_confirmed' => '1',
+        'in_downtime' => '0',
+        'acknowledged' => '0',
+        'passive_checks_enabled' => '0',
+        'active_checks_enabled' => '1',
+        'notifications_enabled' => '1',
+        'last_check' => '1651218259',
+        'last_status_change' => '1651211193',
+        'check_attempts' => '1',
+        'max_check_attempts' => '3',
+        'notes' => 'Notes label',
+        'notes_url' => 'https://www.centreon.com',
+        'action_url' => 'https://www.centreon.com',
+        'output' => 'OK - localhost rta 0.257ms lost 0%',
+        'poller_id' => '1',
+        'has_graph' => '1',
+        'monitoring_server_name' => 'Central',
+        'enabled' => '1',
+        'icon_id' => '0',
+        'severity_id' => '10',
+        'severity_name' => 'High',
+        'severity_level' => '50',
+        'severity_icon_id' => '1',
+        'severity_type' => '0',
+    ];
+});
 
-    /**
-     * Test that resource is properly created
-     */
-    public function testResourceCreation(): void
-    {
-        $resource = DbResourceFactory::createFromRecord($this->record);
+it('should create a resource model from record', function () {
+    $resource = DbResourceFactory::createFromRecord($this->record);
+    expect($resource->getId())->toBe((int) $this->record['id']);
+    expect($resource->getParent()?->getId())->toBe((int) $this->record['parent_id']);
+    expect($resource->getName())->toBe($this->record['name']);
+    expect($resource->getAlias())->toBeNull();
+    expect($resource->getFqdn())->toBeNull();
+    expect($resource->getParent()?->getName())->toBe($this->record['parent_name']);
+    expect($resource->getParent()?->getStatus()?->getCode())->toBe((int) $this->record['parent_status']);
+    expect(ResourceStatus::SEVERITY_LOW)->toBe($resource->getParent()?->getStatus()?->getSeverityCode());
+    expect($this->record['parent_alias'])->toBe($resource->getParent()?->getAlias());
+    expect(ResourceEntity::TYPE_SERVICE)->toBe($resource->getType());
+    expect(ResourceStatus::STATUS_NAME_OK)->toBe($resource->getStatus()?->getName());
+    expect((int) $this->record['status'])->toBe($resource->getStatus()?->getCode());
+    expect(ResourceStatus::SEVERITY_OK)->toBe($resource->getStatus()?->getSeverityCode());
 
-        $this->assertEquals((int) $this->record['id'], $resource->getId());
-        $this->assertEquals((int) $this->record['parent_id'], $resource->getParent()->getId());
-        $this->assertEquals($this->record['name'], $resource->getName());
-        $this->assertNull($resource->getAlias());
-        $this->assertNull($resource->getFqdn());
-        $this->assertEquals($this->record['parent_name'], $resource->getParent()->getName());
-        $this->assertEquals((int) $this->record['parent_status'], $resource->getParent()->getStatus()->getCode());
-        $this->assertEquals(ResourceStatus::SEVERITY_LOW, $resource->getParent()->getStatus()->getSeverityCode());
-        $this->assertEquals($this->record['parent_alias'], $resource->getParent()->getAlias());
-        $this->assertEquals((int) $this->record['severity_level'], $resource->getSeverityLevel());
-        $this->assertEquals(ResourceEntity::TYPE_SERVICE, $resource->getType());
-        $this->assertEquals(ResourceStatus::STATUS_NAME_OK, $resource->getStatus()->getName());
-        $this->assertEquals((int) $this->record['status'], $resource->getStatus()->getCode());
-        $this->assertEquals(ResourceStatus::SEVERITY_OK, $resource->getStatus()->getSeverityCode());
+    $statusConfirmedAsString = (int) $this->record['status_confirmed'] === 1 ? 'H' : 'S';
+    $tries = $this->record['check_attempts']
+        . '/' . $this->record['max_check_attempts'] . ' (' . $statusConfirmedAsString . ')';
 
-        $statusConfirmedAsString = (int) $this->record['status_confirmed'] === 1 ? 'H' : 'S';
-        $tries = $this->record['check_attempts']
-            . '/' . $this->record['max_check_attempts'] . ' (' . $statusConfirmedAsString . ')';
-
-        $this->assertEquals($tries, $resource->getTries());
-        $this->assertFalse($resource->getInDowntime());
-        $this->assertFalse($resource->getAcknowledged());
-        $this->assertFalse($resource->getPassiveChecks());
-        $this->assertTrue($resource->getActiveChecks());
-        $this->assertTrue($resource->isNotificationEnabled());
-        $this->assertEquals((int) $this->record['last_check'], $resource->getLastCheck()->getTimestamp());
-        $this->assertEquals(
-            (int) $this->record['last_status_change'],
-            $resource->getLastStatusChange()->getTimestamp()
-        );
-
-        $this->assertEquals($this->record['notes'], $resource->getLinks()->getExternals()->getNotes()->getLabel());
-        $this->assertEquals($this->record['notes_url'], $resource->getLinks()->getExternals()->getNotes()->getUrl());
-        $this->assertEquals($this->record['action_url'], $resource->getLinks()->getExternals()->getActionUrl());
-        $this->assertEquals($this->record['output'], $resource->getInformation());
-        $this->assertEquals($this->record['monitoring_server_name'], $resource->getMonitoringServerName());
-        $this->assertTrue($resource->hasGraph());
-    }
-}
+    expect($resource->getTries())->toBe($tries);
+    expect($resource->getInDowntime())->toBeFalse();
+    expect($resource->getAcknowledged())->toBeFalse();
+    expect($resource->getPassiveChecks())->toBeFalse();
+    expect($resource->getActiveChecks())->toBeTrue();
+    expect($resource->isNotificationEnabled())->toBeTrue();
+    expect($resource->getLastCheck()?->getTimestamp())->toBe((int) $this->record['last_check']);
+    expect($resource->getLastStatusChange()?->getTimestamp())->toBe((int) $this->record['last_status_change']);
+    expect($resource->getLinks()->getExternals()->getNotes()?->getLabel())->toBe($this->record['notes']);
+    expect($resource->getLinks()->getExternals()->getNotes()?->getUrl())->toBe($this->record['notes_url']);
+    expect($resource->getLinks()->getExternals()->getActionUrl())->toBe($this->record['action_url']);
+    expect($resource->getInformation())->toBe($this->record['output']);
+    expect($resource->getMonitoringServerName())->toBe($this->record['monitoring_server_name']);
+    expect($resource->hasGraph())->toBeTrue();
+    expect($resource->getSeverity()?->getName())->toBe($this->record['severity_name']);
+    expect($resource->getSeverity()?->getId())->toBe((int) $this->record['severity_id']);
+    expect($resource->getSeverity()?->getLevel())->toBe((int) $this->record['severity_level']);
+    expect($resource->getSeverity()?->getType())->toBe((int) $this->record['severity_type']);
+    expect($resource->getSeverity()?->getIcon()->getId())->toBe((int) $this->record['severity_icon_id']);
+});

--- a/tests/php/Centreon/Infrastructure/Monitoring/Resource/DbResourceFactoryTest.php
+++ b/tests/php/Centreon/Infrastructure/Monitoring/Resource/DbResourceFactoryTest.php
@@ -27,8 +27,6 @@ use Centreon\Domain\Monitoring\Resource as ResourceEntity;
 use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Infrastructure\Monitoring\Resource\DbResourceFactory;
 
-use function PHPUnit\Framework\assertNotNull;
-
 beforeEach(function () {
     $this->record = [
         'resource_id' => '9',


### PR DESCRIPTION
This PR intends to add

- A new `severity` key to the API response of Resource Status listing
- 4 new filters: service_severity_names, host_severity_names, service_severity_levels, host_severity_levels

API response

<img width="775" alt="image" src="https://user-images.githubusercontent.com/31647811/175336566-7fe9d088-6398-4bc6-aa0a-c719e166343d.png">


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Will be fully tested when merged with frontend

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
