### PR TITLE
ft(UI): Add frontend button to export data to csv format in Timeline

### DIFF
--- a/config/routes/Centreon/monitoring/timeline.yaml
+++ b/config/routes/Centreon/monitoring/timeline.yaml
@@ -15,3 +15,9 @@ centreon_application_monitoring_gettimelinebymetaservices:
     path: /monitoring/metaservice/{metaId}/timeline
     controller: 'Centreon\Application\Controller\Monitoring\TimelineController::getMetaServiceTimeline'
     condition: "request.attributes.get('version') >= 21.10"
+
+centreon_application_monitoring_gettimelinebyhostandservice_download:
+    methods: GET
+    path: /monitoring/hosts/{hostId}/services/{serviceId}/timeline/download
+    controller: 'Centreon\Application\Controller\Monitoring\TimelineController::downloadServiceTimeline'
+    condition: "request.attributes.get('version') >= 22.10"

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -4514,7 +4514,6 @@ components:
         - auto_import
         - contact_template
         - email_bind_attribute
-        - alias_bind_attribute
         - fullname_bind_attribute
         - contact_group
         - authorization_claim
@@ -4626,11 +4625,6 @@ components:
           type: string
           description: "Email bind attribute"
           example: "email"
-          nullable: true
-        alias_bind_attribute:
-          type: string
-          description: "Alias bind attribute"
-          example: "preferred_username"
           nullable: true
         fullname_bind_attribute:
           type: string

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15172,3 +15172,6 @@ msgstr "Se ha producido un error al recuperar los categorías de servicios"
 
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
+
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
+#  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15020,16 +15020,10 @@ msgstr ""
 # msgid "Enable auto import"
 # msgstr ""
 
-# msgid "Email attribute to bind"
+# msgid "Email attribute"
 # msgstr ""
 
-# msgid "Alias attribute to bind"
-# msgstr ""
-
-# msgid "Fullname attribute to bind"
-# msgstr ""
-
-# msgid "Auto import"
+# msgid "Fullname attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16722,17 +16722,11 @@ msgstr "Impossible d'obtenir les modèles de contact depuis le stockage de donn�
 msgid "Enable auto import"
 msgstr "Activer l'importation automatique"
 
-msgid "Email attribute to bind"
-msgstr "Attribut de mail à lier"
+msgid "Email attribute"
+msgstr "Attribut de mail"
 
-msgid "Alias attribute to bind"
-msgstr "Attribut d'alias à lier"
-
-msgid "Fullname attribute to bind"
-msgstr "Attribut de nom complet à lier"
-
-msgid "Auto import"
-msgstr "Importation automatique"
+msgid "Fullname attribute"
+msgstr "Attribut de nom complet"
 
 # msgid "You are not authorized to access the configuration"
 # msgstr "Vous n’êtes pas autorisé à accéder à la configuration"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16917,3 +16917,6 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories de s
 
 msgid "An error occured while retrieving host categories"
 msgstr "Une erreur s'est produite lors de la récupération des catégories d'hôtes"
+
+msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
+msgstr "Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera tronqué à l'enregistrement"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15471,16 +15471,10 @@ msgstr ""
 # msgid "Enable auto import"
 # msgstr ""
 
-# msgid "Email attribute to bind"
+# msgid "Email attribute"
 # msgstr ""
 
-# msgid "Alias attribute to bind"
-# msgstr ""
-
-# msgid "Fullname attribute to bind"
-# msgstr ""
-
-# msgid "Auto import"
+# msgid "Fullname attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15623,3 +15623,6 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 
 msgid "An error occured while retrieving host categories"
 msgstr "Ocorreu um erro durante a recuperação das categorias de hosts"
+
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15611,3 +15611,6 @@ msgstr "Ocorreu um erro durante a recuperação das categorias de serviços"
 
 msgid "An error occured while retrieving host categories"
 msgstr "Se ha producido un error al recuperar los categorías de hosts"
+
+#  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15459,16 +15459,10 @@ msgstr ""
 # msgid "Enable auto import"
 # msgstr ""
 
-# msgid "Email attribute to bind"
+# msgid "Email attribute"
 # msgstr ""
 
-# msgid "Alias attribute to bind"
-# msgstr ""
-
-# msgid "Fullname attribute to bind"
-# msgstr ""
-
-# msgid "Auto import"
+# msgid "Fullname attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -93,7 +93,7 @@ class UserController extends AbstractController
             'locale' => $user->getLocale(),
             'is_admin' => $user->isAdmin(),
             'use_deprecated_pages' => $user->isUsingDeprecatedPages(),
-            'is_export_button_enabled' => $user->isOneClickExportEnabled(),
+            'is_export_button_enabled' => $this->getAuthorizationForRole(Contact::ROLE_GENERATE_CONFIGURATION),
             'theme' => $user->getTheme(),
             'default_page' => $user->getDefaultPage()?->getRedirectionUri()
         ]);

--- a/src/Centreon/Domain/Contact/Contact.php
+++ b/src/Centreon/Domain/Contact/Contact.php
@@ -184,11 +184,6 @@ class Contact implements UserInterface, ContactInterface
     private $useDeprecatedPages;
 
     /**
-     * @var bool
-     */
-    private $isOneClickExportEnabled = false;
-
-    /**
      * @var string|null
      */
     private $theme;
@@ -635,25 +630,6 @@ class Contact implements UserInterface, ContactInterface
     public function setUseDeprecatedPages(bool $useDeprecatedPages): static
     {
         $this->useDeprecatedPages = $useDeprecatedPages;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isOneClickExportEnabled(): bool
-    {
-        return $this->isOneClickExportEnabled;
-    }
-
-    /**
-     * @param bool $isOneClickExportEnabled
-     * @return self
-     */
-    public function setOneClickExportEnabled(bool $isOneClickExportEnabled): self
-    {
-        $this->isOneClickExportEnabled = $isOneClickExportEnabled;
 
         return $this;
     }

--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -424,7 +424,6 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             ->setLocale($contactLocale)
             ->setDefaultPage($page)
             ->setUseDeprecatedPages($contact['show_deprecated_pages'] === '1')
-            ->setOneClickExportEnabled($contact['enable_one_click_export'] === '1')
             ->setTheme($contact['contact_theme']);
 
         $this->addActionRules($contact);

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilder.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilder.php
@@ -68,7 +68,6 @@ class ConfigurationBuilder
                 self::validateParametersForAutoImport(
                     $contactTemplate,
                     $request->emailBindAttribute,
-                    $request->userAliasBindAttribute,
                     $request->userNameBindAttribute
                 );
             }
@@ -95,7 +94,6 @@ class ConfigurationBuilder
             ->setUserInformationEndpoint($request->userInformationEndpoint)
             ->setContactTemplate($contactTemplate)
             ->setEmailBindAttribute($request->emailBindAttribute)
-            ->setUserAliasBindAttribute($request->userAliasBindAttribute)
             ->setUserNameBindAttribute($request->userNameBindAttribute)
             ->setContactGroup($contactGroup)
             ->setClaimName($request->claimName);
@@ -106,14 +104,12 @@ class ConfigurationBuilder
      *
      * @param ContactTemplate|null $contactTemplate
      * @param string|null $emailBindAttribute
-     * @param string|null $userAliasBindAttribute
      * @param string|null $userNameBindAttribute
      * @throws OpenIdConfigurationException
      */
     private static function validateParametersForAutoImport(
         ?ContactTemplate $contactTemplate,
         ?string $emailBindAttribute,
-        ?string $userAliasBindAttribute,
         ?string $userNameBindAttribute
     ): void {
         $missingMandatoryParameters = [];
@@ -122,9 +118,6 @@ class ConfigurationBuilder
         }
         if (empty($emailBindAttribute)) {
             $missingMandatoryParameters[] = 'email_bind_attribute';
-        }
-        if (empty($userAliasBindAttribute)) {
-            $missingMandatoryParameters[] = 'alias_bind_attribute';
         }
         if (empty($userNameBindAttribute)) {
             $missingMandatoryParameters[] = 'fullname_bind_attribute';

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfiguration.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfiguration.php
@@ -85,7 +85,6 @@ class FindOpenIdConfiguration
             ? null
             : $findOpenIdConfigurationResponse::contactTemplateToArray($configuration->getContactTemplate());
         $findOpenIdConfigurationResponse->emailBindAttribute = $configuration->getEmailBindAttribute();
-        $findOpenIdConfigurationResponse->userAliasBindAttribute = $configuration->getUserAliasBindAttribute();
         $findOpenIdConfigurationResponse->userNameBindAttribute = $configuration->getUserNameBindAttribute();
         $findOpenIdConfigurationResponse->claimName = $configuration->getClaimName();
         $findOpenIdConfigurationResponse->contactGroup = $configuration->getContactGroup() === null

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
@@ -127,11 +127,6 @@ class FindOpenIdConfigurationResponse
     /**
      * @var string|null
      */
-    public ?string $userAliasBindAttribute = null;
-
-    /**
-     * @var string|null
-     */
     public ?string $userNameBindAttribute = null;
 
     /**

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationRequest.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationRequest.php
@@ -128,11 +128,6 @@ class UpdateOpenIdConfigurationRequest
     /**
      * @var string|null
      */
-    public ?string $userAliasBindAttribute = null;
-
-    /**
-     * @var string|null
-     */
     public ?string $userNameBindAttribute = null;
 
     /**

--- a/src/Core/Security/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Domain/Provider/OpenIdProvider.php
@@ -606,9 +606,6 @@ class OpenIdProvider implements OpenIdProviderInterface
         if (! array_key_exists($this->configuration->getEmailBindAttribute(), $this->userInformations)) {
             $missingAttributes[] = $this->configuration->getEmailBindAttribute();
         }
-        if (! array_key_exists($this->configuration->getUserAliasBindAttribute(), $this->userInformations)) {
-            $missingAttributes[] = $this->configuration->getUserAliasBindAttribute();
-        }
         if (! array_key_exists($this->configuration->getUserNameBindAttribute(), $this->userInformations)) {
             $missingAttributes[] = $this->configuration->getUserNameBindAttribute();
         }

--- a/src/Core/Security/Domain/ProviderConfiguration/OpenId/Model/Configuration.php
+++ b/src/Core/Security/Domain/ProviderConfiguration/OpenId/Model/Configuration.php
@@ -147,11 +147,6 @@ class Configuration implements ProviderConfigurationInterface
     /**
      * @var string|null
      */
-    private ?string $userAliasBindAttribute = null;
-
-    /**
-     * @var string|null
-     */
     private ?string $userNameBindAttribute = null;
 
     /**
@@ -325,14 +320,6 @@ class Configuration implements ProviderConfigurationInterface
     public function getEmailBindAttribute(): ?string
     {
         return $this->emailBindAttribute;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getUserAliasBindAttribute(): ?string
-    {
-        return $this->userAliasBindAttribute;
     }
 
     /**
@@ -622,17 +609,6 @@ class Configuration implements ProviderConfigurationInterface
     public function setEmailBindAttribute(?string $emailBindAttribute): self
     {
         $this->emailBindAttribute = $emailBindAttribute;
-
-        return $this;
-    }
-
-    /**
-     * @param string|null $userAliasBindAttribute
-     * @return self
-     */
-    public function setUserAliasBindAttribute(?string $userAliasBindAttribute): self
-    {
-        $this->userAliasBindAttribute = $userAliasBindAttribute;
 
         return $this;
     }

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationPresenter.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationPresenter.php
@@ -57,7 +57,6 @@ class FindOpenIdConfigurationPresenter extends AbstractPresenter implements Find
             'auto_import' => $response->isAutoImportEnabled,
             'contact_template' => $response->contactTemplate,
             'email_bind_attribute' => $response->emailBindAttribute,
-            'alias_bind_attribute' => $response->userAliasBindAttribute,
             'fullname_bind_attribute' => $response->userNameBindAttribute,
             'contact_group' => $response->contactGroup,
             'claim_name' => $response->claimName,

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationController.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationController.php
@@ -79,7 +79,6 @@ class UpdateOpenIdConfigurationController extends AbstractController
         $updateOpenIdConfigurationRequest->isAutoImportEnabled = $requestData['auto_import'];
         $updateOpenIdConfigurationRequest->contactTemplate = $requestData['contact_template'];
         $updateOpenIdConfigurationRequest->emailBindAttribute = $requestData['email_bind_attribute'];
-        $updateOpenIdConfigurationRequest->userAliasBindAttribute = $requestData['alias_bind_attribute'];
         $updateOpenIdConfigurationRequest->userNameBindAttribute = $requestData['fullname_bind_attribute'];
         $updateOpenIdConfigurationRequest->claimName = $requestData['claim_name'];
         $updateOpenIdConfigurationRequest->authorizationRules = $requestData['authorization_rules'];

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationSchema.json
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationSchema.json
@@ -23,7 +23,6 @@
         "auto_import",
         "contact_template",
         "email_bind_attribute",
-        "alias_bind_attribute",
         "fullname_bind_attribute",
         "contact_group_id",
         "claim_name",
@@ -102,9 +101,6 @@
         }
       },
       "email_bind_attribute": {
-        "type": ["string", "null"]
-      },
-      "alias_bind_attribute": {
         "type": ["string", "null"]
       },
       "fullname_bind_attribute": {

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilder.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilder.php
@@ -62,7 +62,6 @@ class DbConfigurationBuilder
                 self::validateParametersForAutoImport(
                     $customConfiguration['contact_template'],
                     $customConfiguration['email_bind_attribute'],
-                    $customConfiguration['alias_bind_attribute'],
                     $customConfiguration['fullname_bind_attribute']
                 );
             }
@@ -82,7 +81,6 @@ class DbConfigurationBuilder
             ->setUserInformationEndpoint($customConfiguration['userinfo_endpoint'])
             ->setContactTemplate($customConfiguration['contact_template'])
             ->setEmailBindAttribute($customConfiguration['email_bind_attribute'])
-            ->setUserAliasBindAttribute($customConfiguration['alias_bind_attribute'])
             ->setUserNameBindAttribute($customConfiguration['fullname_bind_attribute'])
             ->setTrustedClientAddresses($customConfiguration['trusted_client_addresses'])
             ->setBlacklistClientAddresses($customConfiguration['blacklist_client_addresses'])
@@ -101,14 +99,12 @@ class DbConfigurationBuilder
      *
      * @param ContactTemplate|null $contactTemplate
      * @param string|null $emailBindAttribute
-     * @param string|null $userAliasBindAttribute
      * @param string|null $userNameBindAttribute
      * @throws OpenIdConfigurationException
      */
     private static function validateParametersForAutoImport(
         ?ContactTemplate $contactTemplate,
         ?string $emailBindAttribute,
-        ?string $userAliasBindAttribute,
         ?string $userNameBindAttribute
     ): void {
         $missingMandatoryParameters = [];
@@ -117,9 +113,6 @@ class DbConfigurationBuilder
         }
         if (empty($emailBindAttribute)) {
             $missingMandatoryParameters[] = 'email_bind_attribute';
-        }
-        if (empty($userAliasBindAttribute)) {
-            $missingMandatoryParameters[] = 'alias_bind_attribute';
         }
         if (empty($userNameBindAttribute)) {
             $missingMandatoryParameters[] = 'fullname_bind_attribute';

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/CustomConfigurationSchema.json
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/CustomConfigurationSchema.json
@@ -21,7 +21,6 @@
         "auto_import",
         "contact_template_id",
         "email_bind_attribute",
-        "alias_bind_attribute",
         "fullname_bind_attribute"
     ],
     "properties": {
@@ -89,9 +88,6 @@
         "type": ["number", "null"]
       },
       "email_bind_attribute": {
-        "type": ["string", "null"]
-      },
-      "alias_bind_attribute": {
         "type": ["string", "null"]
       },
       "fullname_bind_attribute": {

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/DbWriteOpenIdConfigurationRepository.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/DbWriteOpenIdConfigurationRepository.php
@@ -91,7 +91,6 @@ class DbWriteOpenIdConfigurationRepository extends AbstractRepositoryDRB impleme
             'auto_import' => $configuration->isAutoImportEnabled(),
             'contact_template_id' => $configuration->getContactTemplate()?->getId(),
             'email_bind_attribute' => $configuration->getEmailBindAttribute(),
-            'alias_bind_attribute' => $configuration->getUserAliasBindAttribute(),
             'fullname_bind_attribute' => $configuration->getUserNameBindAttribute(),
             'claim_name' => $configuration->getClaimName(),
             'contact_group_id' => $configuration->getContactGroup()?->getId()

--- a/tests/clapi_export/clapi-configuration.txt
+++ b/tests/clapi_export/clapi-configuration.txt
@@ -566,7 +566,6 @@ CONTACTTPL;setparam;contact_template;contact_activate;1
 CONTACTTPL;setparam;contact_template;show_deprecated_pages;0
 CONTACTTPL;setparam;contact_template;contact_ldap_last_sync;0
 CONTACTTPL;setparam;contact_template;contact_ldap_required_sync;0
-CONTACTTPL;setparam;contact_template;enable_one_click_export;0
 CONTACTTPL;ADD;test_name;test_contact-template;;$2y$10$BqnZdxhI2wz1Ot/exXd73eOngqA2RPeBmjxSSyEzSygFXo3L9guAW;0;1;;local
 CONTACTTPL;setparam;test_contact-template;hostnotifopt;n
 CONTACTTPL;setparam;test_contact-template;servicenotifopt;n
@@ -581,7 +580,6 @@ CONTACTTPL;setparam;test_contact-template;contact_activate;1
 CONTACTTPL;setparam;test_contact-template;show_deprecated_pages;0
 CONTACTTPL;setparam;test_contact-template;contact_ldap_last_sync;0
 CONTACTTPL;setparam;test_contact-template;contact_ldap_required_sync;0
-CONTACTTPL;setparam;test_contact-template;enable_one_click_export;0
 CONTACT;ADD;admin admin;admin;admin@centreon.com;$2y$10$kBoz3kL/8kIe8BGStjH67uW7xX060pbypSKcnLfGDYu.FPuShgsKS;1;1;en_US.UTF-8;local
 CONTACT;setparam;admin;hostnotifperiod;24x7
 CONTACT;setparam;admin;svcnotifperiod;24x7
@@ -598,7 +596,6 @@ CONTACT;setparam;admin;contact_activate;1
 CONTACT;setparam;admin;show_deprecated_pages;0
 CONTACT;setparam;admin;contact_ldap_last_sync;0
 CONTACT;setparam;admin;contact_ldap_required_sync;0
-CONTACT;setparam;admin;enable_one_click_export;0
 CONTACT;setparam;admin;hostnotifcmd;host-notify-by-email
 CONTACT;setparam;admin;svcnotifcmd;service-notify-by-email
 CONTACT;ADD;Guest;guest;guest@localhost;$2y$10$PktpVP.m4EWXkblTgNDqu.qNLwXrASiS8E0.d8E9giKzAhvSBH/5a;0;0;en_US.UTF-8;local
@@ -617,7 +614,6 @@ CONTACT;setparam;guest;contact_activate;0
 CONTACT;setparam;guest;show_deprecated_pages;0
 CONTACT;setparam;guest;contact_ldap_last_sync;0
 CONTACT;setparam;guest;contact_ldap_required_sync;0
-CONTACT;setparam;guest;enable_one_click_export;0
 CONTACT;setparam;guest;hostnotifcmd;host-notify-by-email
 CONTACT;setparam;guest;svcnotifcmd;service-notify-by-email
 CONTACT;ADD;Jean-Pierre;jeanpierre;Jean-Pierre@hotmail.fr;$2y$10$xRDrrYnB0.ZcN2cWq7idOeFKfzwTQXm3b0xh6TuYUxI8ctVE98ddy;0;1;browser;local
@@ -634,7 +630,6 @@ CONTACT;setparam;jeanpierre;contact_activate;1
 CONTACT;setparam;jeanpierre;show_deprecated_pages;0
 CONTACT;setparam;jeanpierre;contact_ldap_last_sync;0
 CONTACT;setparam;jeanpierre;contact_ldap_required_sync;0
-CONTACT;setparam;jeanpierre;enable_one_click_export;0
 CONTACT;ADD;test_contact;test_contact;test@localhost;$2y$10$HcwRGF.oU8k9sfm9Vpp7eOlrNHomq4RuNLqhTQcnqDNfAPBe44wGK;0;0;en_US.UTF-8;local
 CONTACT;setparam;test_contact;hostnotifopt;n
 CONTACT;setparam;test_contact;servicenotifopt;n
@@ -649,7 +644,6 @@ CONTACT;setparam;test_contact;contact_activate;1
 CONTACT;setparam;test_contact;show_deprecated_pages;0
 CONTACT;setparam;test_contact;contact_ldap_last_sync;0
 CONTACT;setparam;test_contact;contact_ldap_required_sync;0
-CONTACT;setparam;test_contact;enable_one_click_export;0
 CONTACT;ADD;User;user;user@localhost;$2y$10$Da/IX.qnrwXwu7JJe04JWOJOdTUmqicml7B56wZDyZd6ohZJfOKKm;0;0;en_US.UTF-8;local
 CONTACT;setparam;user;hostnotifperiod;24x7
 CONTACT;setparam;user;svcnotifperiod;24x7
@@ -666,7 +660,6 @@ CONTACT;setparam;user;contact_activate;0
 CONTACT;setparam;user;show_deprecated_pages;0
 CONTACT;setparam;user;contact_ldap_last_sync;0
 CONTACT;setparam;user;contact_ldap_required_sync;0
-CONTACT;setparam;user;enable_one_click_export;0
 CONTACT;setparam;user;hostnotifcmd;host-notify-by-email
 CONTACT;setparam;user;svcnotifcmd;service-notify-by-email
 TRAP;ADD;adDiagCancelled;.1.3.6.1.4.1.674.10893.1.1.200.0.537

--- a/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilderTest.php
+++ b/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilderTest.php
@@ -87,7 +87,7 @@ it(
 )->throws(
     OpenIdConfigurationException::class,
     OpenIdConfigurationException::missingAutoImportMandatoryParameters(
-        ['contact_template', 'email_bind_attribute', 'alias_bind_attribute', 'fullname_bind_attribute']
+        ['contact_template', 'email_bind_attribute', 'fullname_bind_attribute']
     )->getMessage()
 );
 
@@ -101,7 +101,6 @@ it('should return a Configuration when all mandatory parameters are present', fu
     $request->isActive = true;
     $request->introspectionTokenEndpoint = '/introspect';
     $request->isAutoImportEnabled = true;
-    $request->userAliasBindAttribute = 'alias';
     $request->userNameBindAttribute = 'name';
     $request->emailBindAttribute = 'email';
     $contactTemplate = new ContactTemplate(1, 'contact_template');

--- a/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
+++ b/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
@@ -95,7 +95,6 @@ it('should present a provider configuration', function () {
         expect($presenter->response->contactTemplate)->toBe(['id' => 1, 'name' => 'contact_template']);
         expect($presenter->response->isAutoImportEnabled)->toBeFalse();
         expect($presenter->response->emailBindAttribute)->toBeNull();
-        expect($presenter->response->userAliasBindAttribute)->toBeNull();
         expect($presenter->response->userNameBindAttribute)->toBeNull();
         expect($presenter->response->contactGroup)->toBe(['id' => 1, 'name' => 'contact_group']);
 });

--- a/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -175,7 +175,6 @@ it('should present an Error Response when auto import is enable and mandatory pa
     $missingParameters = [
         'contact_template',
         'email_bind_attribute',
-        'alias_bind_attribute',
         'fullname_bind_attribute',
     ];
 
@@ -226,7 +225,6 @@ it('should present an Error Response when auto import is enable and the contact 
     $request->isAutoImportEnabled = true;
     $request->contactTemplate = ['id' => 1, "name" => 'contact_template'];
     $request->emailBindAttribute = 'email';
-    $request->userAliasBindAttribute = 'alias';
     $request->userNameBindAttribute = 'name';
     $request->contactGroupId = 1;
     $request->claimName = 'groups';

--- a/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+++ b/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
@@ -121,7 +121,6 @@ it('should execute the usecase properly', function () {
             'auto_import' => false,
             'contact_template' => null,
             'email_bind_attribute' => null,
-            'alias_bind_attribute' => null,
             'fullname_bind_attribute' => null,
             'contact_group_id' => 1,
             'claim_name' => "groups",

--- a/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilderTest.php
+++ b/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilderTest.php
@@ -42,7 +42,6 @@ beforeEach(function () {
         'userinfo_endpoint' => '/userinfo',
         'contact_template' => new ContactTemplate(1, 'contact_template'),
         'email_bind_attribute' => 'email',
-        'alias_bind_attribute' => 'alias',
         'fullname_bind_attribute' => 'name',
         'trusted_client_addresses' => [],
         'blacklist_client_addresses' => [],
@@ -83,7 +82,6 @@ it(
     function () {
         $this->customConfiguration['contact_template'] = null;
         $this->customConfiguration['email_bind_attribute'] =  null;
-        $this->customConfiguration['alias_bind_attribute'] =  null;
         $this->customConfiguration['fullname_bind_attribute'] = null;
         DbConfigurationBuilder::create(
             ['id' => 2, 'is_active' => true, 'is_forced' => true],
@@ -93,7 +91,7 @@ it(
 )->throws(
     OpenIdConfigurationException::class,
     OpenIdConfigurationException::missingAutoImportMandatoryParameters(
-        ['contact_template', 'email_bind_attribute', 'alias_bind_attribute', 'fullname_bind_attribute']
+        ['contact_template', 'email_bind_attribute', 'fullname_bind_attribute']
     )->getMessage()
 );
 

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -407,7 +407,6 @@ class CentreonContact extends CentreonObject
                             'reach_api_rt',
                             'default_page',
                             'show_deprecated_pages',
-                            'enable_one_click_export'
                         ]
                     )
                 ) {

--- a/www/front_src/src/Authentication/Openid/Form/inputs.ts
+++ b/www/front_src/src/Authentication/Openid/Form/inputs.ts
@@ -3,7 +3,6 @@ import { FormikValues } from 'formik';
 
 import {
   labelAccessGroup,
-  labelAliasAttributeToBind,
   labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled,
   labelAuthenticationMode,
   labelAuthorizationEndpoint,
@@ -14,11 +13,11 @@ import {
   labelContactGroup,
   labelContactTemplate,
   labelDisableVerifyPeer,
-  labelEmailAttributeToBind,
+  labelEmailAttribute,
   labelEnableAutoImport,
   labelEnableOpenIDConnectAuthentication,
   labelEndSessionEndpoint,
-  labelFullnameAttributeToBind,
+  labelFullnameAttribute,
   labelIntrospectionTokenEndpoint,
   labelLoginClaimValue,
   labelMixed,
@@ -38,7 +37,7 @@ import { InputProps, InputType } from '../../FormInputs/models';
 import {
   labelActivation,
   labelAuthorizations,
-  labelAutoImport,
+  labelAutoImportUsers,
   labelClientAddresses,
   labelIdentityProvider,
 } from '../../translatedLabels';
@@ -183,13 +182,13 @@ export const inputs: Array<InputProps> = [
     type: InputType.Switch,
   },
   {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     fieldName: 'autoImport',
     label: labelEnableAutoImport,
     type: InputType.Switch,
   },
   {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     endpoint: contactTemplatesEndpoint,
     fieldName: 'contactTemplate',
     getDisabled: isAutoImportDisabled,
@@ -198,27 +197,19 @@ export const inputs: Array<InputProps> = [
     type: InputType.ConnectedAutocomplete,
   },
   {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     fieldName: 'emailBindAttribute',
     getDisabled: isAutoImportDisabled,
     getRequired: isAutoImportEnabled,
-    label: labelEmailAttributeToBind,
+    label: labelEmailAttribute,
     type: InputType.Text,
   },
   {
-    category: labelAutoImport,
-    fieldName: 'aliasBindAttribute',
-    getDisabled: isAutoImportDisabled,
-    getRequired: isAutoImportEnabled,
-    label: labelAliasAttributeToBind,
-    type: InputType.Text,
-  },
-  {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     fieldName: 'fullnameBindAttribute',
     getDisabled: isAutoImportDisabled,
     getRequired: isAutoImportEnabled,
-    label: labelFullnameAttributeToBind,
+    label: labelFullnameAttribute,
     type: InputType.Text,
   },
   {

--- a/www/front_src/src/Authentication/Openid/index.test.tsx
+++ b/www/front_src/src/Authentication/Openid/index.test.tsx
@@ -21,7 +21,6 @@ import { labelActivation } from '../translatedLabels';
 
 import {
   labelAccessGroup,
-  labelAliasAttributeToBind,
   labelAuthorizationEndpoint,
   labelAuthorizationKey,
   labelAuthorizationValue,
@@ -33,11 +32,11 @@ import {
   labelContactTemplate,
   labelDefineOpenIDConnectConfiguration,
   labelDisableVerifyPeer,
-  labelEmailAttributeToBind,
+  labelEmailAttribute,
   labelEnableAutoImport,
   labelEnableOpenIDConnectAuthentication,
   labelEndSessionEndpoint,
-  labelFullnameAttributeToBind,
+  labelFullnameAttribute,
   labelIntrospectionTokenEndpoint,
   labelInvalidIPAddress,
   labelInvalidURL,
@@ -70,7 +69,6 @@ const renderOpenidConfigurationForm = (): RenderResult =>
   render(<OpenidConfigurationForm />);
 
 const retrievedOpenidConfiguration = {
-  alias_bind_attribute: 'firstname',
   authentication_type: 'client_secret_post',
   authorization_endpoint: '/authorize',
   authorization_rules: [
@@ -111,7 +109,6 @@ const retrievedOpenidConfiguration = {
 };
 
 const retrievedOpenidConfigurationWithEmptyAuthorization = {
-  alias_bind_attribute: 'firstname',
   authentication_type: 'client_secret_post',
   authorization_endpoint: '/authorize',
   authorization_rules: [],
@@ -243,13 +240,8 @@ describe('Openid configuration form', () => {
     ).not.toBeChecked();
     expect(screen.getByLabelText(labelDisableVerifyPeer)).not.toBeChecked();
     expect(screen.getByLabelText(labelEnableAutoImport)).toBeChecked();
-    expect(screen.getByLabelText(labelEmailAttributeToBind)).toHaveValue(
-      'email',
-    );
-    expect(screen.getByLabelText(labelAliasAttributeToBind)).toHaveValue(
-      'firstname',
-    );
-    expect(screen.getByLabelText(labelFullnameAttributeToBind)).toHaveValue(
+    expect(screen.getByLabelText(labelEmailAttribute)).toHaveValue('email');
+    expect(screen.getByLabelText(labelFullnameAttribute)).toHaveValue(
       'lastname',
     );
     expect(screen.getByText('Contact group')).toBeInTheDocument();
@@ -416,12 +408,10 @@ describe('Openid configuration form', () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText(labelEmailAttributeToBind),
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText(labelEmailAttribute)).toBeInTheDocument();
     });
 
-    userEvent.type(screen.getByLabelText(labelEmailAttributeToBind), '');
+    userEvent.type(screen.getByLabelText(labelEmailAttribute), '');
 
     await waitFor(() => {
       expect(screen.getByText(labelSave)).toBeDisabled();

--- a/www/front_src/src/Authentication/Openid/models.ts
+++ b/www/front_src/src/Authentication/Openid/models.ts
@@ -14,7 +14,6 @@ export interface AuthorizationRelationToAPI {
 }
 
 export interface OpenidConfiguration {
-  aliasBindAttribute?: string | null;
   authenticationType: string | null;
   authorizationEndpoint: string | null;
   authorizationRules: Array<AuthorizationRule>;
@@ -41,7 +40,6 @@ export interface OpenidConfiguration {
 }
 
 export interface OpenidConfigurationToAPI {
-  alias_bind_attribute: string | null;
   authentication_type: string | null;
   authorization_endpoint: string | null;
   authorization_rules: Array<AuthorizationRelationToAPI>;

--- a/www/front_src/src/Authentication/Openid/translatedLabels.tsx
+++ b/www/front_src/src/Authentication/Openid/translatedLabels.tsx
@@ -30,9 +30,8 @@ export const labelOpenIDConnectOnly = 'OpenID Connect only';
 export const labelMixed = 'Mixed';
 export const labelEnableAutoImport = 'Enable auto import';
 export const labelContactTemplate = 'Contact template';
-export const labelEmailAttributeToBind = 'Email attribute to bind';
-export const labelAliasAttributeToBind = 'Alias attribute to bind';
-export const labelFullnameAttributeToBind = 'Fullname attribute to bind';
+export const labelEmailAttribute = 'Email attribute';
+export const labelFullnameAttribute = 'Fullname attribute';
 export const labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled =
   'At least one of the two following fields must be filled';
 export const labelContactGroup = 'Contact group';

--- a/www/front_src/src/Authentication/Openid/useValidationSchema.ts
+++ b/www/front_src/src/Authentication/Openid/useValidationSchema.ts
@@ -27,14 +27,6 @@ const useValidationSchema = (): Yup.SchemaOf<OpenidConfiguration> => {
   });
 
   return Yup.object({
-    aliasBindAttribute: Yup.string().when(
-      'autoImport',
-      (autoImport, schema) => {
-        return autoImport
-          ? schema.nullable().required(t(labelRequired))
-          : schema.nullable();
-      },
-    ),
     authenticationType: Yup.string().required(t(labelRequired)),
     authorizationEndpoint: Yup.string().nullable().required(t(labelRequired)),
     authorizationRules: Yup.array()

--- a/www/front_src/src/Authentication/api/adapters.ts
+++ b/www/front_src/src/Authentication/api/adapters.ts
@@ -101,13 +101,11 @@ export const adaptOpenidConfigurationToAPI = ({
   autoImport,
   contactTemplate,
   emailBindAttribute,
-  aliasBindAttribute,
   fullnameBindAttribute,
   contactGroup,
   claimName,
   authorizationRules,
 }: OpenidConfiguration): OpenidConfigurationToAPI => ({
-  alias_bind_attribute: aliasBindAttribute || null,
   authentication_type: authenticationType || null,
   authorization_endpoint: authorizationEndpoint || null,
   authorization_rules:

--- a/www/front_src/src/Authentication/api/decoders.ts
+++ b/www/front_src/src/Authentication/api/decoders.ts
@@ -73,7 +73,6 @@ const authorization = JsonDecoder.object<AuthorizationRule>(
 export const openidConfigurationDecoder =
   JsonDecoder.object<OpenidConfiguration>(
     {
-      aliasBindAttribute: JsonDecoder.nullable(JsonDecoder.string),
       authenticationType: JsonDecoder.nullable(JsonDecoder.string),
       authorizationEndpoint: JsonDecoder.nullable(JsonDecoder.string),
       authorizationRules: JsonDecoder.array(
@@ -116,7 +115,6 @@ export const openidConfigurationDecoder =
     },
     'Open ID Configuration',
     {
-      aliasBindAttribute: 'alias_bind_attribute',
       authenticationType: 'authentication_type',
       authorizationEndpoint: 'authorization_endpoint',
       authorizationRules: 'authorization_rules',

--- a/www/front_src/src/Authentication/index.tsx
+++ b/www/front_src/src/Authentication/index.tsx
@@ -22,7 +22,7 @@ import { labelWebSSOConfiguration } from './WebSSO/translatedLabels';
 import {
   labelActivation,
   labelAuthorizations,
-  labelAutoImport,
+  labelAutoImportUsers,
   labelClientAddresses,
   labelIdentityProvider,
 } from './translatedLabels';
@@ -67,7 +67,7 @@ export const categories: Array<Category> = [
     order: 3,
   },
   {
-    name: labelAutoImport,
+    name: labelAutoImportUsers,
     order: 3,
   },
   {

--- a/www/front_src/src/Authentication/translatedLabels.ts
+++ b/www/front_src/src/Authentication/translatedLabels.ts
@@ -1,6 +1,6 @@
 export const labelActivation = 'Activation';
 export const labelIdentityProvider = 'Identity provider';
 export const labelClientAddresses = 'Client addresses';
-export const labelAutoImport = 'Auto import';
+export const labelAutoImportUsers = 'Auto import users';
 export const labelAuthorizations = 'Authorizations';
 export const labelPressEnterToAccept = 'Press Enter to accept';

--- a/www/front_src/src/Resources/Details/tabs/Timeline/ExportToCsv.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/ExportToCsv.tsx
@@ -1,24 +1,39 @@
 import { useTranslation } from 'react-i18next';
+import { useAtomValue } from 'jotai';
+import { IconButton } from 'centreon-frontend/packages/centreon-ui/src';
+import { path } from 'ramda';
 
-import { Box, Link, Stack, Tooltip } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 
 import { labelExportToCsv } from '../../../translatedLabels';
+import { detailsAtom } from '../../detailsAtoms';
 
 const ExportToCsv = (): JSX.Element => {
   const { t } = useTranslation();
 
+  const details = useAtomValue(detailsAtom);
+
+  const openInNewTab = (url): void => {
+    window.open(url, 'noopener', 'noreferrer');
+  };
+
+  const downloadTimelineFile = `${details?.links.endpoints.timeline}/download`;
+
+  const exportToCsv = (): void => {
+    openInNewTab(downloadTimelineFile);
+  };
+
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box>
       <Stack sx={{ alignItems: 'center', padding: 1 }}>
-        <Tooltip title={t(labelExportToCsv)}>
-          <Link
-            data-testid={labelExportToCsv}
-            href="http://localhost:4000/centreon/api/latest/monitoring/hosts/14/services/25/timeline/download"
-          >
-            <FileDownloadIcon style={{ fontSize: 30 }} />
-          </Link>
-        </Tooltip>
+        <IconButton
+          data-testid={labelExportToCsv}
+          title={t(labelExportToCsv)}
+          onClick={exportToCsv}
+        >
+          <FileDownloadIcon style={{ fontSize: 30 }} />
+        </IconButton>
       </Stack>
     </Box>
   );
@@ -26,4 +41,6 @@ const ExportToCsv = (): JSX.Element => {
 
 export default ExportToCsv;
 
+// Snackbar
+// si href non ok => window open
 //     path: /monitoring/hosts/{hostId}/services/{serviceId}/timeline/download

--- a/www/front_src/src/Resources/Details/tabs/Timeline/ExportToCsv.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/ExportToCsv.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+
+import { Box, Link, Stack, Tooltip } from '@mui/material';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+
+import { labelExportToCsv } from '../../../translatedLabels';
+
+const ExportToCsv = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Stack sx={{ alignItems: 'center', padding: 1 }}>
+        <Tooltip title={t(labelExportToCsv)}>
+          <Link
+            data-testid={labelExportToCsv}
+            href="http://localhost:4000/centreon/api/latest/monitoring/hosts/14/services/25/timeline/download"
+          >
+            <FileDownloadIcon style={{ fontSize: 30 }} />
+          </Link>
+        </Tooltip>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ExportToCsv;
+
+//     path: /monitoring/hosts/{hostId}/services/{serviceId}/timeline/download

--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -4,19 +4,17 @@ import { useTranslation } from 'react-i18next';
 import { prop, isEmpty, path, isNil } from 'ramda';
 import { useAtomValue } from 'jotai/utils';
 
-import { Paper, Stack, Link } from '@mui/material';
-import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import { Paper } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 
 import {
-  IconButton,
   useRequest,
   ListingModel,
   MultiAutocompleteField,
   SearchParameter,
 } from '@centreon/ui';
 
-import { labelEvent, labelExportToCsv } from '../../../translatedLabels';
+import { labelEvent } from '../../../translatedLabels';
 import { TabProps } from '..';
 import InfiniteScroll from '../../InfiniteScroll';
 import TimePeriodButtonGroup from '../../../Graph/Performance/TimePeriods';

--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -4,19 +4,17 @@ import { useTranslation } from 'react-i18next';
 import { prop, isEmpty, path, isNil } from 'ramda';
 import { useAtomValue } from 'jotai/utils';
 
-import { Paper, Stack, Link } from '@mui/material';
-import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import { Paper } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 
 import {
-  IconButton,
   useRequest,
   ListingModel,
   MultiAutocompleteField,
   SearchParameter,
 } from '@centreon/ui';
 
-import { labelEvent, labelExportToCsv } from '../../../translatedLabels';
+import { labelEvent } from '../../../translatedLabels';
 import { TabProps } from '..';
 import InfiniteScroll from '../../InfiniteScroll';
 import TimePeriodButtonGroup from '../../../Graph/Performance/TimePeriods';
@@ -32,6 +30,7 @@ import { listTimelineEventsDecoder } from './api/decoders';
 import { listTimelineEvents } from './api';
 import Events from './Events';
 import LoadingSkeleton from './LoadingSkeleton';
+import ExportToCsv from './ExportToCsv';
 
 type TimelineListing = ListingModel<TimelineEvent>;
 
@@ -115,12 +114,6 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
     setSelectedTypes(typeIds);
   };
 
-  const openInNewTab = (url): void => {
-    window.open(url);
-  };
-
-  const exportToCsv = (): void => openInNewTab('https://google.com');
-
   return (
     <InfiniteScroll
       details={details}
@@ -135,15 +128,7 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
             value={selectedTypes}
             onChange={changeSelectedTypes}
           />
-          <Stack>
-            <IconButton
-              data-testid={labelExportToCsv}
-              title={t(labelExportToCsv)}
-              onClick={exportToCsv}
-            >
-              <FileDownloadIcon style={{ fontSize: 18 }} />
-            </IconButton>
-          </Stack>
+          <ExportToCsv />
         </Paper>
       }
       limit={limit}

--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -4,17 +4,19 @@ import { useTranslation } from 'react-i18next';
 import { prop, isEmpty, path, isNil } from 'ramda';
 import { useAtomValue } from 'jotai/utils';
 
-import { Paper } from '@mui/material';
+import { Paper, Stack, Link } from '@mui/material';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import makeStyles from '@mui/styles/makeStyles';
 
 import {
+  IconButton,
   useRequest,
   ListingModel,
   MultiAutocompleteField,
   SearchParameter,
 } from '@centreon/ui';
 
-import { labelEvent } from '../../../translatedLabels';
+import { labelEvent, labelExportToCsv } from '../../../translatedLabels';
 import { TabProps } from '..';
 import InfiniteScroll from '../../InfiniteScroll';
 import TimePeriodButtonGroup from '../../../Graph/Performance/TimePeriods';
@@ -37,6 +39,9 @@ const useStyles = makeStyles((theme) => ({
   filter: {
     padding: theme.spacing(2),
     paddingTop: 0,
+  },
+  iconCSV: {
+    padding: 4,
   },
 }));
 
@@ -110,6 +115,12 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
     setSelectedTypes(typeIds);
   };
 
+  const openInNewTab = (url): void => {
+    window.open(url);
+  };
+
+  const exportToCsv = (): void => openInNewTab('https://google.com');
+
   return (
     <InfiniteScroll
       details={details}
@@ -124,6 +135,15 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
             value={selectedTypes}
             onChange={changeSelectedTypes}
           />
+          <Stack>
+            <IconButton
+              data-testid={labelExportToCsv}
+              title={t(labelExportToCsv)}
+              onClick={exportToCsv}
+            >
+              <FileDownloadIcon style={{ fontSize: 18 }} />
+            </IconButton>
+          </Stack>
         </Paper>
       }
       limit={limit}

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -253,3 +253,4 @@ export const labelParentAlias = 'Parent alias';
 export const labelCategories = 'Categories';
 export const labelHostCategory = 'Host category';
 export const labelServiceCategory = 'Service category';
+export const labelExportToCsv = 'Export to Csv';

--- a/www/include/Administration/myAccount/DB-Func.php
+++ b/www/include/Administration/myAccount/DB-Func.php
@@ -148,8 +148,7 @@ function updateContact($contactId = null)
           'default_page = :defaultPage, ' .
           'show_deprecated_pages = :showDeprecatedPages, ' .
           'contact_autologin_key = :contactAutologinKey, ' .
-          'contact_theme = :contactTheme, ' .
-          'enable_one_click_export = :enableOneClickExport';
+          'contact_theme = :contactTheme';
     $rq .= ' WHERE contact_id = :contactId';
 
     $stmt = $pearDB->prepare($rq);
@@ -183,7 +182,6 @@ function updateContact($contactId = null)
     );
     $stmt->bindValue(':defaultPage', !empty($ret['default_page']) ? $ret['default_page'] : null, \PDO::PARAM_INT);
     $stmt->bindValue(':showDeprecatedPages', isset($ret['show_deprecated_pages']) ? 1 : 0, \PDO::PARAM_STR);
-    $stmt->bindValue(':enableOneClickExport', isset($ret['enable_one_click_export']) ? '1' : '0', \PDO::PARAM_STR);
     $stmt->bindValue(':contactId', $contactId, \PDO::PARAM_INT);
     $stmt->execute();
 

--- a/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -55,9 +55,6 @@
             </tr>
             <tr class="list_two"><td class="FormRowField">{$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td></tr>
-            {if $contactIsAdmin && !$isRemote}
-            <tr class="list_one"><td class="FormRowField">{$form.enable_one_click_export.label}</td><td class="FormRowValue">{$form.enable_one_click_export.html}</td></tr>
-            {/if}
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
                     <h4>{t}Authentication{/t}</h4>

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -71,7 +71,7 @@ $cct = array();
 if ($o == "c") {
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
-        contact_theme, enable_one_click_export
+        contact_theme
         FROM contact WHERE contact_id = :id";
     $DBRESULT = $pearDB->prepare($query);
     $DBRESULT->bindValue(':id', $centreon->user->get_id(), \PDO::PARAM_INT);
@@ -173,15 +173,6 @@ $form->addElement(
 );
 $form->addElement('select', 'contact_lang', _("Language"), $langs);
 $form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
-if (!$isRemote) {
-    $form->addElement(
-        'checkbox',
-        'enable_one_click_export',
-        _("Enable the one-click export button for poller configuration [BETA]"),
-        null,
-        $attrsText
-    );
-}
 
 
 /* ------------------------ Topoogy ---------------------------- */
@@ -452,7 +443,6 @@ if ($form->validate()) {
     if (
         $form->getSubmitValue("contact_lang") !== $cct['contact_lang']
         || $showDeprecatedPages !== $cct['show_deprecated_pages']
-        || $form->getSubmitValue('enable_one_click_export') !== $cct['enable_one_click_export']
     ) {
         $contactStatement = $pearDB->prepare(
             'SELECT * FROM contact WHERE contact_id = :contact_id'

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -252,6 +252,24 @@ function myTrim($str)
     return (trim($str));
 }
 
+/**
+ * @param string $value
+ * @return string
+ */
+function limitNotesLength(string $value): string
+{
+    return substr($value, 0, 512);
+}
+
+/**
+ * @param string $value
+ * @return string
+ */
+function limitUrlLength(string $value): string
+{
+    return substr($value, 0, 2048);
+}
+
 /*
  * Hosts Functions
  */

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -91,7 +91,7 @@
 				<td class="FormRowValue">{$form.host_location.html}</td>
 			</tr>
 			{if $o == "mc"}
-			<tr class="list_two">	
+			<tr class="list_two">
 				<td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_tplp.label}</td>
 				<td class="FormRowValue">{$form.mc_mod_tplp.html}</td>
 			</tr>
@@ -423,7 +423,7 @@
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="flap_detection_enabled"> {$form.host_flap_detection_enabled.label}</td><td class="FormRowValue">{$form.host_flap_detection_enabled.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="low_flap_threshold"> {$form.host_low_flap_threshold.label}</td><td class="FormRowValue">{$form.host_low_flap_threshold.html}&nbsp;%</td></tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="high_flap_threshold"> {$form.host_high_flap_threshold.label}</td><td class="FormRowValue">{$form.host_high_flap_threshold.html}&nbsp;%</td></tr>
-	
+
 	<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
       <h4>{$History_Options}</h4>
     </td></tr>
@@ -527,13 +527,31 @@
 <script>
 	var alert_check_interval = null;
 	{if isset($alert_check_interval)}
-		alert_check_interval = "{$alert_check_interval}";
+	alert_check_interval = "{$alert_check_interval}";
+	{/if}
+	var alert_max_length_exceeded = null;
+	{ if isset($alert_max_length_exceeded)}
+		alert_max_length_exceeded = "{$alert_max_length_exceeded}";
 	{/if}
 {literal}
 jQuery('input[name=host_check_interval]').change(function(){
     if (parseInt(jQuery(this).val()) >= 1440){
         alert(alert_check_interval);
     }
+});
+
+$('input[name=ehi_notes_url], input[name=ehi_action_url]').change(function () {
+	inputName = $(this).parent('td').prev().text();
+	if ($(this).val().length > 2048) {
+		alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '2048'));
+	}
+});
+
+$('input[name=ehi_notes]').change(function () {
+	inputName = $(this).parent('td').prev().text();
+	if ($(this).val().length > 512) {
+		alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '512'));
+	}
 });
 
 jQuery(function() {
@@ -671,7 +689,7 @@ function setListener(elem){
     }
 
     elem.on('change',function(event,data){
-        if(typeof data != "undefined" && typeof data.origin !=undefined 
+        if(typeof data != "undefined" && typeof data.origin !=undefined
             && data.origin == "select2defaultinit"){
             return false;
         }
@@ -688,7 +706,7 @@ function clonerefreshListener(el){
     setListener(el.find('select[name^=tpSelect]'));
 }
 
-{/literal}{if $o != "mc"}{literal}    
+{/literal}{if $o != "mc"}{literal}
     function doAjaxLoad(elems) {
             jQuery.ajax({
                 url: "./include/configuration/configObject/host/refreshMacroAjax.php",
@@ -701,7 +719,7 @@ function clonerefreshListener(el){
                     jQuery("#clone-values-macro").data("clone-values-macro",json.macros);
                     sheepIt.removeAllForms();
                     for (i = 0; i < jQuery("#clone-count-macro").data("clone-count-macro"); i++) {
-                        sheepIt.addForm();	
+                        sheepIt.addForm();
                     }
 
                     sheepIt.inject(jQuery("#clone-values-macro").data("clone-values-macro"));

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -118,7 +118,7 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
 
     // Set Host Category Parents
     $statement = $pearDB->prepare(
-        'SELECT DISTINCT hostcategories_hc_id 
+        'SELECT DISTINCT hostcategories_hc_id
         FROM hostcategories_relation hcr
         INNER JOIN hostcategories hc
             ON hcr.hostcategories_hc_id = hc.hc_id
@@ -146,7 +146,7 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
 
     // Set critically
     $statement = $pearDB->prepare(
-        'SELECT hc.hc_id 
+        'SELECT hc.hc_id
         FROM hostcategories hc
         INNER JOIN hostcategories_relation hcr
             ON hcr.hostcategories_hc_id = hc.hc_id
@@ -1050,6 +1050,11 @@ function myReplace()
 }
 
 $form->applyFilter('__ALL__', 'myTrim');
+
+$form->applyFilter('ehi_notes', 'limitNotesLength');
+$form->applyFilter('ehi_notes_url', 'limitUrlLength');
+$form->applyFilter('ehi_action_url', 'limitUrlLength');
+
 $from_list_menu = false;
 if ($o !== HOST_MASSIVE_CHANGE) {
     $form->applyFilter('host_name', 'myReplace');
@@ -1111,6 +1116,11 @@ $tpl->assign(
     'alert_check_interval',
     _("Warning, unconventional use of interval check. You should prefer to use an interval lower than 24h,"
         . " if needed, pair this configuration with the use of timeperiods")
+);
+
+$tpl->assign(
+    'alert_max_length_exceeded',
+    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving")
 );
 
 if ($o === HOST_WATCH) {

--- a/www/include/configuration/configObject/service/formService.ihtml
+++ b/www/include/configuration/configObject/service/formService.ihtml
@@ -16,8 +16,8 @@
         <li class="a" id='c1'><a href="#" onclick="javascript:montre('1');">{t}General Information{/t}</a></li>
         <li class="b" id='c2'><a href="#" onclick="javascript:montre('2');">{t}Notifications{/t}</a></li>
         <li class="b" id='c3'><a href="#" onclick="javascript:montre('3');">{t}Relations{/t}</a></li>
-        <li class="b" id='c4'><a href="#" onclick="javascript:montre('4');">{t}Data Processing{/t}</a></li>     
-        <li class="b" id='c5'><a href="#" onclick="javascript:montre('5');">{t}Extended Info{/t}</a></li>       
+        <li class="b" id='c4'><a href="#" onclick="javascript:montre('4');">{t}Data Processing{/t}</a></li>
+        <li class="b" id='c5'><a href="#" onclick="javascript:montre('5');">{t}Extended Info{/t}</a></li>
     </ul>
     <div id="validFormTop">
     {if $o == "a" || $o == "c" || $o == "mc"}
@@ -299,7 +299,7 @@
             <h3>| {$form.header.title3}</h3>
           </td>
         </tr>
-        
+
         <tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$form.header.treatment}</h4>
@@ -312,7 +312,7 @@
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$Freshness_Control_options}</h4>
           </td>
-        </tr>   
+        </tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="check_freshness"> {$form.service_check_freshness.label}</td><td class="FormRowValue">{$form.service_check_freshness.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="freshness_threshold"> {$form.service_freshness_threshold.label}</td><td class="FormRowValue">{$form.service_freshness_threshold.html}&nbsp;{$seconds}</td></tr>
 
@@ -320,7 +320,7 @@
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$Flapping_Options}</h4>
           </td>
-        </tr>       
+        </tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="flap_detection_enabled"> {$form.service_flap_detection_enabled.label}</td><td class="FormRowValue">{$form.service_flap_detection_enabled.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="low_flap_threshold"> {$form.service_low_flap_threshold.label}</td><td class="FormRowValue">{$form.service_low_flap_threshold.html}&nbsp;%</td></tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="high_flap_threshold"> {$form.service_high_flap_threshold.label}</td><td class="FormRowValue">{$form.service_high_flap_threshold.html}&nbsp;%</td></tr>
@@ -349,7 +349,7 @@
                 {/if}
             </td>
         </tr>
-        {if $v > "1"}       
+        {if $v > "1"}
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="event_handler_args"> {$form.command_command_id_arg2.label}</td><td class="FormRowValue">{$form.command_command_id_arg2.html}
         {if $o == "a" || $o == "c"}
         &nbsp;<img src="./img/icons/arrow-left.png" class="ico-14" style='cursor: pointer;margin: 0 6px;vertical-align: middle;' alt="*" onClick="set_arg('example2','command_command_id_arg2');"><input type="text" name="example2" disabled>
@@ -372,7 +372,7 @@
           </td>
         </tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="graph_template"> {$form.graph_id.label}</td><td class="FormRowValue">{$form.graph_id.html}</td></tr>
-        
+
         {if $o == "mc"}
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_sc.label}</td><td class="FormRowValue">{$form.mc_mod_sc.html}</td></tr>
         {/if}
@@ -429,10 +429,29 @@ var alert_check_interval = null;
     var alert_check_interval = "{$alert_check_interval}";
 {/if}
 
+var alert_max_length_exceeded = null;
+{ if isset($alert_max_length_exceeded)}
+alert_max_length_exceeded = "{$alert_max_length_exceeded}";
+{/if}
+
 {literal}
 jQuery('input[name=service_normal_check_interval]').change(function() {
     if (parseInt(jQuery(this).val()) >= 1440) {
         alert(alert_check_interval);
+    }
+});
+
+$('input[name=esi_notes_url], input[name=esi_action_url]').change(function () {
+    inputName = $(this).parent('td').prev().text();
+    if ($(this).val().length > 2048) {
+        alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '2048'));
+    }
+});
+
+$('input[name=esi_notes]').change(function () {
+    inputName = $(this).parent('td').prev().text();
+    if ($(this).val().length > 512) {
+        alert(alert_max_length_exceeded.replace('%s', $.trim(inputName)).replace('%d', '512'));
     }
 });
 

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -90,7 +90,7 @@ $macroPasswords = [];
 
 if (($o == SERVICE_MODIFY || $o == SERVICE_WATCH) && $service_id) {
     $statement = $pearDB->prepare(
-        'SELECT * 
+        'SELECT *
         FROM service
         LEFT JOIN extended_service_information esi
             ON esi.service_service_id = service_id
@@ -126,7 +126,7 @@ if (($o == SERVICE_MODIFY || $o == SERVICE_WATCH) && $service_id) {
      * Set criticality
      */
     $statement = $pearDB->prepare(
-        'SELECT sc.sc_id 
+        'SELECT sc.sc_id
         FROM service_categories sc
         INNER JOIN service_categories_relation scr
             ON scr.sc_id = sc.sc_id
@@ -1017,6 +1017,10 @@ if (is_array($select)) {
  * Form Rules
  */
 $form->applyFilter('__ALL__', 'myTrim');
+$form->applyFilter('esi_notes', 'limitNotesLength');
+$form->applyFilter('esi_notes_url', 'limitUrlLength');
+$form->applyFilter('esi_action_url', 'limitUrlLength');
+
 $from_list_menu = false;
 if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->addRule('service_description', _("Compulsory Name"), 'required');
@@ -1085,6 +1089,11 @@ $tpl->assign(
     'alert_check_interval',
     _("Warning, unconventional use of interval check. You should prefer to use an interval lower than 24h, "
         . "if needed, pair this configuration with the use of timeperiods")
+);
+
+$tpl->assign(
+    'alert_max_length_exceeded',
+    _("Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving")
 );
 
 // Just watch a host information

--- a/www/include/eventLogs/export/Formatter.php
+++ b/www/include/eventLogs/export/Formatter.php
@@ -1,0 +1,414 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+namespace Centreon\Legacy\EventLogs\Export;
+
+class Formatter
+{
+    private const DATE_FORMAT = 'Y/m/d';
+    private const TIME_FORMAT = 'H:i:s';
+    private const DATE_TIME_FORMAT = 'Y/m/d (H:i:s)';
+    private const SERVICE_ACKNOWLEDGEMENT_MSG_TYPE = 10;
+    private const HOST_ACKNOWLEDGEMENT_MSG_TYPE = 11;
+    private const ACKNOWLEDGMENT_MESSAGE_TYPE = 'ACK';
+    private const INITIAL_STATE_VALUE = 'INITIAL STATE';
+    private const NOTIFICATION_TYPE_VALUE = 'NOTIF';
+    /**
+     * @var string[]
+     */
+    private array $hosts = [];
+    /**
+     * @var string[]
+     */
+    private array $serviceStatuses = ['0' => 'OK', '1' => 'WARNING', '2' => 'CRITICAL', '3' => 'UNKNOWN'];
+    /**
+     * @var string[]
+     */
+    private array $hostStatuses = ['0' => 'UP', '1' => 'DOWN', '2' => 'UNREACHABLE',];
+    /**
+     * @var string[]
+     */
+    private array $notificationTypes = ['1' => 'HARD', '0' => 'SOFT'];
+    private int $start = 0;
+    private int $end = 0;
+    private string $notification = '';
+    private string $alert = '';
+    private string $error = '';
+    private string $up = '';
+    private string $down = '';
+    private string $unreachable = '';
+    private string $ok = '';
+    private string $warning = '';
+    private string $critical = '';
+    private string $unknown = '';
+
+    /**
+     * @param int $start
+     * @return void
+     */
+    public function setStart(int $start): void
+    {
+        $this->start = $start;
+    }
+
+    /**
+     * @param int $end
+     * @return void
+     */
+    public function setEnd(int $end): void
+    {
+        $this->end = $end;
+    }
+
+    /**
+     * @param string $notification
+     * @return void
+     */
+    public function setNotification(string $notification): void
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param string $alert
+     * @return void
+     */
+    public function setAlert(string $alert): void
+    {
+        $this->alert = $alert;
+    }
+
+    /**
+     * @param string $error
+     * @return void
+     */
+    public function setError(string $error): void
+    {
+        $this->error = $error;
+    }
+
+    /**
+     * @param string $up
+     * @return void
+     */
+    public function setUp(string $up): void
+    {
+        $this->up = $up;
+    }
+
+    /**
+     * @param string $down
+     * @return void
+     */
+    public function setDown(string $down): void
+    {
+        $this->down = $down;
+    }
+
+    /**
+     * @param string $unreachable
+     * @return void
+     */
+    public function setUnreachable(string $unreachable): void
+    {
+        $this->unreachable = $unreachable;
+    }
+
+    /**
+     * @param string $ok
+     * @return void
+     */
+    public function setOk(string $ok): void
+    {
+        $this->ok = $ok;
+    }
+
+    /**
+     * @param string $warning
+     * @return void
+     */
+    public function setWarning(string $warning): void
+    {
+        $this->warning = $warning;
+    }
+
+    /**
+     * @param string $critical
+     * @return void
+     */
+    public function setCritical(string $critical): void
+    {
+        $this->critical = $critical;
+    }
+
+    /**
+     * @param string $unknown
+     * @return void
+     */
+    public function setUnknown(string $unknown): void
+    {
+        $this->unknown = $unknown;
+    }
+
+    /**
+     * @param string[] $hosts
+     * @return void
+     */
+    public function setHosts(array $hosts): void
+    {
+        $this->hosts = $hosts;
+    }
+
+    /**
+     * Generates an array with metadata (filter values from http request)
+     * @return mixed[]
+     */
+    public function formatMetaData(): array
+    {
+        return  [
+            ['Begin date', 'End date'],
+            [$this->formatStart(), $this->formatEnd()],
+            [],
+            ['Type', 'Notification', 'Alert', 'error'],
+            ['', $this->notification, $this->alert, $this->error],
+            [],
+            ['Host', 'Up', 'Down', 'Unreachable'],
+            ['', $this->up, $this->down, $this->unreachable],
+            [],
+            ['Service', 'Ok', 'Warning', 'Critical', 'Unknown'],
+            ['', $this->ok, $this->warning, $this->critical, $this->unknown],
+            [],
+        ];
+    }
+
+    /**
+     * Column names for CSV data table
+     * @return string[]
+     */
+    public function getLogHeads(): array
+    {
+        return ['Day', 'Time', 'Host', 'Address', 'Service', 'Status', 'Type', 'Retry', 'Output', 'Contact', 'Cmd',];
+    }
+
+    /**
+     * Generates formatted CSV  data
+     * @param \PDOStatement $logs
+     * @return \Iterator<String[]>
+     */
+    public function formatLogs(iterable $logs): iterable
+    {
+        foreach ($logs as $log) {
+            yield $this->formatLog($log);
+        }
+    }
+
+    /**
+     * Formats individual log data for CSV
+     * @param String[] $log
+     * @return String[]
+     */
+    private function formatLog(array $log): array
+    {
+        return [
+            'Day' => $this->dateFromTimestamp((int)$log['ctime']),
+            'Time' => $this->timeFromTimestamp((int)$log['ctime']),
+            'Host' => $log['host_name'],
+            'Address' => $this->formatAddress($log['host_name']),
+            'Service' => $log['service_description'],
+            'Status' => $this->formatStatus($log['status'], $log['msg_type'], $log['service_description']),
+            'Type' => $this->formatType($log['type'], $log['msg_type']),
+            'Retry' => $this->formatRetry($log['retry'], $log['msg_type']),
+            'Output' => $this->formatOutput($log['output'], $log['status']),
+            'Contact' => $log['notification_contact'],
+            'Cmd' => $log['notification_cmd'],
+        ];
+    }
+
+    /**
+     * Formats timestamp to date string
+     * @param int $timestamp
+     * @return string
+     */
+    private function dateFromTimestamp(int $timestamp): string
+    {
+        return date(self::DATE_FORMAT, $timestamp);
+    }
+
+    /**
+     * Formats timestamp to time string
+     * @param int $timestamp
+     * @return string
+     */
+    private function timeFromTimestamp(int $timestamp): string
+    {
+        return date(self::TIME_FORMAT, $timestamp);
+    }
+
+    /**
+     * Formats output value
+     *
+     * @param string $output
+     * @param string $status
+     * @return string
+     */
+    private function formatOutput(string $output, string $status): string
+    {
+        if ($output === '' && $status !== '') {
+            return self::INITIAL_STATE_VALUE;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Formats host name to IP address
+     * @param string $hostName
+     * @return string
+     */
+    private function formatAddress(string $hostName): string
+    {
+        if (array_key_exists($hostName, $this->hosts)) {
+            return (string)$this->hosts[$hostName];
+        }
+
+        return '';
+    }
+
+    /**
+     * Formats status value query parameter to CSV data
+     * @param string $status
+     * @param string $msgType
+     * @param string $serviceDescription
+     * @return string
+     */
+    private function formatStatus(string $status, string $msgType, string $serviceDescription): string
+    {
+        if ($this->msgTypeIsAcknowledged($msgType)) {
+            return self::ACKNOWLEDGMENT_MESSAGE_TYPE;
+        }
+
+        if ($serviceDescription && array_key_exists($status, $this->serviceStatuses)) {
+            return $this->serviceStatuses[$status];
+        }
+
+        if (array_key_exists($status, $this->hostStatuses)) {
+            return $this->hostStatuses[$status];
+        }
+
+        return $status;
+    }
+
+    /**
+     * Checks that message type is one from the available list
+     * @param string $msgType
+     * @return bool
+     */
+    private function msgTypeIsAcknowledged(string $msgType): bool
+    {
+        return in_array($msgType, [self::HOST_ACKNOWLEDGEMENT_MSG_TYPE, self::SERVICE_ACKNOWLEDGEMENT_MSG_TYPE]);
+    }
+
+    /**
+     * Formats type for CSV data
+     * @param string $type
+     * @param string $msgType
+     * @return string
+     */
+    private function formatType(string $type, string $msgType): string
+    {
+        // For an ACK there is no point to display TYPE column
+        if ($this->msgTypeIsAcknowledged($msgType)) {
+            return '';
+        }
+
+        if (array_key_exists($type, $this->notificationTypes)) {
+            return $this->notificationTypes[$type];
+        }
+
+        if ($this->typeIsNotification($type)) {
+            return self::NOTIFICATION_TYPE_VALUE;
+        }
+
+        return $type;
+    }
+
+    /**
+     * Checks that type is one of allowed one
+     * @param string $type
+     * @return bool
+     */
+    private function typeIsNotification(string $type): bool
+    {
+        return in_array($type, ['2', '3']);
+    }
+
+    /**
+     * Formats retry query argument
+     * @param string $retry
+     * @param string $msgType
+     * @return string
+     */
+    private function formatRetry(string $retry, string $msgType): string
+    {
+        // For an ACK there is no point to display RETRY column
+        if ($this->msgTypeIsAcknowledged($msgType)) {
+            return '';
+        }
+
+        if ((int)$msgType > 1) {
+            return '';
+        }
+
+        return $retry;
+    }
+
+    /**
+     * Converts end date to datetime format
+     * @return string
+     */
+    private function formatEnd(): string
+    {
+        return $this->formatDateTime($this->end);
+    }
+
+    /**
+     * Converts start date to datetime format
+     *
+     * @return string
+     */
+    private function formatStart(): string
+    {
+        return $this->formatDateTime($this->start);
+    }
+
+    /**
+     * Formats timestamp to datetime string
+     * @param int $date
+     * @return string
+     */
+    private function formatDateTime(int $date): string
+    {
+        if ($date <= 0) {
+            return '';
+        }
+
+        return date(self::DATE_TIME_FORMAT, $date);
+    }
+}

--- a/www/include/eventLogs/export/Presenter.php
+++ b/www/include/eventLogs/export/Presenter.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Centreon\Legacy\EventLogs\Export;
+
+class Presenter
+{
+    private const DELIMITER = ';';
+
+    /**
+     * @var String[]
+     */
+    private array $heads = [];
+
+    /**
+     * @var \Iterator<String[]>
+     */
+    private iterable $logs;
+
+    /**
+     * @var mixed[]
+     */
+    private array $metaData;
+
+    /**
+     * @param String[] $heads
+     * @return void
+     */
+    public function setHeads(array $heads): void
+    {
+        $this->heads = $heads;
+    }
+
+    /**
+     * @param mixed[] $metaData
+     * @return void
+     */
+    public function setMetaData(array $metaData): void
+    {
+        $this->metaData = $metaData;
+    }
+
+    /**
+     * @param \Iterator<String[]> $logs
+     * @return void
+     */
+    public function setLogs(iterable $logs): void
+    {
+        $this->logs = $logs;
+    }
+
+    /**
+     * Renders metadata and formatted records as CSV file
+     * @return void
+     */
+    public function render()
+    {
+        header('Content-Disposition: attachment;filename="EventLogs.csv";');
+        header('Content-Type: application/csv; charset=UTF-8');
+        header("Pragma: no-cache");
+
+        $f = fopen('php://output', 'w');
+
+        if ($f === false) {
+            throw new \RuntimeException('Unable to write content in output');
+        }
+
+        //print meta data
+        foreach ($this->metaData as $metaData) {
+            fputcsv($f, $metaData, self::DELIMITER);
+        }
+
+        //print heads
+        fputcsv($f, $this->heads, self::DELIMITER);
+
+        //print data
+        foreach ($this->logs as $log) {
+            fputcsv($f, $log, self::DELIMITER);
+        }
+
+        fclose($f);
+    }
+}

--- a/www/include/eventLogs/export/QueryGenerator.php
+++ b/www/include/eventLogs/export/QueryGenerator.php
@@ -1,0 +1,608 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Centreon\Legacy\EventLogs\Export;
+
+use CentreonACL;
+use CentreonDB;
+use PDOStatement;
+
+class QueryGenerator
+{
+    /**
+     * @var array<array<int,mixed>>
+     */
+    private array $queryValues = [];
+    private ?int $is_admin;
+    private string $openid = '';
+    private string $output = '';
+    private CentreonACL $access;
+    private int $start;
+    private int $end;
+    private string $up;
+    private string $down;
+    private string $unreachable;
+    private string $ok;
+    private string $warning;
+    private string $critical;
+    private string $unknown;
+    private string $notification;
+    private string $alert;
+    private string $error;
+    private string $oh;
+    /**
+     * @var String[]
+     */
+    private array $hostMsgStatusSet = [];
+    /**
+     * @var String[]
+     */
+    private array $svcMsgStatusSet = [];
+    /**
+     * @var String[]
+     */
+    private array $tabHostIds = [];
+    private string $searchHost = '';
+    /**
+     * @var array<mixed>
+     */
+    private array $tabSvc;
+    private string $searchService = '';
+    private string $engine;
+    private string|int $export;
+    private int $num = 0;
+    private ?int $limit;
+
+    public function __construct(private CentreonDB $pearDBO)
+    {
+    }
+
+    /**
+     * @param int|null $is_admin
+     * @return void
+     */
+    public function setIsAdmin(?int $is_admin): void
+    {
+        $this->is_admin = $is_admin;
+    }
+
+    /**
+     * @param string $openId
+     * @return void
+     */
+    public function setOpenId(string $openId): void
+    {
+        $this->openid = $openId;
+    }
+
+    /**
+     * @param string $output
+     * @return void
+     */
+    public function setOutput(string $output): void
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @param CentreonACL $access
+     * @return void
+     */
+    public function setAccess(CentreonACL $access): void
+    {
+        $this->access = $access;
+    }
+
+    /**
+     * @param int $start
+     * @return void
+     */
+    public function setStart(int $start): void
+    {
+        $this->start = $start;
+    }
+
+    /**
+     * @param int $end
+     * @return void
+     */
+    public function setEnd(int $end): void
+    {
+        $this->end = $end;
+    }
+
+    /**
+     * @param string $up
+     * @return void
+     */
+    public function setUp(string $up): void
+    {
+        $this->up = $up;
+    }
+
+    /**
+     * @param string $down
+     * @return void
+     */
+    public function setDown(string $down): void
+    {
+        $this->down = $down;
+    }
+
+    /**
+     * @param string $unreachable
+     * @return void
+     */
+    public function setUnreachable(string $unreachable): void
+    {
+        $this->unreachable = $unreachable;
+    }
+
+    /**
+     * @param string $ok
+     * @return void
+     */
+    public function setOk(string $ok): void
+    {
+        $this->ok = $ok;
+    }
+
+    /**
+     * @param string $warning
+     * @return void
+     */
+    public function setWarning(string $warning): void
+    {
+        $this->warning = $warning;
+    }
+
+    /**
+     * @param string $critical
+     * @return void
+     */
+    public function setCritical(string $critical): void
+    {
+        $this->critical = $critical;
+    }
+
+    /**
+     * @param string $unknown
+     * @return void
+     */
+    public function setUnknown(string $unknown): void
+    {
+        $this->unknown = $unknown;
+    }
+
+    /**
+     * @param string $notification
+     * @return void
+     */
+    public function setNotification(string $notification): void
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param string $alert
+     * @return void
+     */
+    public function setAlert(string $alert): void
+    {
+        $this->alert = $alert;
+    }
+
+    /**
+     * @param string $error
+     * @return void
+     */
+    public function setError(string $error): void
+    {
+        $this->error = $error;
+    }
+
+    /**
+     * @param string $oh
+     * @return void
+     */
+    public function setOh(string $oh): void
+    {
+        $this->oh = $oh;
+    }
+
+    /**
+     * @param String[] $hostMsgStatusSet
+     * @return void
+     */
+    public function setHostMsgStatusSet(array $hostMsgStatusSet): void
+    {
+        $this->hostMsgStatusSet = $hostMsgStatusSet;
+    }
+
+    /***
+     * @param String[] $svcMsgStatusSet
+     * @return void
+     */
+    public function setSvcMsgStatusSet(array $svcMsgStatusSet): void
+    {
+        $this->svcMsgStatusSet = $svcMsgStatusSet;
+    }
+
+    /**
+     * @param String[] $tabHostIds
+     * @return void
+     */
+    public function setTabHostIds(array $tabHostIds): void
+    {
+        $this->tabHostIds = $tabHostIds;
+    }
+
+    /**
+     * @param string $searchHost
+     * @return void
+     */
+    public function setSearchHost(string $searchHost): void
+    {
+        $this->searchHost = $searchHost;
+    }
+
+    /**
+     * @param String[] $tabSvc
+     * @return void
+     */
+    public function setTabSvc(array $tabSvc): void
+    {
+        $this->tabSvc = $tabSvc;
+    }
+
+    /**
+     * @param string $searchService
+     * @return void
+     */
+    public function setSearchService(string $searchService): void
+    {
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * @param string $engine
+     * @return void
+     */
+    public function setEngine(string $engine): void
+    {
+        $this->engine = $engine;
+    }
+
+    /**
+     * @param int|string $export
+     * @return void
+     */
+    public function setExport(int|string $export): void
+    {
+        $this->export = $export;
+    }
+
+    /**
+     * @param int $num
+     * @return void
+     */
+    public function setNum(int $num): void
+    {
+        $this->num = $num;
+    }
+
+    /**
+     * @param int|null $limit
+     * @return void
+     */
+    public function setLimit(?int $limit): void
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * Generates executable PROStatement for all database records
+     * @return PDOStatement
+     */
+    public function getStatement(): PDOStatement
+    {
+        $req = $this->generateQuery();
+        $stmt = $this->pearDBO->prepare($req);
+
+        foreach ($this->queryValues as $bindId => $bindData) {
+            foreach ($bindData as $bindType => $bindValue) {
+                $stmt->bindValue($bindId, $bindValue, $bindType);
+            }
+        }
+
+        return $stmt;
+    }
+
+    /**
+     * Generates SQL statement with placeholders for all database records
+     * @return string
+     */
+    private function generateQuery(): string
+    {
+        $whereOutput = $this->generateWhere();
+        $msg_req = $this->generateMsgHost();
+
+        // Build final request
+        $req = "SELECT SQL_CALC_FOUND_ROWS " . (!$this->is_admin ? "DISTINCT" : "") . "
+            logs.ctime,
+            logs.host_id,
+            logs.host_name,
+            logs.service_id,
+            logs.service_description,
+            logs.msg_type,
+            logs.notification_cmd,
+            logs.notification_contact,
+            logs.output,
+            logs.retry,
+            logs.status,
+            logs.type,
+            logs.instance_name
+            FROM logs " . $this->generateInnerJoinQuery()
+            . (
+            !$this->is_admin ?
+                " INNER JOIN centreon_acl acl ON (logs.host_id = acl.host_id AND (acl.service_id IS NULL OR "
+                . " acl.service_id = logs.service_id)) "
+                . " WHERE acl.group_id IN (" . $this->access->getAccessGroupsString() . ") AND " :
+                "WHERE "
+            )
+            . " logs.ctime > '{$this->start}' AND logs.ctime <= '{$this->end}' {$whereOutput} {$msg_req}";
+
+        /*
+         * Add Host
+         */
+        $str_unitH = "";
+        $str_unitH_append = "";
+        $host_search_sql = "";
+        if (count($this->tabHostIds) == 0 && count($this->tabSvc) == 0) {
+            if ($this->engine == "false") {
+                $req .= " AND `msg_type` NOT IN ('4','5') ";
+                $req .= " AND logs.host_name NOT LIKE '\\_Module\\_BAM%' ";
+            }
+        } else {
+            foreach ($this->tabHostIds as $host_id) {
+                if ($host_id != "") {
+                    $str_unitH .= $str_unitH_append . "'$host_id'";
+                    $str_unitH_append = ", ";
+                }
+            }
+            if ($str_unitH != "") {
+                $str_unitH = "(logs.host_id IN ($str_unitH) AND (logs.service_id IS NULL OR logs.service_id = 0))";
+                if (isset($this->searchHost) && $this->searchHost != "") {
+                    $host_search_sql =
+                        " AND logs.host_name LIKE '%" . $this->pearDBO->escape($this->searchHost) . "%' ";
+                }
+            }
+
+            /*
+             * Add services
+             */
+            $flag = 0;
+            $str_unitSVC = "";
+            $service_search_sql = "";
+            if (
+                (count($this->tabSvc) || count($this->tabHostIds)) &&
+                (
+                    $this->up == 'true' ||
+                    $this->down == 'true' ||
+                    $this->unreachable == 'true' ||
+                    $this->ok == 'true' || $this->warning == 'true' ||
+                    $this->critical == 'true' ||
+                    $this->unknown == 'true'
+                )
+            ) {
+                $req_append = "";
+                foreach ($this->tabSvc as $host_id => $services) {
+                    $str = "";
+                    $str_append = "";
+                    foreach ($services as $svc_id => $svc_name) {
+                        if ($svc_id != "") {
+                            $str .= $str_append . $svc_id;
+                            $str_append = ", ";
+                        }
+                    }
+                    if ($str != "") {
+                        if ($host_id === '_Module_Meta') {
+                            $str_unitSVC .= $req_append . " (logs.host_name = '" . $host_id . "' "
+                                . "AND logs.service_id IN (" . $str . ")) ";
+                        } else {
+                            $str_unitSVC .= $req_append .
+                                " (logs.host_id = '" . $host_id . "' AND logs.service_id IN ($str)) ";
+                        }
+                        $req_append = " OR";
+                    }
+                }
+                if (isset($this->searchService) && $this->searchService != "") {
+                    $service_search_sql =
+                        " AND logs.service_description LIKE '%" . $this->pearDBO->escape($this->searchService) . "%' ";
+                }
+                if ($str_unitH != "" && $str_unitSVC != "") {
+                    $str_unitSVC = " OR " . $str_unitSVC;
+                }
+                if ($str_unitH != "" || $str_unitSVC != "") {
+                    $req .= " AND (" . $str_unitH . $str_unitSVC . ")";
+                }
+            } else {
+                $req .= "AND 0 ";
+            }
+            $req .= " AND logs.host_name NOT LIKE '\\_Module\\_BAM%' ";
+            $req .= $host_search_sql . $service_search_sql;
+        }
+
+        $limit = ($this->export !== "1" && $this->num) ? $this->generateLimit() : '';
+
+        $req .= ' ORDER BY ctime DESC ' . $limit;
+
+        return $req;
+    }
+
+    /**
+     * Generates limit statement
+     * @return string
+     */
+    private function generateLimit(): string
+    {
+        if ($this->num < 0) {
+            $this->num = 0;
+        }
+
+        $offset = $this->num * $this->limit;
+        $this->queryValues['offset'] = [\PDO::PARAM_INT => $offset];
+        $this->queryValues['limit'] = [\PDO::PARAM_INT => $this->limit];
+
+        return " LIMIT :offset, :limit";
+    }
+
+    /**
+     * Creates join statement with instances and filters on poller IDs
+     * @return string
+     */
+    private function generateInnerJoinQuery(): string
+    {
+        $innerJoinEngineLog = '';
+        if ($this->engine == "true" && isset($this->openid) && $this->openid != "") {
+            // filtering poller ids and keeping only real ids
+            $pollerIds = explode(',', $this->openid);
+            $filteredIds = array_filter($pollerIds, function ($id) {
+                return is_numeric($id);
+            });
+
+            if (count($filteredIds) > 0) {
+                foreach ($filteredIds as $index => $filteredId) {
+                    $key = ':pollerId' . $index;
+                    $this->queryValues[$key] = [\PDO::PARAM_INT => $filteredId];
+                    $pollerIds[] = $key;
+                }
+                $innerJoinEngineLog = ' INNER JOIN instances i ON i.name = logs.instance_name'
+                    . ' AND i.instance_id IN ( ' . implode(',', array_values($pollerIds)) . ')';
+            }
+        }
+
+        return $innerJoinEngineLog;
+    }
+
+    /**
+     * Generates Where statement
+     * @return string
+     */
+    private function generateWhere(): string
+    {
+        $whereOutput = "";
+        if (isset($this->output) && $this->output != "") {
+            $this->queryValues[':output'] = [\PDO::PARAM_STR => '%' . $this->output . '%'];
+            $whereOutput = " AND logs.output like :output ";
+        }
+
+        return $whereOutput;
+    }
+
+    /**
+     * Generates sub request with filters
+     * @return string
+     */
+    private function generateMsgHost(): string
+    {
+        $msg_req = '';
+
+        $flag_begin = 0;
+
+        if ($this->notification == 'true') {
+            if (count($this->hostMsgStatusSet)) {
+                $msg_req .= "(";
+                $flag_begin = 1;
+                $msg_req .= " (`msg_type` = '3' ";
+                $msg_req .= " AND `status` IN (" . implode(',', $this->hostMsgStatusSet) . "))";
+                $msg_req .= ") ";
+            }
+            if (count($this->svcMsgStatusSet)) {
+                if ($flag_begin == 0) {
+                    $msg_req .= "(";
+                } else {
+                    $msg_req .= " OR ";
+                }
+                $msg_req .= " (`msg_type` = '2' ";
+                $msg_req .= " AND `status` IN (" . implode(',', $this->svcMsgStatusSet) . "))";
+                if ($flag_begin == 0) {
+                    $msg_req .= ") ";
+                }
+                $flag_begin = 1;
+            }
+        }
+
+        if ($this->alert == 'true') {
+            if (count($this->hostMsgStatusSet)) {
+                if ($flag_begin) {
+                    $msg_req .= " OR ";
+                }
+                if ($this->oh == true) {
+                    $msg_req .= " ( ";
+                    $flag_oh = true;
+                }
+                $flag_begin = 1;
+                $msg_req .= " ((`msg_type` IN ('1', '10', '11') ";
+                $msg_req .= " AND `status` IN (" . implode(',', $this->hostMsgStatusSet) . ")) ";
+                $msg_req .= ") ";
+            }
+            if (count($this->svcMsgStatusSet)) {
+                if ($flag_begin) {
+                    $msg_req .= " OR ";
+                }
+                if ($this->oh == true && !isset($flag_oh)) {
+                    $msg_req .= " ( ";
+                }
+                $flag_begin = 1;
+                $msg_req .= " ((`msg_type` IN ('0', '10', '11') ";
+                $msg_req .= " AND `status` IN (" . implode(',', $this->svcMsgStatusSet) . ")) ";
+                $msg_req .= ") ";
+            }
+            if ($flag_begin) {
+                $msg_req .= ")";
+            }
+            if ((count($this->hostMsgStatusSet) || count($this->svcMsgStatusSet)) && $this->oh == 'true') {
+                $msg_req .= " AND ";
+            }
+            if ($this->oh == 'true') {
+                $flag_begin = 1;
+                $msg_req .= " `type` = '1' ";
+            }
+        }
+        // Error filter is only used in the engine log page.
+        if ($this->error == 'true') {
+            if ($flag_begin == 0) {
+                $msg_req .= "AND ";
+            } else {
+                $msg_req .= " OR ";
+            }
+            $msg_req .= " `msg_type` IN ('4','5') ";
+        }
+        if ($flag_begin) {
+            $msg_req = " AND (" . $msg_req . ") ";
+        }
+
+        return $msg_req;
+    }
+}

--- a/www/include/eventLogs/export/Request.php
+++ b/www/include/eventLogs/export/Request.php
@@ -1,0 +1,684 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Centreon\Legacy\EventLogs\Export;
+
+class Request
+{
+    private const STATUS_UP = 0;
+    private const STATUS_DOWN = 1;
+    private const STATUS_UNREACHABLE = 2;
+    private const STATUS_OK = 0;
+    private const STATUS_WARNING = 1;
+    private const STATUS_CRITICAL = 2;
+    private const STATUS_UNKNOWN = 3;
+
+    private ?int $is_admin;
+    /**
+     * @var array<string,mixed>
+     */
+    private array $lca = [];
+    private ?string $lang = null;
+    private ?string $id = null;
+    private ?int $limit = null;
+    private ?string $startDate = null;
+    private ?string $startTime = null;
+    private ?string $endDate = null;
+    private ?string $endTime = null;
+    private ?int $period = null;
+    private string $engine = 'false';
+    private string $up = 'true';
+    private string $down = 'true';
+    private string $unreachable = 'true';
+    private string $ok = 'true';
+    private string $warning = 'true';
+    private string $critical = 'true';
+    private string $unknown = 'true';
+    private string $notification = 'false';
+    private string $alert = 'true';
+    private string $oh = 'false';
+    private string $error = 'false';
+    private string $output = '';
+    private string $searchH = 'VIDE';
+    private string $searchS = 'VIDE';
+    private string $searchHost = '';
+    private string $searchService = '';
+    private string $export = '0';
+    /**
+     * @var array<int, string>
+     */
+    private array $hostMsgStatusSet = [];
+    /**
+     * @var array<int, string>
+     */
+    private array $svcMsgStatusSet = [];
+    /**
+     * @var array<int, string>
+     */
+    private array $tabHostIds = [];
+    /**
+     * @var mixed[]
+     */
+    private array $tabSvc = [];
+
+    public function __construct()
+    {
+        $this->populateClassPropertiesFromRequestParameters();
+    }
+
+    /**
+     * @param int|null $is_admin
+     * @return void
+     */
+    public function setIsAdmin(?int $is_admin): void
+    {
+        $this->is_admin = $is_admin;
+    }
+
+    /**
+     * @param array<string,mixed> $lca
+     * @return void
+     */
+    public function setLca(array $lca): void
+    {
+        $this->lca = $lca;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLang(): ?string
+    {
+        return $this->lang;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOpenid(): string
+    {
+        $sanitized = filter_var($this->getId() ?? '-1', FILTER_SANITIZE_STRING);
+
+        if ($sanitized !== false) {
+            return $sanitized;
+        }
+
+        return '';
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    /**
+     * Retrieves timestamp for start date
+     * @return int
+     */
+    public function getStart(): int
+    {
+        $start = 0;
+
+        if ($this->startDate != '') {
+            $start = $this->dateStringToTimestamp((string) $this->startDate);
+        }
+
+        // setting the startDate/Time using the user's chosen period
+        // and checking if the start date/time was set by the user,
+        // to avoid to display/export the whole data since 1/1/1970
+        if ($this->getPeriod() > 0 || $start === 0) {
+            $start = time() - $this->getPeriod();
+        }
+
+        return $start;
+    }
+
+    /**
+     * * Retrieves timestamp for end date
+     * @return int
+     */
+    public function getEnd(): int
+    {
+        $end = time();
+
+        if ($this->endDate != '') {
+            $end = $this->dateStringToTimestamp((string) $this->endDate);
+        }
+
+        return $end;
+    }
+
+    /**
+     * Converts date string to timestamp
+     * Expected format of date string : 06/22/2022 00:00
+     *
+     * @param string $dateString
+     * @return int
+     */
+    private function dateStringToTimestamp(string $dateString): int
+    {
+        preg_match("/^([0-9]*)\/([0-9]*)\/([0-9]*)/", $dateString, $matchesD);
+        preg_match("/^([0-9]*):([0-9]*)/", $dateString, $matchesT);
+
+        $tmstp = mktime(
+            (int) $matchesT[1],
+            (int) $matchesT[2],
+            0,
+            (int) $matchesD[1],
+            (int) $matchesD[2],
+            (int) $matchesD[3]
+        );
+
+        if ($tmstp === false) {
+            throw new \InvalidArgumentException('Unable to convert string to timestamp');
+        }
+
+        return $tmstp;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEndDate(): ?string
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStartTime(): ?string
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPeriod(): ?int
+    {
+        return $this->period ?? 0;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEngine(): string
+    {
+        return htmlentities($this->engine);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUp(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+        return htmlentities($this->up);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDown(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->down);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUnreachable(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->unreachable);
+    }
+
+    /**
+     * @return string
+     */
+    public function getOk(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+        return htmlentities($this->ok);
+    }
+
+    /**
+     * @return string
+     */
+    public function getWarning(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->warning);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCritical(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->critical);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUnknown(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+        return htmlentities($this->unknown);
+    }
+
+    /**
+     * @return string
+     */
+    public function getNotification(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->notification);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlert(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->alert);
+    }
+
+    /**
+     * @return string
+     */
+    public function getOh(): string
+    {
+        if ($this->getEngine() === 'true') {
+            return 'false';
+        }
+
+        return htmlentities($this->oh);
+    }
+
+    /**
+     * @return string
+     */
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutput(): string
+    {
+        return urldecode($this->output);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSearchS(): ?string
+    {
+        return $this->searchS;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSearchHost(): string
+    {
+        return $this->charsToHtmlEntities($this->searchHost);
+    }
+
+    /**
+     * @return string
+     */
+    public function getSearchService(): string
+    {
+        return$this->charsToHtmlEntities($this->searchService);
+    }
+
+    /**
+     * @return string
+     */
+    public function getExport(): string
+    {
+        return $this->charsToHtmlEntities($this->export);
+    }
+
+    /**
+     * Retrieves list of host message statuses depending on request parameters
+     * @return String[]
+     */
+    public function getHostMsgStatusSet(): array
+    {
+        if ($this->getUp() === 'true') {
+            $this->hostMsgStatusSet[] = sprintf("'%s'", self::STATUS_UP);
+        }
+        if ($this->getDown() === 'true') {
+            $this->hostMsgStatusSet[] = sprintf("'%s'", self::STATUS_DOWN);
+        }
+        if ($this->getUnreachable() === 'true') {
+            $this->hostMsgStatusSet[] = sprintf("'%s'", self::STATUS_UNREACHABLE);
+        }
+
+        return $this->hostMsgStatusSet;
+    }
+
+    /**
+     * Retrieves list of service message statuses depending on request parameters
+     * @return String[]
+     */
+    public function getSvcMsgStatusSet(): array
+    {
+        if ($this->getOk() === 'true') {
+            $this->svcMsgStatusSet[] = sprintf("'%s'", self::STATUS_OK);
+        }
+        if ($this->getWarning() === 'true') {
+            $this->svcMsgStatusSet[] = sprintf("'%s'", self::STATUS_WARNING);
+        }
+        if ($this->getCritical() === 'true') {
+            $this->svcMsgStatusSet[] = sprintf("'%s'", self::STATUS_CRITICAL);
+        }
+        if ($this->getUnknown() === 'true') {
+            $this->svcMsgStatusSet[] = sprintf("'%s'", self::STATUS_UNKNOWN);
+        }
+
+        return $this->svcMsgStatusSet;
+    }
+
+    /**
+     * Retrieves host ids depending on open id parameter
+     * @return mixed[]
+     */
+    public function getTabHostIds(): array
+    {
+        $tab_id = preg_split("/\,/", $this->getOpenid());
+        if ($tab_id === false) {
+            throw new \InvalidArgumentException('Unable to parse open ID');
+        }
+
+        foreach ($tab_id as $openid) {
+            $openIdChunks = $this->splitOpenId($openid);
+            $id = $openIdChunks['id'];
+            $type = $openIdChunks['type'];
+
+            if ($id === '') {
+                continue;
+            }
+
+            if ($type == 'HG' && (isset($this->lca["LcaHostGroup"][$id]) || $this->is_admin)) {
+                // Get hosts from hostgroups @phpstan-ignore-next-line
+                $hosts = getMyHostGroupHosts($id);
+                if (count($hosts) == 0) {
+                    $this->tabHostIds[] = "-1";
+                } else {
+                    foreach ($hosts as $h_id) {
+                        if (isset($this->lca["LcaHost"][$h_id])) {
+                            $this->tabHostIds[] = $h_id;
+                        }
+                    }
+                }
+            } elseif ($type == "HH" && isset($this->lca["LcaHost"][$id])) {
+                $this->tabHostIds[] = $id;
+            }
+        }
+
+        return $this->tabHostIds;
+    }
+
+    /**
+     * Splits open id string into associative array of id, hostId and type
+     *
+     * @param string $openid
+     * @return array<string, string>
+     */
+    private function splitOpenId(string $openid): array
+    {
+        $chunks = preg_split("/\_/", $openid);
+        if (!is_array($chunks)) {
+            return ['id' => '', 'hostId' => '', 'type' => ''];
+        }
+
+        $id = '';
+        $hostId = '';
+
+        if (isset($chunks[2])) {
+            $hostId = $chunks[1];
+            $id = $chunks[2];
+        } elseif (isset($chunks[1])) {
+            $id = $chunks[1];
+        }
+
+        return ['id' => $id, 'hostId' => $hostId, 'type' => $chunks[0]];
+    }
+
+    /**
+     * Retrieves service ids depending on open id parameter
+     * @return array<mixed>
+     */
+    public function getTabSvc(): array
+    {
+        $tab_id = preg_split("/\,/", $this->getOpenid());
+        /** @phpstan-ignore-next-line */
+        foreach ($tab_id as $openid) {
+            $openIdChunks = $this->splitOpenId($openid);
+            $id = $openIdChunks['id'];
+            $type = $openIdChunks['type'];
+            $hostId = $openIdChunks['hostId'];
+
+            if ($id === '') {
+                continue;
+            }
+
+            if ($type == "HG" && (isset($this->lca["LcaHostGroup"][$id]) || $this->is_admin)) {
+                // Get hosts from hostgroups @phpstan-ignore-next-line
+                $hosts = getMyHostGroupHosts($id);
+                if (count($hosts) !== 0) {
+                    foreach ($hosts as $h_id) {
+                        if (isset($this->lca["LcaHost"][$h_id])) {
+                            $this->tabSvc[$h_id] = $this->lca["LcaHost"][$h_id];
+                        }
+                    }
+                }
+            } elseif ($type == 'SG' && (isset($this->lca["LcaSG"][$id]) || $this->is_admin)) {
+                /** @phpstan-ignore-next-line */
+                $services = getMyServiceGroupServices($id);
+                if (count($services) == 0) {
+                    $this->tabSvc[] = "-1";
+                } else {
+                    foreach ($services as $svc_id => $svc_name) {
+                        $tab_tmp = preg_split("/\_/", $svc_id);/** @phpstan-ignore-line @phpstan-ignore-next-line */
+                        $tmp_host_id = $tab_tmp[0];
+                        $tmp_service_id = $tab_tmp[1]; //@phpstan-ignore-line
+                        if (isset($this->lca["LcaHost"][$tmp_host_id][$tmp_service_id])) {
+                            $this->tabSvc[$tmp_host_id][$tmp_service_id] =
+                                $this->lca["LcaHost"][$tmp_host_id][$tmp_service_id];
+                        }
+                    }
+                }
+            } elseif ($type == "HH" && isset($this->lca["LcaHost"][$id])) {
+                $this->tabSvc[$id] = $this->lca["LcaHost"][$id];
+            } elseif ($type == "HS" && isset($this->lca["LcaHost"][$hostId][$id])) {
+                $this->tabSvc[$hostId][$id] = $this->lca["LcaHost"][$hostId][$id];
+            } elseif ($type == "MS") {
+                $this->tabSvc["_Module_Meta"][$id] = "meta_" . $id;
+            }
+        }
+
+        return $this->tabSvc;
+    }
+
+    /**
+     * Populates class properties from request.
+     * Request arguments are matched against property name. Request values are used as property values.
+     * @return void
+     */
+    private function populateClassPropertiesFromRequestParameters(): void
+    {
+        $inputArguments = $this->getInputFilters();
+
+        $inputGet = filter_input_array(INPUT_GET, $inputArguments);
+        $inputPost = filter_input_array(INPUT_POST, $inputArguments);
+
+        foreach (array_keys($inputArguments) as $argumentName) {
+            if (
+                is_array($inputGet) &&
+                array_key_exists($argumentName, $inputGet) &&
+                !empty($inputGet[$argumentName])
+            ) {
+                $this->populateClassPropertyWithRequestArgument($argumentName, $inputGet[$argumentName]);
+            } elseif (
+                is_array($inputPost) &&
+                array_key_exists($argumentName, $inputPost) &&
+                !empty($inputPost[$argumentName])
+            ) {
+                $this->populateClassPropertyWithRequestArgument($argumentName, $inputPost[$argumentName]);
+            }
+        }
+    }
+
+    /**
+     * Populates class properties from request.
+     * Arguments are matched against property name. Values as property values.
+     * @param mixed $argumentName
+     * @param mixed $propertyValue
+     * @return void
+     */
+    private function populateClassPropertyWithRequestArgument(mixed $argumentName, mixed $propertyValue): void
+    {
+        $propertyName = $this->stringToCamelCase($argumentName);
+        if (property_exists($this, $propertyName)) {
+            $this->$propertyName = $propertyValue;
+        }
+    }
+
+    /**
+     * Converts string to camelCase literal
+     * @param string $string
+     * @return string
+     */
+    private function stringToCamelCase(string $string): string
+    {
+        $str = str_replace('_', '', ucwords($string, '_'));
+
+        return lcfirst($str);
+    }
+
+    /**
+     * Array of available request argument.
+     * Array keys are available request arguments. Values sanitizing rules
+     * @param int $defaultLimit
+     * @return array<string, mixed>
+     */
+    private function getInputFilters(int $defaultLimit = 30): array
+    {
+        return [
+            'lang' => FILTER_SANITIZE_STRING,
+            'id' => FILTER_SANITIZE_STRING,
+            'num' => [
+                'filter' => FILTER_VALIDATE_INT,
+                'options' => [
+                    'default' => 0
+                ]
+            ],
+            'limit' => [
+                'filter' => FILTER_VALIDATE_INT,
+                'options' => [
+                    'default' => $defaultLimit
+                ]
+            ],
+            'StartDate' => FILTER_SANITIZE_STRING,
+            'EndDate' => FILTER_SANITIZE_STRING,
+            'StartTime' => FILTER_SANITIZE_STRING,
+            'EndTime' => FILTER_SANITIZE_STRING,
+            'period' => FILTER_VALIDATE_INT,
+            'engine' => FILTER_SANITIZE_STRING,
+            'up' => FILTER_SANITIZE_STRING,
+            'down' => FILTER_SANITIZE_STRING,
+            'unreachable' => FILTER_SANITIZE_STRING,
+            'ok' => FILTER_SANITIZE_STRING,
+            'warning' => FILTER_SANITIZE_STRING,
+            'critical' => FILTER_SANITIZE_STRING,
+            'unknown' => FILTER_SANITIZE_STRING,
+            'notification' => FILTER_SANITIZE_STRING,
+            'alert' => FILTER_SANITIZE_STRING,
+            'oh' => FILTER_SANITIZE_STRING,
+            'error' => FILTER_SANITIZE_STRING,
+            'output' => FILTER_SANITIZE_STRING,
+            'search_H' => FILTER_SANITIZE_STRING,
+            'search_S' => FILTER_SANITIZE_STRING,
+            'search_host' => FILTER_SANITIZE_STRING,
+            'search_service' => FILTER_SANITIZE_STRING,
+            'export' => FILTER_SANITIZE_STRING,
+        ];
+    }
+
+    /**
+     * Convert string to HTML entities in order to secure against XSS vulnerabilities
+     * @param string $string
+     * @return string
+     */
+    private function charsToHtmlEntities(string $string): string
+    {
+        return htmlentities($string, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -712,7 +712,6 @@ CREATE TABLE `contact` (
   `contact_register` tinyint(6) NOT NULL DEFAULT '1',
   `contact_ldap_last_sync` int(11) NOT NULL DEFAULT 0,
   `contact_ldap_required_sync` enum('0','1') NOT NULL DEFAULT '0',
-  `enable_one_click_export` enum('0','1') DEFAULT '0',
   `login_attempts` INT(11) UNSIGNED DEFAULT NULL,
   `blocking_time` BIGINT(20) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`contact_id`),

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -1425,7 +1425,7 @@ VALUES (
 (
   'openid',
   'openid',
-  '{"trusted_client_addresses":[],"blacklist_client_addresses":[],"base_url":null,"authorization_endpoint":null,"token_endpoint":null,"introspection_token_endpoint":null,"userinfo_endpoint":null,"endsession_endpoint":null,"connection_scopes":[],"login_claim":null,"client_id":null,"client_secret":null,"authentication_type":"client_secret_post","verify_peer":true, "auto_import": false, "contact_template_id": null, "email_bind_attribute": null, "alias_bind_attribute": null, "fullname_bind_attribute": null, "claim_name": "groups", "contact_group_id": null}',
+  '{"trusted_client_addresses":[],"blacklist_client_addresses":[],"base_url":null,"authorization_endpoint":null,"token_endpoint":null,"introspection_token_endpoint":null,"userinfo_endpoint":null,"endsession_endpoint":null,"connection_scopes":[],"login_claim":null,"client_id":null,"client_secret":null,"authentication_type":"client_secret_post","verify_peer":true, "auto_import": false, "contact_template_id": null, "email_bind_attribute": null, "fullname_bind_attribute": null, "claim_name": "groups", "contact_group_id": null}',
   false,
   false
 ),

--- a/www/install/php/Update-22.04.1.php
+++ b/www/install/php/Update-22.04.1.php
@@ -82,7 +82,6 @@ function updateOpenIdConfiguration(CentreonDB $pearDB): void
         $openIdCustomConfiguration["auto_import"] = false;
         $openIdCustomConfiguration["contact_template_id"] = null;
         $openIdCustomConfiguration["email_bind_attribute"] = null;
-        $openIdCustomConfiguration["alias_bind_attribute"] = null;
         $openIdCustomConfiguration["fullname_bind_attribute"] = null;
         $openIdCustomConfiguration["contact_group_id"] = $defaultContactGroupId;
         $openIdCustomConfiguration["claim_name"] = Configuration::DEFAULT_CLAIM_NAME;

--- a/www/install/sql/centreon/Update-DB-22.10.0.sql
+++ b/www/install/sql/centreon/Update-DB-22.10.0.sql
@@ -120,3 +120,6 @@ ALTER TABLE cfg_nagios MODIFY `log_passive_checks` enum('0','1');
 ALTER TABLE cfg_nagios MODIFY `enable_predictive_host_dependency_checks` enum('0','1');
 ALTER TABLE cfg_nagios MODIFY `enable_predictive_service_dependency_checks` enum('0','1');
 ALTER TABLE cfg_nagios MODIFY `debug_verbosity` enum('0','1');
+
+
+ALTER TABLE contact DROP COLUMN IF EXISTS `enable_one_click_export`;


### PR DESCRIPTION
## Description

Add frontend button to export data to csv format in Timeline

- In the "Resource status" view, in the right panel displayed after clicking on a resource, in the "Timeline" tab, under the filter input.

- When the CSV export button is clicked, the "CSV Exporter" API specified in [this ticket](https://centreon.atlassian.net/browse/MON-6585) is called to generate and download the CSV file.

- When the user click on th export button, open a new tab in the browser.

- When opening this new tab,

Start downloading the file.

Inside the new tab, display an information message to the user to tell him that the download of the file he requested has started “Your file is being uploaded“.

- The CSV export format should be as follows :

['type', 'date', 'content', 'contact', 'status', 'tries',];

- In filters, only “Event” type is supported.

- If a filter was applied on the time period, generate the CSV file using the filtered data.

- CSV export from the timeline should only be applicable for ressource of type host and services. and meta-service.

 

**Fixes** # (issue)

## Type of change

- [x] New functionality (non-breaking change)

## Target serie

- [x] 22.10.x (master)
