### PR TITLE
fix(web): display command with status$ in the command definition

### DIFF
--- a/src/Centreon/Domain/Monitoring/CommandLineTrait.php
+++ b/src/Centreon/Domain/Monitoring/CommandLineTrait.php
@@ -45,7 +45,7 @@ trait CommandLineTrait
     ): string {
         // if the command line contains $$ after a macro (so $$$), delete one of them to match with
         // the command executed by centreon-engine
-        $configurationCommand = str_replace('$$$', '$$', $configurationCommand);
+        $configurationCommand = str_replace('$$', '$', $configurationCommand);
         $macroPasswordNames = [];
         foreach ($macros as $macro) {
             if ($macro->isPassword()) {

--- a/src/Centreon/Domain/Monitoring/CommandLineTrait.php
+++ b/src/Centreon/Domain/Monitoring/CommandLineTrait.php
@@ -45,7 +45,7 @@ trait CommandLineTrait
     ): string {
         // if the command line contains $$ after a macro (so $$$), delete one of them to match with
         // the command executed by centreon-engine
-        $configurationCommand = str_replace('$$', '$', $configurationCommand);
+        $configurationCommand = str_replace('$$$', '$$', $configurationCommand);
         $macroPasswordNames = [];
         foreach ($macros as $macro) {
             if ($macro->isPassword()) {

--- a/src/Centreon/Domain/Monitoring/CommandLineTrait.php
+++ b/src/Centreon/Domain/Monitoring/CommandLineTrait.php
@@ -43,6 +43,9 @@ trait CommandLineTrait
         array $macros,
         string $replacementValue
     ): string {
+        // if the command line contains $$ after a macro (so $$$), delete one of them to match with
+        // the command executed by centreon-engine
+        $configurationCommand = str_replace('$$$', '$$', $configurationCommand);
         $macroPasswordNames = [];
         foreach ($macros as $macro) {
             if ($macro->isPassword()) {

--- a/tests/php/Centreon/Domain/Monitoring/CommandLineTraitTest.php
+++ b/tests/php/Centreon/Domain/Monitoring/CommandLineTraitTest.php
@@ -180,7 +180,7 @@ class CommandLineTraitTest extends TestCase
             . $this->replacementValue . ' -f extra options';
 
         $this->expectException(MonitoringServiceException::class);
-        $this->expectExceptionMessage('Macro passwords cannot be detected');
+        $this->expectExceptionMessage('Configuration has changed');
 
         $this->buildCommandLineFromConfiguration(
             $this->configurationCommand,

--- a/tests/php/Centreon/Domain/Monitoring/CommandLineTraitTest.php
+++ b/tests/php/Centreon/Domain/Monitoring/CommandLineTraitTest.php
@@ -180,7 +180,7 @@ class CommandLineTraitTest extends TestCase
             . $this->replacementValue . ' -f extra options';
 
         $this->expectException(MonitoringServiceException::class);
-        $this->expectExceptionMessage('Configuration has changed');
+        $this->expectExceptionMessage('Macro passwords cannot be detected');
 
         $this->buildCommandLineFromConfiguration(
             $this->configurationCommand,


### PR DESCRIPTION
## Description

In the check command definition we have to define some options like this:
`--interface='^$_SERVICEINTERFACENAME$$$'`

It allows the user to only monitor the resource he defined in the macro value.
But Centreon-Engine will replace the last two $$ by only one $.

We have to deal with it.

**Fixes** MON-14128

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)