### PR TITLE
enh(UI): Remove alias bind attribute and improve labels

### DIFF
--- a/doc/API/centreon-api-v22.04.yaml
+++ b/doc/API/centreon-api-v22.04.yaml
@@ -4440,7 +4440,6 @@ components:
         - auto_import
         - contact_template
         - email_bind_attribute
-        - alias_bind_attribute
         - fullname_bind_attribute
         - contact_group
         - authorization_claim
@@ -4552,11 +4551,6 @@ components:
           type: string
           description: "Email bind attribute"
           example: "email"
-          nullable: true
-        alias_bind_attribute:
-          type: string
-          description: "Alias bind attribute"
-          example: "preferred_username"
           nullable: true
         fullname_bind_attribute:
           type: string

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15023,7 +15023,7 @@ msgstr ""
 # msgid "Email attribute"
 # msgstr ""
 
-# msgid "Fullname attribute"
+# msgid "Full name attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15020,16 +15020,10 @@ msgstr ""
 # msgid "Enable auto import"
 # msgstr ""
 
-# msgid "Email attribute to bind"
+# msgid "Email attribute"
 # msgstr ""
 
-# msgid "Alias attribute to bind"
-# msgstr ""
-
-# msgid "Fullname attribute to bind"
-# msgstr ""
-
-# msgid "Auto import"
+# msgid "Fullname attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16722,17 +16722,11 @@ msgstr "Impossible d'obtenir les modèles de contact depuis le stockage de donn�
 msgid "Enable auto import"
 msgstr "Activer l'importation automatique"
 
-msgid "Email attribute to bind"
-msgstr "Attribut de mail à lier"
+msgid "Email attribute"
+msgstr "Attribut de mail"
 
-msgid "Alias attribute to bind"
-msgstr "Attribut d'alias à lier"
-
-msgid "Fullname attribute to bind"
-msgstr "Attribut de nom complet à lier"
-
-msgid "Auto import"
-msgstr "Importation automatique"
+msgid "Fullname attribute"
+msgstr "Attribut de nom complet"
 
 # msgid "You are not authorized to access the configuration"
 # msgstr "Vous n’êtes pas autorisé à accéder à la configuration"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16723,7 +16723,7 @@ msgid "Enable auto import"
 msgstr "Activer l'importation automatique"
 
 msgid "Email attribute"
-msgstr "Attribut de mail"
+msgstr "Attribut de l'email"
 
 msgid "Fullname attribute"
 msgstr "Attribut de nom complet"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16726,7 +16726,7 @@ msgid "Email attribute"
 msgstr "Attribut de l'email"
 
 msgid "Fullname attribute"
-msgstr "Attribut de nom complet"
+msgstr "Attribut du nom complet"
 
 # msgid "You are not authorized to access the configuration"
 # msgstr "Vous n’êtes pas autorisé à accéder à la configuration"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16725,7 +16725,7 @@ msgstr "Activer l'importation automatique"
 msgid "Email attribute"
 msgstr "Attribut de l'email"
 
-msgid "Fullname attribute"
+msgid "Full name attribute"
 msgstr "Attribut du nom complet"
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15471,16 +15471,10 @@ msgstr ""
 # msgid "Enable auto import"
 # msgstr ""
 
-# msgid "Email attribute to bind"
+# msgid "Email attribute"
 # msgstr ""
 
-# msgid "Alias attribute to bind"
-# msgstr ""
-
-# msgid "Fullname attribute to bind"
-# msgstr ""
-
-# msgid "Auto import"
+# msgid "Fullname attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15474,7 +15474,7 @@ msgstr ""
 # msgid "Email attribute"
 # msgstr ""
 
-# msgid "Fullname attribute"
+# msgid "Full name attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15459,16 +15459,10 @@ msgstr ""
 # msgid "Enable auto import"
 # msgstr ""
 
-# msgid "Email attribute to bind"
+# msgid "Email attribute"
 # msgstr ""
 
-# msgid "Alias attribute to bind"
-# msgstr ""
-
-# msgid "Fullname attribute to bind"
-# msgstr ""
-
-# msgid "Auto import"
+# msgid "Fullname attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15462,7 +15462,7 @@ msgstr ""
 # msgid "Email attribute"
 # msgstr ""
 
-# msgid "Fullname attribute"
+# msgid "Full name attribute"
 # msgstr ""
 
 # msgid "You are not authorized to access the configuration"

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilder.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilder.php
@@ -68,7 +68,6 @@ class ConfigurationBuilder
                 self::validateParametersForAutoImport(
                     $contactTemplate,
                     $request->emailBindAttribute,
-                    $request->userAliasBindAttribute,
                     $request->userNameBindAttribute
                 );
             }
@@ -95,7 +94,6 @@ class ConfigurationBuilder
             ->setUserInformationEndpoint($request->userInformationEndpoint)
             ->setContactTemplate($contactTemplate)
             ->setEmailBindAttribute($request->emailBindAttribute)
-            ->setUserAliasBindAttribute($request->userAliasBindAttribute)
             ->setUserNameBindAttribute($request->userNameBindAttribute)
             ->setContactGroup($contactGroup)
             ->setClaimName($request->claimName);
@@ -106,14 +104,12 @@ class ConfigurationBuilder
      *
      * @param ContactTemplate|null $contactTemplate
      * @param string|null $emailBindAttribute
-     * @param string|null $userAliasBindAttribute
      * @param string|null $userNameBindAttribute
      * @throws OpenIdConfigurationException
      */
     private static function validateParametersForAutoImport(
         ?ContactTemplate $contactTemplate,
         ?string $emailBindAttribute,
-        ?string $userAliasBindAttribute,
         ?string $userNameBindAttribute
     ): void {
         $missingMandatoryParameters = [];
@@ -122,9 +118,6 @@ class ConfigurationBuilder
         }
         if (empty($emailBindAttribute)) {
             $missingMandatoryParameters[] = 'email_bind_attribute';
-        }
-        if (empty($userAliasBindAttribute)) {
-            $missingMandatoryParameters[] = 'alias_bind_attribute';
         }
         if (empty($userNameBindAttribute)) {
             $missingMandatoryParameters[] = 'fullname_bind_attribute';

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfiguration.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfiguration.php
@@ -85,7 +85,6 @@ class FindOpenIdConfiguration
             ? null
             : $findOpenIdConfigurationResponse::contactTemplateToArray($configuration->getContactTemplate());
         $findOpenIdConfigurationResponse->emailBindAttribute = $configuration->getEmailBindAttribute();
-        $findOpenIdConfigurationResponse->userAliasBindAttribute = $configuration->getUserAliasBindAttribute();
         $findOpenIdConfigurationResponse->userNameBindAttribute = $configuration->getUserNameBindAttribute();
         $findOpenIdConfigurationResponse->claimName = $configuration->getClaimName();
         $findOpenIdConfigurationResponse->contactGroup = $configuration->getContactGroup() === null

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
@@ -127,11 +127,6 @@ class FindOpenIdConfigurationResponse
     /**
      * @var string|null
      */
-    public ?string $userAliasBindAttribute = null;
-
-    /**
-     * @var string|null
-     */
     public ?string $userNameBindAttribute = null;
 
     /**

--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationRequest.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationRequest.php
@@ -128,11 +128,6 @@ class UpdateOpenIdConfigurationRequest
     /**
      * @var string|null
      */
-    public ?string $userAliasBindAttribute = null;
-
-    /**
-     * @var string|null
-     */
     public ?string $userNameBindAttribute = null;
 
     /**

--- a/src/Core/Security/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Domain/Provider/OpenIdProvider.php
@@ -606,9 +606,6 @@ class OpenIdProvider implements OpenIdProviderInterface
         if (! array_key_exists($this->configuration->getEmailBindAttribute(), $this->userInformations)) {
             $missingAttributes[] = $this->configuration->getEmailBindAttribute();
         }
-        if (! array_key_exists($this->configuration->getUserAliasBindAttribute(), $this->userInformations)) {
-            $missingAttributes[] = $this->configuration->getUserAliasBindAttribute();
-        }
         if (! array_key_exists($this->configuration->getUserNameBindAttribute(), $this->userInformations)) {
             $missingAttributes[] = $this->configuration->getUserNameBindAttribute();
         }

--- a/src/Core/Security/Domain/ProviderConfiguration/OpenId/Model/Configuration.php
+++ b/src/Core/Security/Domain/ProviderConfiguration/OpenId/Model/Configuration.php
@@ -147,11 +147,6 @@ class Configuration implements ProviderConfigurationInterface
     /**
      * @var string|null
      */
-    private ?string $userAliasBindAttribute = null;
-
-    /**
-     * @var string|null
-     */
     private ?string $userNameBindAttribute = null;
 
     /**
@@ -325,14 +320,6 @@ class Configuration implements ProviderConfigurationInterface
     public function getEmailBindAttribute(): ?string
     {
         return $this->emailBindAttribute;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getUserAliasBindAttribute(): ?string
-    {
-        return $this->userAliasBindAttribute;
     }
 
     /**
@@ -622,17 +609,6 @@ class Configuration implements ProviderConfigurationInterface
     public function setEmailBindAttribute(?string $emailBindAttribute): self
     {
         $this->emailBindAttribute = $emailBindAttribute;
-
-        return $this;
-    }
-
-    /**
-     * @param string|null $userAliasBindAttribute
-     * @return self
-     */
-    public function setUserAliasBindAttribute(?string $userAliasBindAttribute): self
-    {
-        $this->userAliasBindAttribute = $userAliasBindAttribute;
 
         return $this;
     }

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationPresenter.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationPresenter.php
@@ -57,7 +57,6 @@ class FindOpenIdConfigurationPresenter extends AbstractPresenter implements Find
             'auto_import' => $response->isAutoImportEnabled,
             'contact_template' => $response->contactTemplate,
             'email_bind_attribute' => $response->emailBindAttribute,
-            'alias_bind_attribute' => $response->userAliasBindAttribute,
             'fullname_bind_attribute' => $response->userNameBindAttribute,
             'contact_group' => $response->contactGroup,
             'claim_name' => $response->claimName,

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationController.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationController.php
@@ -79,7 +79,6 @@ class UpdateOpenIdConfigurationController extends AbstractController
         $updateOpenIdConfigurationRequest->isAutoImportEnabled = $requestData['auto_import'];
         $updateOpenIdConfigurationRequest->contactTemplate = $requestData['contact_template'];
         $updateOpenIdConfigurationRequest->emailBindAttribute = $requestData['email_bind_attribute'];
-        $updateOpenIdConfigurationRequest->userAliasBindAttribute = $requestData['alias_bind_attribute'];
         $updateOpenIdConfigurationRequest->userNameBindAttribute = $requestData['fullname_bind_attribute'];
         $updateOpenIdConfigurationRequest->claimName = $requestData['claim_name'];
         $updateOpenIdConfigurationRequest->authorizationRules = $requestData['authorization_rules'];

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationSchema.json
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationSchema.json
@@ -23,7 +23,6 @@
         "auto_import",
         "contact_template",
         "email_bind_attribute",
-        "alias_bind_attribute",
         "fullname_bind_attribute",
         "contact_group_id",
         "claim_name",
@@ -102,9 +101,6 @@
         }
       },
       "email_bind_attribute": {
-        "type": ["string", "null"]
-      },
-      "alias_bind_attribute": {
         "type": ["string", "null"]
       },
       "fullname_bind_attribute": {

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilder.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilder.php
@@ -62,7 +62,6 @@ class DbConfigurationBuilder
                 self::validateParametersForAutoImport(
                     $customConfiguration['contact_template'],
                     $customConfiguration['email_bind_attribute'],
-                    $customConfiguration['alias_bind_attribute'],
                     $customConfiguration['fullname_bind_attribute']
                 );
             }
@@ -82,7 +81,6 @@ class DbConfigurationBuilder
             ->setUserInformationEndpoint($customConfiguration['userinfo_endpoint'])
             ->setContactTemplate($customConfiguration['contact_template'])
             ->setEmailBindAttribute($customConfiguration['email_bind_attribute'])
-            ->setUserAliasBindAttribute($customConfiguration['alias_bind_attribute'])
             ->setUserNameBindAttribute($customConfiguration['fullname_bind_attribute'])
             ->setTrustedClientAddresses($customConfiguration['trusted_client_addresses'])
             ->setBlacklistClientAddresses($customConfiguration['blacklist_client_addresses'])
@@ -101,14 +99,12 @@ class DbConfigurationBuilder
      *
      * @param ContactTemplate|null $contactTemplate
      * @param string|null $emailBindAttribute
-     * @param string|null $userAliasBindAttribute
      * @param string|null $userNameBindAttribute
      * @throws OpenIdConfigurationException
      */
     private static function validateParametersForAutoImport(
         ?ContactTemplate $contactTemplate,
         ?string $emailBindAttribute,
-        ?string $userAliasBindAttribute,
         ?string $userNameBindAttribute
     ): void {
         $missingMandatoryParameters = [];
@@ -117,9 +113,6 @@ class DbConfigurationBuilder
         }
         if (empty($emailBindAttribute)) {
             $missingMandatoryParameters[] = 'email_bind_attribute';
-        }
-        if (empty($userAliasBindAttribute)) {
-            $missingMandatoryParameters[] = 'alias_bind_attribute';
         }
         if (empty($userNameBindAttribute)) {
             $missingMandatoryParameters[] = 'fullname_bind_attribute';

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/CustomConfigurationSchema.json
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/CustomConfigurationSchema.json
@@ -21,7 +21,6 @@
         "auto_import",
         "contact_template_id",
         "email_bind_attribute",
-        "alias_bind_attribute",
         "fullname_bind_attribute"
     ],
     "properties": {
@@ -89,9 +88,6 @@
         "type": ["number", "null"]
       },
       "email_bind_attribute": {
-        "type": ["string", "null"]
-      },
-      "alias_bind_attribute": {
         "type": ["string", "null"]
       },
       "fullname_bind_attribute": {

--- a/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/DbWriteOpenIdConfigurationRepository.php
+++ b/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Repository/DbWriteOpenIdConfigurationRepository.php
@@ -91,7 +91,6 @@ class DbWriteOpenIdConfigurationRepository extends AbstractRepositoryDRB impleme
             'auto_import' => $configuration->isAutoImportEnabled(),
             'contact_template_id' => $configuration->getContactTemplate()?->getId(),
             'email_bind_attribute' => $configuration->getEmailBindAttribute(),
-            'alias_bind_attribute' => $configuration->getUserAliasBindAttribute(),
             'fullname_bind_attribute' => $configuration->getUserNameBindAttribute(),
             'claim_name' => $configuration->getClaimName(),
             'contact_group_id' => $configuration->getContactGroup()?->getId()

--- a/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilderTest.php
+++ b/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilderTest.php
@@ -87,7 +87,7 @@ it(
 )->throws(
     OpenIdConfigurationException::class,
     OpenIdConfigurationException::missingAutoImportMandatoryParameters(
-        ['contact_template', 'email_bind_attribute', 'alias_bind_attribute', 'fullname_bind_attribute']
+        ['contact_template', 'email_bind_attribute', 'fullname_bind_attribute']
     )->getMessage()
 );
 
@@ -101,7 +101,6 @@ it('should return a Configuration when all mandatory parameters are present', fu
     $request->isActive = true;
     $request->introspectionTokenEndpoint = '/introspect';
     $request->isAutoImportEnabled = true;
-    $request->userAliasBindAttribute = 'alias';
     $request->userNameBindAttribute = 'name';
     $request->emailBindAttribute = 'email';
     $contactTemplate = new ContactTemplate(1, 'contact_template');

--- a/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
+++ b/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
@@ -95,7 +95,6 @@ it('should present a provider configuration', function () {
         expect($presenter->response->contactTemplate)->toBe(['id' => 1, 'name' => 'contact_template']);
         expect($presenter->response->isAutoImportEnabled)->toBeFalse();
         expect($presenter->response->emailBindAttribute)->toBeNull();
-        expect($presenter->response->userAliasBindAttribute)->toBeNull();
         expect($presenter->response->userNameBindAttribute)->toBeNull();
         expect($presenter->response->contactGroup)->toBe(['id' => 1, 'name' => 'contact_group']);
 });

--- a/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -175,7 +175,6 @@ it('should present an Error Response when auto import is enable and mandatory pa
     $missingParameters = [
         'contact_template',
         'email_bind_attribute',
-        'alias_bind_attribute',
         'fullname_bind_attribute',
     ];
 
@@ -226,7 +225,6 @@ it('should present an Error Response when auto import is enable and the contact 
     $request->isAutoImportEnabled = true;
     $request->contactTemplate = ['id' => 1, "name" => 'contact_template'];
     $request->emailBindAttribute = 'email';
-    $request->userAliasBindAttribute = 'alias';
     $request->userNameBindAttribute = 'name';
     $request->contactGroupId = 1;
     $request->claimName = 'groups';

--- a/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+++ b/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
@@ -121,7 +121,6 @@ it('should execute the usecase properly', function () {
             'auto_import' => false,
             'contact_template' => null,
             'email_bind_attribute' => null,
-            'alias_bind_attribute' => null,
             'fullname_bind_attribute' => null,
             'contact_group_id' => 1,
             'claim_name' => "groups",

--- a/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilderTest.php
+++ b/tests/php/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Builder/DbConfigurationBuilderTest.php
@@ -42,7 +42,6 @@ beforeEach(function () {
         'userinfo_endpoint' => '/userinfo',
         'contact_template' => new ContactTemplate(1, 'contact_template'),
         'email_bind_attribute' => 'email',
-        'alias_bind_attribute' => 'alias',
         'fullname_bind_attribute' => 'name',
         'trusted_client_addresses' => [],
         'blacklist_client_addresses' => [],
@@ -83,7 +82,6 @@ it(
     function () {
         $this->customConfiguration['contact_template'] = null;
         $this->customConfiguration['email_bind_attribute'] =  null;
-        $this->customConfiguration['alias_bind_attribute'] =  null;
         $this->customConfiguration['fullname_bind_attribute'] = null;
         DbConfigurationBuilder::create(
             ['id' => 2, 'is_active' => true, 'is_forced' => true],
@@ -93,7 +91,7 @@ it(
 )->throws(
     OpenIdConfigurationException::class,
     OpenIdConfigurationException::missingAutoImportMandatoryParameters(
-        ['contact_template', 'email_bind_attribute', 'alias_bind_attribute', 'fullname_bind_attribute']
+        ['contact_template', 'email_bind_attribute', 'fullname_bind_attribute']
     )->getMessage()
 );
 

--- a/www/front_src/src/Authentication/Openid/Form/inputs.ts
+++ b/www/front_src/src/Authentication/Openid/Form/inputs.ts
@@ -3,7 +3,6 @@ import { FormikValues } from 'formik';
 
 import {
   labelAccessGroup,
-  labelAliasAttributeToBind,
   labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled,
   labelAuthenticationMode,
   labelAuthorizationEndpoint,
@@ -14,11 +13,11 @@ import {
   labelContactGroup,
   labelContactTemplate,
   labelDisableVerifyPeer,
-  labelEmailAttributeToBind,
+  labelEmailAttribute,
   labelEnableAutoImport,
   labelEnableOpenIDConnectAuthentication,
   labelEndSessionEndpoint,
-  labelFullnameAttributeToBind,
+  labelFullnameAttribute,
   labelIntrospectionTokenEndpoint,
   labelLoginClaimValue,
   labelMixed,
@@ -38,7 +37,7 @@ import { InputProps, InputType } from '../../FormInputs/models';
 import {
   labelActivation,
   labelAuthorizations,
-  labelAutoImport,
+  labelAutoImportUsers,
   labelClientAddresses,
   labelIdentityProvider,
 } from '../../translatedLabels';
@@ -183,13 +182,13 @@ export const inputs: Array<InputProps> = [
     type: InputType.Switch,
   },
   {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     fieldName: 'autoImport',
     label: labelEnableAutoImport,
     type: InputType.Switch,
   },
   {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     endpoint: contactTemplatesEndpoint,
     fieldName: 'contactTemplate',
     getDisabled: isAutoImportDisabled,
@@ -198,27 +197,19 @@ export const inputs: Array<InputProps> = [
     type: InputType.ConnectedAutocomplete,
   },
   {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     fieldName: 'emailBindAttribute',
     getDisabled: isAutoImportDisabled,
     getRequired: isAutoImportEnabled,
-    label: labelEmailAttributeToBind,
+    label: labelEmailAttribute,
     type: InputType.Text,
   },
   {
-    category: labelAutoImport,
-    fieldName: 'aliasBindAttribute',
-    getDisabled: isAutoImportDisabled,
-    getRequired: isAutoImportEnabled,
-    label: labelAliasAttributeToBind,
-    type: InputType.Text,
-  },
-  {
-    category: labelAutoImport,
+    category: labelAutoImportUsers,
     fieldName: 'fullnameBindAttribute',
     getDisabled: isAutoImportDisabled,
     getRequired: isAutoImportEnabled,
-    label: labelFullnameAttributeToBind,
+    label: labelFullnameAttribute,
     type: InputType.Text,
   },
   {

--- a/www/front_src/src/Authentication/Openid/index.test.tsx
+++ b/www/front_src/src/Authentication/Openid/index.test.tsx
@@ -21,7 +21,6 @@ import { labelActivation } from '../translatedLabels';
 
 import {
   labelAccessGroup,
-  labelAliasAttributeToBind,
   labelAuthorizationEndpoint,
   labelAuthorizationKey,
   labelAuthorizationValue,
@@ -33,11 +32,11 @@ import {
   labelContactTemplate,
   labelDefineOpenIDConnectConfiguration,
   labelDisableVerifyPeer,
-  labelEmailAttributeToBind,
+  labelEmailAttribute,
   labelEnableAutoImport,
   labelEnableOpenIDConnectAuthentication,
   labelEndSessionEndpoint,
-  labelFullnameAttributeToBind,
+  labelFullnameAttribute,
   labelIntrospectionTokenEndpoint,
   labelInvalidIPAddress,
   labelInvalidURL,
@@ -70,7 +69,6 @@ const renderOpenidConfigurationForm = (): RenderResult =>
   render(<OpenidConfigurationForm />);
 
 const retrievedOpenidConfiguration = {
-  alias_bind_attribute: 'firstname',
   authentication_type: 'client_secret_post',
   authorization_endpoint: '/authorize',
   authorization_rules: [
@@ -111,7 +109,6 @@ const retrievedOpenidConfiguration = {
 };
 
 const retrievedOpenidConfigurationWithEmptyAuthorization = {
-  alias_bind_attribute: 'firstname',
   authentication_type: 'client_secret_post',
   authorization_endpoint: '/authorize',
   authorization_rules: [],
@@ -243,13 +240,8 @@ describe('Openid configuration form', () => {
     ).not.toBeChecked();
     expect(screen.getByLabelText(labelDisableVerifyPeer)).not.toBeChecked();
     expect(screen.getByLabelText(labelEnableAutoImport)).toBeChecked();
-    expect(screen.getByLabelText(labelEmailAttributeToBind)).toHaveValue(
-      'email',
-    );
-    expect(screen.getByLabelText(labelAliasAttributeToBind)).toHaveValue(
-      'firstname',
-    );
-    expect(screen.getByLabelText(labelFullnameAttributeToBind)).toHaveValue(
+    expect(screen.getByLabelText(labelEmailAttribute)).toHaveValue('email');
+    expect(screen.getByLabelText(labelFullnameAttribute)).toHaveValue(
       'lastname',
     );
     expect(screen.getByText('Contact group')).toBeInTheDocument();
@@ -416,12 +408,10 @@ describe('Openid configuration form', () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText(labelEmailAttributeToBind),
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText(labelEmailAttribute)).toBeInTheDocument();
     });
 
-    userEvent.type(screen.getByLabelText(labelEmailAttributeToBind), '');
+    userEvent.type(screen.getByLabelText(labelEmailAttribute), '');
 
     await waitFor(() => {
       expect(screen.getByText(labelSave)).toBeDisabled();

--- a/www/front_src/src/Authentication/Openid/models.ts
+++ b/www/front_src/src/Authentication/Openid/models.ts
@@ -14,7 +14,6 @@ export interface AuthorizationRelationToAPI {
 }
 
 export interface OpenidConfiguration {
-  aliasBindAttribute?: string | null;
   authenticationType: string | null;
   authorizationEndpoint: string | null;
   authorizationRules: Array<AuthorizationRule>;
@@ -41,7 +40,6 @@ export interface OpenidConfiguration {
 }
 
 export interface OpenidConfigurationToAPI {
-  alias_bind_attribute: string | null;
   authentication_type: string | null;
   authorization_endpoint: string | null;
   authorization_rules: Array<AuthorizationRelationToAPI>;

--- a/www/front_src/src/Authentication/Openid/translatedLabels.tsx
+++ b/www/front_src/src/Authentication/Openid/translatedLabels.tsx
@@ -31,7 +31,7 @@ export const labelMixed = 'Mixed';
 export const labelEnableAutoImport = 'Enable auto import';
 export const labelContactTemplate = 'Contact template';
 export const labelEmailAttribute = 'Email attribute';
-export const labelFullnameAttribute = 'Fullname attribute';
+export const labelFullnameAttribute = 'Full name attribute';
 export const labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled =
   'At least one of the two following fields must be filled';
 export const labelContactGroup = 'Contact group';

--- a/www/front_src/src/Authentication/Openid/translatedLabels.tsx
+++ b/www/front_src/src/Authentication/Openid/translatedLabels.tsx
@@ -30,9 +30,8 @@ export const labelOpenIDConnectOnly = 'OpenID Connect only';
 export const labelMixed = 'Mixed';
 export const labelEnableAutoImport = 'Enable auto import';
 export const labelContactTemplate = 'Contact template';
-export const labelEmailAttributeToBind = 'Email attribute to bind';
-export const labelAliasAttributeToBind = 'Alias attribute to bind';
-export const labelFullnameAttributeToBind = 'Fullname attribute to bind';
+export const labelEmailAttribute = 'Email attribute';
+export const labelFullnameAttribute = 'Fullname attribute';
 export const labelAtLeastOneOfTheTwoFollowingFieldsMustBeFilled =
   'At least one of the two following fields must be filled';
 export const labelContactGroup = 'Contact group';

--- a/www/front_src/src/Authentication/Openid/useValidationSchema.ts
+++ b/www/front_src/src/Authentication/Openid/useValidationSchema.ts
@@ -27,14 +27,6 @@ const useValidationSchema = (): Yup.SchemaOf<OpenidConfiguration> => {
   });
 
   return Yup.object({
-    aliasBindAttribute: Yup.string().when(
-      'autoImport',
-      (autoImport, schema) => {
-        return autoImport
-          ? schema.nullable().required(t(labelRequired))
-          : schema.nullable();
-      },
-    ),
     authenticationType: Yup.string().required(t(labelRequired)),
     authorizationEndpoint: Yup.string().nullable().required(t(labelRequired)),
     authorizationRules: Yup.array()

--- a/www/front_src/src/Authentication/api/adapters.ts
+++ b/www/front_src/src/Authentication/api/adapters.ts
@@ -101,13 +101,11 @@ export const adaptOpenidConfigurationToAPI = ({
   autoImport,
   contactTemplate,
   emailBindAttribute,
-  aliasBindAttribute,
   fullnameBindAttribute,
   contactGroup,
   claimName,
   authorizationRules,
 }: OpenidConfiguration): OpenidConfigurationToAPI => ({
-  alias_bind_attribute: aliasBindAttribute || null,
   authentication_type: authenticationType || null,
   authorization_endpoint: authorizationEndpoint || null,
   authorization_rules:

--- a/www/front_src/src/Authentication/api/decoders.ts
+++ b/www/front_src/src/Authentication/api/decoders.ts
@@ -73,7 +73,6 @@ const authorization = JsonDecoder.object<AuthorizationRule>(
 export const openidConfigurationDecoder =
   JsonDecoder.object<OpenidConfiguration>(
     {
-      aliasBindAttribute: JsonDecoder.nullable(JsonDecoder.string),
       authenticationType: JsonDecoder.nullable(JsonDecoder.string),
       authorizationEndpoint: JsonDecoder.nullable(JsonDecoder.string),
       authorizationRules: JsonDecoder.array(
@@ -116,7 +115,6 @@ export const openidConfigurationDecoder =
     },
     'Open ID Configuration',
     {
-      aliasBindAttribute: 'alias_bind_attribute',
       authenticationType: 'authentication_type',
       authorizationEndpoint: 'authorization_endpoint',
       authorizationRules: 'authorization_rules',

--- a/www/front_src/src/Authentication/index.tsx
+++ b/www/front_src/src/Authentication/index.tsx
@@ -22,7 +22,7 @@ import { labelWebSSOConfiguration } from './WebSSO/translatedLabels';
 import {
   labelActivation,
   labelAuthorizations,
-  labelAutoImport,
+  labelAutoImportUsers,
   labelClientAddresses,
   labelIdentityProvider,
 } from './translatedLabels';
@@ -67,7 +67,7 @@ export const categories: Array<Category> = [
     order: 3,
   },
   {
-    name: labelAutoImport,
+    name: labelAutoImportUsers,
     order: 3,
   },
   {

--- a/www/front_src/src/Authentication/translatedLabels.ts
+++ b/www/front_src/src/Authentication/translatedLabels.ts
@@ -1,6 +1,6 @@
 export const labelActivation = 'Activation';
 export const labelIdentityProvider = 'Identity provider';
 export const labelClientAddresses = 'Client addresses';
-export const labelAutoImport = 'Auto import';
+export const labelAutoImportUsers = 'Auto import users';
 export const labelAuthorizations = 'Authorizations';
 export const labelPressEnterToAccept = 'Press Enter to accept';

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -1425,7 +1425,7 @@ VALUES (
 (
   'openid',
   'openid',
-  '{"trusted_client_addresses":[],"blacklist_client_addresses":[],"base_url":null,"authorization_endpoint":null,"token_endpoint":null,"introspection_token_endpoint":null,"userinfo_endpoint":null,"endsession_endpoint":null,"connection_scopes":[],"login_claim":null,"client_id":null,"client_secret":null,"authentication_type":"client_secret_post","verify_peer":true, "auto_import": false, "contact_template_id": null, "email_bind_attribute": null, "alias_bind_attribute": null, "fullname_bind_attribute": null, "claim_name": "groups", "contact_group_id": null}',
+  '{"trusted_client_addresses":[],"blacklist_client_addresses":[],"base_url":null,"authorization_endpoint":null,"token_endpoint":null,"introspection_token_endpoint":null,"userinfo_endpoint":null,"endsession_endpoint":null,"connection_scopes":[],"login_claim":null,"client_id":null,"client_secret":null,"authentication_type":"client_secret_post","verify_peer":true, "auto_import": false, "contact_template_id": null, "email_bind_attribute": null, "fullname_bind_attribute": null, "claim_name": "groups", "contact_group_id": null}',
   false,
   false
 ),

--- a/www/install/php/Update-22.04.1.php
+++ b/www/install/php/Update-22.04.1.php
@@ -82,7 +82,6 @@ function updateOpenIdConfiguration(CentreonDB $pearDB): void
         $openIdCustomConfiguration["auto_import"] = false;
         $openIdCustomConfiguration["contact_template_id"] = null;
         $openIdCustomConfiguration["email_bind_attribute"] = null;
-        $openIdCustomConfiguration["alias_bind_attribute"] = null;
         $openIdCustomConfiguration["fullname_bind_attribute"] = null;
         $openIdCustomConfiguration["contact_group_id"] = $defaultContactGroupId;
         $openIdCustomConfiguration["claim_name"] = Configuration::DEFAULT_CLAIM_NAME;


### PR DESCRIPTION
## Description

**NOTE: This is a backport**

This PR Intends to remove alias bind attribute and improve labels.

While auto importing, Alias Bind Attribute is no longer needed as in Centreon alias must be unique, and depending of the configuration of the field Alias Bind Attribute it could result as non unique alias. Instead we use the login claim (which is the unique identifier on the IdP) as alias .

Also this PR improve some verbose on labels

**Fixes** # MON-14019

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
