### PR TITLE
enh(conf) Enable the export button in topcounter for all users having sufficient privileges

### DIFF
--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -93,7 +93,7 @@ class UserController extends AbstractController
             'locale' => $user->getLocale(),
             'is_admin' => $user->isAdmin(),
             'use_deprecated_pages' => $user->isUsingDeprecatedPages(),
-            'is_export_button_enabled' => $user->isOneClickExportEnabled(),
+            'is_export_button_enabled' => $user->isAdmin() || $user->hasRole(Contact::ROLE_GENERATE_CONFIGURATION),
             'theme' => $user->getTheme(),
             'default_page' => $user->getDefaultPage()?->getRedirectionUri()
         ]);

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -93,7 +93,7 @@ class UserController extends AbstractController
             'locale' => $user->getLocale(),
             'is_admin' => $user->isAdmin(),
             'use_deprecated_pages' => $user->isUsingDeprecatedPages(),
-            'is_export_button_enabled' => $user->isAdmin() || $user->hasRole(Contact::ROLE_GENERATE_CONFIGURATION),
+            'is_export_button_enabled' => $this->getAuthorizationForRole(Contact::ROLE_GENERATE_CONFIGURATION),
             'theme' => $user->getTheme(),
             'default_page' => $user->getDefaultPage()?->getRedirectionUri()
         ]);

--- a/src/Centreon/Domain/Contact/Contact.php
+++ b/src/Centreon/Domain/Contact/Contact.php
@@ -184,11 +184,6 @@ class Contact implements UserInterface, ContactInterface
     private $useDeprecatedPages;
 
     /**
-     * @var bool
-     */
-    private $isOneClickExportEnabled = false;
-
-    /**
      * @var string|null
      */
     private $theme;
@@ -635,25 +630,6 @@ class Contact implements UserInterface, ContactInterface
     public function setUseDeprecatedPages(bool $useDeprecatedPages): static
     {
         $this->useDeprecatedPages = $useDeprecatedPages;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isOneClickExportEnabled(): bool
-    {
-        return $this->isOneClickExportEnabled;
-    }
-
-    /**
-     * @param bool $isOneClickExportEnabled
-     * @return self
-     */
-    public function setOneClickExportEnabled(bool $isOneClickExportEnabled): self
-    {
-        $this->isOneClickExportEnabled = $isOneClickExportEnabled;
 
         return $this;
     }

--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -424,7 +424,6 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             ->setLocale($contactLocale)
             ->setDefaultPage($page)
             ->setUseDeprecatedPages($contact['show_deprecated_pages'] === '1')
-            ->setOneClickExportEnabled($contact['enable_one_click_export'] === '1')
             ->setTheme($contact['contact_theme']);
 
         $this->addActionRules($contact);

--- a/tests/clapi_export/clapi-configuration.txt
+++ b/tests/clapi_export/clapi-configuration.txt
@@ -566,7 +566,6 @@ CONTACTTPL;setparam;contact_template;contact_activate;1
 CONTACTTPL;setparam;contact_template;show_deprecated_pages;0
 CONTACTTPL;setparam;contact_template;contact_ldap_last_sync;0
 CONTACTTPL;setparam;contact_template;contact_ldap_required_sync;0
-CONTACTTPL;setparam;contact_template;enable_one_click_export;0
 CONTACTTPL;ADD;test_name;test_contact-template;;$2y$10$BqnZdxhI2wz1Ot/exXd73eOngqA2RPeBmjxSSyEzSygFXo3L9guAW;0;1;;local
 CONTACTTPL;setparam;test_contact-template;hostnotifopt;n
 CONTACTTPL;setparam;test_contact-template;servicenotifopt;n
@@ -581,7 +580,6 @@ CONTACTTPL;setparam;test_contact-template;contact_activate;1
 CONTACTTPL;setparam;test_contact-template;show_deprecated_pages;0
 CONTACTTPL;setparam;test_contact-template;contact_ldap_last_sync;0
 CONTACTTPL;setparam;test_contact-template;contact_ldap_required_sync;0
-CONTACTTPL;setparam;test_contact-template;enable_one_click_export;0
 CONTACT;ADD;admin admin;admin;admin@centreon.com;$2y$10$kBoz3kL/8kIe8BGStjH67uW7xX060pbypSKcnLfGDYu.FPuShgsKS;1;1;en_US.UTF-8;local
 CONTACT;setparam;admin;hostnotifperiod;24x7
 CONTACT;setparam;admin;svcnotifperiod;24x7
@@ -598,7 +596,6 @@ CONTACT;setparam;admin;contact_activate;1
 CONTACT;setparam;admin;show_deprecated_pages;0
 CONTACT;setparam;admin;contact_ldap_last_sync;0
 CONTACT;setparam;admin;contact_ldap_required_sync;0
-CONTACT;setparam;admin;enable_one_click_export;0
 CONTACT;setparam;admin;hostnotifcmd;host-notify-by-email
 CONTACT;setparam;admin;svcnotifcmd;service-notify-by-email
 CONTACT;ADD;Guest;guest;guest@localhost;$2y$10$PktpVP.m4EWXkblTgNDqu.qNLwXrASiS8E0.d8E9giKzAhvSBH/5a;0;0;en_US.UTF-8;local
@@ -617,7 +614,6 @@ CONTACT;setparam;guest;contact_activate;0
 CONTACT;setparam;guest;show_deprecated_pages;0
 CONTACT;setparam;guest;contact_ldap_last_sync;0
 CONTACT;setparam;guest;contact_ldap_required_sync;0
-CONTACT;setparam;guest;enable_one_click_export;0
 CONTACT;setparam;guest;hostnotifcmd;host-notify-by-email
 CONTACT;setparam;guest;svcnotifcmd;service-notify-by-email
 CONTACT;ADD;Jean-Pierre;jeanpierre;Jean-Pierre@hotmail.fr;$2y$10$xRDrrYnB0.ZcN2cWq7idOeFKfzwTQXm3b0xh6TuYUxI8ctVE98ddy;0;1;browser;local
@@ -634,7 +630,6 @@ CONTACT;setparam;jeanpierre;contact_activate;1
 CONTACT;setparam;jeanpierre;show_deprecated_pages;0
 CONTACT;setparam;jeanpierre;contact_ldap_last_sync;0
 CONTACT;setparam;jeanpierre;contact_ldap_required_sync;0
-CONTACT;setparam;jeanpierre;enable_one_click_export;0
 CONTACT;ADD;test_contact;test_contact;test@localhost;$2y$10$HcwRGF.oU8k9sfm9Vpp7eOlrNHomq4RuNLqhTQcnqDNfAPBe44wGK;0;0;en_US.UTF-8;local
 CONTACT;setparam;test_contact;hostnotifopt;n
 CONTACT;setparam;test_contact;servicenotifopt;n
@@ -649,7 +644,6 @@ CONTACT;setparam;test_contact;contact_activate;1
 CONTACT;setparam;test_contact;show_deprecated_pages;0
 CONTACT;setparam;test_contact;contact_ldap_last_sync;0
 CONTACT;setparam;test_contact;contact_ldap_required_sync;0
-CONTACT;setparam;test_contact;enable_one_click_export;0
 CONTACT;ADD;User;user;user@localhost;$2y$10$Da/IX.qnrwXwu7JJe04JWOJOdTUmqicml7B56wZDyZd6ohZJfOKKm;0;0;en_US.UTF-8;local
 CONTACT;setparam;user;hostnotifperiod;24x7
 CONTACT;setparam;user;svcnotifperiod;24x7
@@ -666,7 +660,6 @@ CONTACT;setparam;user;contact_activate;0
 CONTACT;setparam;user;show_deprecated_pages;0
 CONTACT;setparam;user;contact_ldap_last_sync;0
 CONTACT;setparam;user;contact_ldap_required_sync;0
-CONTACT;setparam;user;enable_one_click_export;0
 CONTACT;setparam;user;hostnotifcmd;host-notify-by-email
 CONTACT;setparam;user;svcnotifcmd;service-notify-by-email
 TRAP;ADD;adDiagCancelled;.1.3.6.1.4.1.674.10893.1.1.200.0.537

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -407,7 +407,6 @@ class CentreonContact extends CentreonObject
                             'reach_api_rt',
                             'default_page',
                             'show_deprecated_pages',
-                            'enable_one_click_export'
                         ]
                     )
                 ) {

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -148,8 +148,7 @@ function updateContact($contactId = null)
           'default_page = :defaultPage, ' .
           'show_deprecated_pages = :showDeprecatedPages, ' .
           'contact_autologin_key = :contactAutologinKey, ' .
-          'contact_theme = :contactTheme, ' .
-          'enable_one_click_export = :enableOneClickExport';
+          'contact_theme = :contactTheme';
     $rq .= ' WHERE contact_id = :contactId';
 
     $stmt = $pearDB->prepare($rq);
@@ -183,7 +182,6 @@ function updateContact($contactId = null)
     );
     $stmt->bindValue(':defaultPage', !empty($ret['default_page']) ? $ret['default_page'] : null, \PDO::PARAM_INT);
     $stmt->bindValue(':showDeprecatedPages', isset($ret['show_deprecated_pages']) ? 1 : 0, \PDO::PARAM_STR);
-    $stmt->bindValue(':enableOneClickExport', isset($ret['enable_one_click_export']) ? '1' : '0', \PDO::PARAM_STR);
     $stmt->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
     $stmt->execute();
 

--- a/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -55,9 +55,6 @@
             </tr>
             <tr class="list_two"><td class="FormRowField">{$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td></tr>
-            {if $contactIsAdmin && !$isRemote}
-            <tr class="list_one"><td class="FormRowField">{$form.enable_one_click_export.label}</td><td class="FormRowValue">{$form.enable_one_click_export.html}</td></tr>
-            {/if}
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
                     <h4>{t}Authentication{/t}</h4>

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -71,7 +71,7 @@ $cct = array();
 if ($o == "c") {
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
-        contact_theme, enable_one_click_export
+        contact_theme
         FROM contact WHERE contact_id = :id";
     $DBRESULT = $pearDB->prepare($query);
     $DBRESULT->bindValue(':id', $centreon->user->get_id(), \PDO::PARAM_INT);
@@ -173,15 +173,6 @@ $form->addElement(
 );
 $form->addElement('select', 'contact_lang', _("Language"), $langs);
 $form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
-if (!$isRemote) {
-    $form->addElement(
-        'checkbox',
-        'enable_one_click_export',
-        _("Enable the one-click export button for poller configuration [BETA]"),
-        null,
-        $attrsText
-    );
-}
 
 
 /* ------------------------ Topoogy ---------------------------- */
@@ -452,7 +443,6 @@ if ($form->validate()) {
     if (
         $form->getSubmitValue("contact_lang") !== $cct['contact_lang']
         || $showDeprecatedPages !== $cct['show_deprecated_pages']
-        || $form->getSubmitValue('enable_one_click_export') !== $cct['enable_one_click_export']
     ) {
         $contactStatement = $pearDB->prepare(
             'SELECT * FROM contact WHERE contact_id = :contact_id'

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -712,7 +712,6 @@ CREATE TABLE `contact` (
   `contact_register` tinyint(6) NOT NULL DEFAULT '1',
   `contact_ldap_last_sync` int(11) NOT NULL DEFAULT 0,
   `contact_ldap_required_sync` enum('0','1') NOT NULL DEFAULT '0',
-  `enable_one_click_export` enum('0','1') DEFAULT '0',
   `login_attempts` INT(11) UNSIGNED DEFAULT NULL,
   `blocking_time` BIGINT(20) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`contact_id`),

--- a/www/install/sql/centreon/Update-DB-22.10.0.sql
+++ b/www/install/sql/centreon/Update-DB-22.10.0.sql
@@ -120,3 +120,6 @@ ALTER TABLE cfg_nagios MODIFY `log_passive_checks` enum('0','1');
 ALTER TABLE cfg_nagios MODIFY `enable_predictive_host_dependency_checks` enum('0','1');
 ALTER TABLE cfg_nagios MODIFY `enable_predictive_service_dependency_checks` enum('0','1');
 ALTER TABLE cfg_nagios MODIFY `debug_verbosity` enum('0','1');
+
+
+ALTER TABLE contact DROP COLUMN IF EXISTS `enable_one_click_export`;


### PR DESCRIPTION
## Description

Remove 'one_click_export_enabled' option from Contact
Change the 'is_export_button_enabled' flag in /configuration/users/current/parameters response to be based on user role
The export configuration button will be displayed in the top counter if user is admin or export rights 

<img width="139" alt="image" src="https://user-images.githubusercontent.com/88387848/175346791-ee92922e-a880-46b4-8a4b-07a681a9698d.png">

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

User must be admin or have ActionAccess rights to both ‘Display Top Counter pollers statistics’ and ‘Deploy configuration Files’  to see the export button displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
