### PR TITLE
fix(platform) : Issue with cross databases query when the name contains some characters

### DIFF
--- a/www/api/class/centreon_performance_service.class.php
+++ b/www/api/class/centreon_performance_service.class.php
@@ -114,7 +114,8 @@ class CentreonPerformanceService extends CentreonConfigurationObjects
         }
 
         if ($excludeAnomalyDetection) {
-            $additionalCondition .= 'AND s.service_id NOT IN (SELECT service_id FROM ' . $conf_centreon['db'] . '.mod_anomaly_service) ';
+            $additionalCondition .= 'AND s.service_id NOT IN (SELECT service_id 
+            FROM `' . $conf_centreon['db'] . '`.mod_anomaly_service) ';
         }
         if (isset($this->arguments['hostgroup'])) {
             $additionalCondition .= 'AND (hg.host_id = i.host_id ' .

--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -878,19 +878,20 @@ class CentreonTopCounter extends CentreonWebService
 
         $query = "SELECT * FROM log_action WHERE action_log_date > $lastRestart " .
             "AND ((object_type = 'host' AND ((action_type = 'd' AND object_id IN (SELECT host_id FROM hosts)) " .
-            "OR object_id IN (SELECT host_host_id FROM " .
-            $conf_centreon['db'] . ".ns_host_relation WHERE nagios_server_id = '$pollerId'))) " .
+            "OR object_id IN (SELECT host_host_id FROM `" .
+            $conf_centreon['db'] . "`.ns_host_relation WHERE nagios_server_id = '$pollerId'))) " .
             "OR (object_type = 'service' AND ((action_type = 'd' AND object_id IN (SELECT service_id FROM services)) OR " .
-            "object_id IN (SELECT service_service_id FROM " .
-            $conf_centreon['db'] . ".ns_host_relation nhr, " . $conf_centreon['db'] . ".host_service_relation hsr " .
+            "object_id IN (SELECT service_service_id FROM `" .
+            $conf_centreon['db'] . "`.ns_host_relation nhr, `" . $conf_centreon['db'] . "`.host_service_relation hsr " .
             "WHERE nagios_server_id = '$pollerId' AND hsr.host_host_id = nhr.host_host_id)))" .
             "OR (object_type = 'servicegroup' AND ((action_type = 'd' AND object_id IN (SELECT DISTINCT servicegroup_id " .
-            "FROM services_servicegroups)) OR object_id IN (SELECT DISTINCT servicegroup_sg_id FROM " .
-            $conf_centreon['db'] . ".servicegroup_relation sgr, " . $conf_centreon['db'] . ".ns_host_relation nhr " .
+            "FROM services_servicegroups)) OR object_id IN (SELECT DISTINCT servicegroup_sg_id FROM `" .
+            $conf_centreon['db'] . "`.servicegroup_relation sgr, 
+            `" . $conf_centreon['db'] . "`.ns_host_relation nhr " .
             "WHERE sgr.host_host_id = nhr.host_host_id AND nhr.nagios_server_id = '$pollerId')))" .
             "OR (object_type = 'hostgroup' AND ((action_type = 'd' AND object_id IN (SELECT DISTINCT hostgroup_id " .
-            "FROM hosts_hostgroups)) OR object_id IN (SELECT DISTINCT hr.hostgroup_hg_id FROM " .
-            $conf_centreon['db'] . ".hostgroup_relation hr, " . $conf_centreon['db'] . ".ns_host_relation nhr " .
+            "FROM hosts_hostgroups)) OR object_id IN (SELECT DISTINCT hr.hostgroup_hg_id FROM `" .
+            $conf_centreon['db'] . "`.hostgroup_relation hr, `" . $conf_centreon['db'] . "`.ns_host_relation nhr " .
             "WHERE hr.host_host_id = nhr.host_host_id AND nhr.nagios_server_id = '$pollerId'))))";
 
         try {

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1068,7 +1068,7 @@ WHERE log_action.object_type = 'host' AND action_log_date > $lastRestart GROUP B
 UNION
 SELECT instance_id, COUNT(*) as num_logs, MAX(action_log_date) as action_log_date FROM log_action
     INNER JOIN (
-        SELECT nagios_server_id as instance_id, host_host_id as host_id FROM {$conf_centreon['db']}.ns_host_relation
+        SELECT nagios_server_id as instance_id, host_host_id as host_id FROM `{$conf_centreon['db']}`.ns_host_relation
          WHERE nagios_server_id IN ($pollersSearch)
     ) AS subtable ON log_action.object_id = subtable.host_id
 WHERE log_action.object_type = 'host' AND action_log_date > $lastRestart GROUP BY subtable.instance_id
@@ -1084,7 +1084,7 @@ UNION
 SELECT instance_id, COUNT(*) as num_logs, MAX(action_log_date) as action_log_date FROM log_action
     INNER JOIN (
         SELECT nagios_server_id as instance_id, service_service_id as service_id
-        FROM {$conf_centreon['db']}.ns_host_relation nhr, {$conf_centreon['db']}.host_service_relation hsr
+        FROM `{$conf_centreon['db']}`.ns_host_relation nhr, `{$conf_centreon['db']}`.host_service_relation hsr
         WHERE nagios_server_id IN ($pollersSearch)
             AND hsr.host_host_id = nhr.host_host_id
     ) AS subtable ON log_action.object_id = subtable.service_id
@@ -1101,7 +1101,7 @@ UNION
 SELECT instance_id, COUNT(*) as num_logs, MAX(action_log_date) as action_log_date FROM log_action
     INNER JOIN (
         SELECT nhr.nagios_server_id as instance_id, servicegroup_sg_id as servicegroup_id
-        FROM {$conf_centreon['db']}.servicegroup_relation sgr, {$conf_centreon['db']}.ns_host_relation nhr
+        FROM `{$conf_centreon['db']}`.servicegroup_relation sgr, `{$conf_centreon['db']}`.ns_host_relation nhr
         WHERE nhr.nagios_server_id IN ($pollersSearch)
             AND sgr.host_host_id = nhr.host_host_id
     ) AS subtable ON log_action.object_id = subtable.servicegroup_id
@@ -1118,7 +1118,7 @@ UNION
 SELECT instance_id, COUNT(*) as num_logs, MAX(action_log_date) as action_log_date FROM log_action
     INNER JOIN (
         SELECT nhr.nagios_server_id as instance_id, hostgroup_hg_id as hostgroup_id
-        FROM {$conf_centreon['db']}.hostgroup_relation hr, {$conf_centreon['db']}.ns_host_relation nhr
+        FROM `{$conf_centreon['db']}`.hostgroup_relation hr, `{$conf_centreon['db']}`.ns_host_relation nhr
         WHERE nhr.nagios_server_id IN ($pollersSearch)
             AND hr.host_host_id = nhr.host_host_id
     ) AS subtable ON log_action.object_id = subtable.hostgroup_id
@@ -1178,7 +1178,7 @@ AND (
       )
       OR object_id IN (
         SELECT host_host_id
-        FROM {$conf_centreon['db']}.ns_host_relation
+        FROM `{$conf_centreon['db']}`.ns_host_relation`
         WHERE nagios_server_id = $poller_id
       )
     )
@@ -1196,7 +1196,7 @@ AND (
       )
       OR object_id IN (
         SELECT service_service_id
-        FROM {$conf_centreon['db']}.ns_host_relation nhr, {$conf_centreon['db']}.host_service_relation hsr
+        FROM `{$conf_centreon['db']}`.ns_host_relation nhr, `{$conf_centreon['db']}`.host_service_relation hsr
         WHERE nagios_server_id = $poller_id
         AND hsr.host_host_id = nhr.host_host_id
       )
@@ -1216,7 +1216,7 @@ AND (
       )
       OR object_id IN (
         SELECT DISTINCT servicegroup_sg_id
-        FROM {$conf_centreon['db']}.servicegroup_relation sgr, {$conf_centreon['db']}.ns_host_relation nhr
+        FROM `{$conf_centreon['db']}`.servicegroup_relation sgr, `{$conf_centreon['db']}`.ns_host_relation nhr
         WHERE sgr.host_host_id = nhr.host_host_id
         AND nhr.nagios_server_id = $poller_id
       )
@@ -1236,7 +1236,7 @@ AND (
       )
       OR object_id IN (
         SELECT DISTINCT hr.hostgroup_hg_id
-        FROM {$conf_centreon['db']}.hostgroup_relation hr, {$conf_centreon['db']}.ns_host_relation nhr
+        FROM `{$conf_centreon['db']}`.hostgroup_relation hr, `{$conf_centreon['db']}`.ns_host_relation nhr
         WHERE hr.host_host_id = nhr.host_host_id
         AND nhr.nagios_server_id = $poller_id
       )


### PR DESCRIPTION
## Description

In Centreon Web and some modules, there are some cross databases queries. If a database name contains some characters like dash the query is on error. This database name needs to be surrounded by backquoted.

**Fixes** # MON-13829

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
