### PR TITLE
feat(resources): add Severity to detail panel

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -91,10 +91,6 @@ Centreon\Domain\Monitoring\Resource:
             groups:
                 - 'resource_main'
                 - 'resource_parent'
-        severityLevel:
-            type: int
-            groups:
-                - 'resource_main'
         chartUrl:
             type: string
             groups:

--- a/doc/API/ResourceHostDetail.yaml
+++ b/doc/API/ResourceHostDetail.yaml
@@ -182,10 +182,11 @@ Monitoring.HostDetail:
         level:
           type: integer
           description: "Level of the Severity"
+          minimum: 0
+          maximum: 100
           example: 50
         icon:
           type: object
-          nullable: true
           properties:
             id:
               type: integer

--- a/doc/API/ResourceHostDetail.yaml
+++ b/doc/API/ResourceHostDetail.yaml
@@ -121,11 +121,6 @@ Monitoring.HostDetail:
       type: boolean
       description: "Indicates whether the check script is active or not"
       example: true
-    severity_level:
-      type: integer
-      nullable: true
-      description: "Indicates the severity level"
-      example: 1
     parent: null
     icon:
       type: object
@@ -151,6 +146,60 @@ Monitoring.HostDetail:
           type: string
           description: "Name of the hostgroup"
           example: "Linux-Servers"
+    categories:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: "ID of the host category"
+          example: 28
+        name:
+          type: string
+          description: "Name of the host category"
+          example: "All-Cpu-Services"
+        configuration_uri:
+          type: string
+          nullable: true
+          description: "Internal URI to reach category configuration"
+    severity:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: "ID of the Severity"
+          example: 28
+        name:
+          type: string
+          description: "Name of the Severity"
+          example: "High"
+        type:
+          type: string
+          description: "Type of the Severity"
+          enum: ['host', 'service']
+        level:
+          type: integer
+          description: "Level of the Severity"
+          example: 50
+        icon:
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: integer
+              format: int64
+              description: "ID of the Icon"
+              example: 10
+            name:
+              type: string
+              description: "Name of the Icon"
+              example: "dog.png"
+            url:
+              type: string
+              description: "URL of the Icon"
+              example: "baseUri/ppm/dog.png"
     acknowledgement:
       type: object
       nullable: true

--- a/doc/API/ResourceServiceDetail.yaml
+++ b/doc/API/ResourceServiceDetail.yaml
@@ -188,6 +188,8 @@ Monitoring.ServiceDetail:
         level:
           type: integer
           description: "Level of the Severity"
+          minimum: 0
+          maximum: 100
           example: 50
         icon:
           type: object

--- a/doc/API/ResourceServiceDetail.yaml
+++ b/doc/API/ResourceServiceDetail.yaml
@@ -123,16 +123,10 @@ Monitoring.ServiceDetail:
       type: boolean
       description: "Indicates whether the check script is active or not"
       example: true
-    severity_level:
-      type: integer
-      nullable: true
-      description: "Indicates the severity level"
-      example: 1
     parent:
       $ref: './ResourceHostDetail.yaml'
     icon:
       type: object
-      nullable: true
       properties:
         name:
           type: string
@@ -154,6 +148,63 @@ Monitoring.ServiceDetail:
           type: string
           description: "Name of the servicegroup"
           example: "All-Cpu-Services"
+        configuration_uri:
+          type: string
+          nullable: true
+          description: "Internal URI to reach group configuration"
+    categories:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: "ID of the service category"
+          example: 28
+        name:
+          type: string
+          description: "Name of the service category"
+          example: "All-Cpu-Services"
+        configuration_uri:
+          type: string
+          nullable: true
+          description: "Internal URI to reach category configuration"
+    severity:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: "ID of the Severity"
+          example: 28
+        name:
+          type: string
+          description: "Name of the Severity"
+          example: "High"
+        type:
+          type: string
+          description: "Type of the Severity"
+          enum: ['host', 'service']
+        level:
+          type: integer
+          description: "Level of the Severity"
+          example: 50
+        icon:
+          type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+              description: "ID of the Icon"
+              example: 10
+            name:
+              type: string
+              description: "Name of the Icon"
+              example: "dog.png"
+            url:
+              type: string
+              description: "URL of the Icon"
+              example: "baseUri/ppm/dog.png"
     acknowledgement:
       type: object
       nullable: true

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -1256,7 +1256,6 @@ paths:
         * notes_url
         * parent_name
         * parent_status
-        * severity_level
         * in_downtime
         * acknowledged
         * last_status_change
@@ -6153,11 +6152,6 @@ components:
           type: boolean
           description: "Indicates whether resource is acknowledged"
           example: false
-        severity_level:
-          type: integer
-          nullable: true
-          description: "level of the severity"
-          example: 1
         duration:
           type: string
           nullable: true

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -168,11 +168,6 @@ class Resource
     private $links;
 
     /**
-     * @var int|null
-     */
-    private $severityLevel;
-
-    /**
      * @var string|null
      */
     private $chartUrl;
@@ -734,25 +729,6 @@ class Resource
     public function setLinks(ResourceLinks $links): self
     {
         $this->links = $links;
-        return $this;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getSeverityLevel(): ?int
-    {
-        return $this->severityLevel;
-    }
-
-    /**
-     * @param int|null $severityLevel
-     * @return \Centreon\Domain\Monitoring\Resource
-     */
-    public function setSeverityLevel(?int $severityLevel): self
-    {
-        $this->severityLevel = $severityLevel;
-
         return $this;
     }
 

--- a/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
@@ -364,9 +364,6 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
             fn (ResourceEntity $resource) => $resource->getIcon() !== null
         );
 
-        /**
-         * @todo replace by foreach
-         */
         return array_map(
             fn (ResourceEntity $resource) => $resource->getIcon()?->getId(),
             $resourcesWithIcons
@@ -383,9 +380,6 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
             fn (ResourceEntity $resource) => $resource->getSeverity() !== null
         );
 
-        /**
-         * @todo replace by foreach
-         */
         return array_map(
             fn (ResourceEntity $resource) => $resource->getSeverity()?->getIcon()?->getId(),
             $resourcesWithSeverities

--- a/src/Core/Application/RealTime/Common/RealTimeResponseTrait.php
+++ b/src/Core/Application/RealTime/Common/RealTimeResponseTrait.php
@@ -27,6 +27,7 @@ use Core\Domain\RealTime\Model\Status;
 use Core\Tag\RealTime\Domain\Model\Tag;
 use Core\Domain\RealTime\Model\Downtime;
 use Core\Domain\RealTime\Model\Acknowledgement;
+use Core\Severity\RealTime\Domain\Model\Severity;
 
 trait RealTimeResponseTrait
 {
@@ -138,5 +139,24 @@ trait RealTimeResponseTrait
             'severity_code' => $status->getOrder(),
             'type' => $status->getType()
         ];
+    }
+
+    /**
+     * Converts Severity model into an array for DTO
+     *
+     * @param Severity|null $severity
+     * @return array<string, mixed>
+     */
+    private function severityToArray(?Severity $severity): array
+    {
+        return is_null($severity)
+            ? []
+            : [
+                'id' => $severity->getId(),
+                'name' => $severity->getName(),
+                'level' => $severity->getLevel(),
+                'type' => $severity->getTypeAsString(),
+                'icon' => $this->iconToArray($severity->getIcon())
+            ];
     }
 }

--- a/src/Core/Application/RealTime/Common/RealTimeResponseTrait.php
+++ b/src/Core/Application/RealTime/Common/RealTimeResponseTrait.php
@@ -52,13 +52,14 @@ trait RealTimeResponseTrait
      * Converts an Icon model into an array
      *
      * @param Icon|null $icon
-     * @return array<string, string|null>
+     * @return array<string, mixed>
      */
     public function iconToArray(?Icon $icon): array
     {
         return is_null($icon)
             ? []
             : [
+                'id' => $icon->getId(),
                 'name' => $icon->getName(),
                 'url' => $icon->getUrl()
             ];
@@ -144,19 +145,17 @@ trait RealTimeResponseTrait
     /**
      * Converts Severity model into an array for DTO
      *
-     * @param Severity|null $severity
+     * @param Severity $severity
      * @return array<string, mixed>
      */
-    private function severityToArray(?Severity $severity): array
+    private function severityToArray(Severity $severity): array
     {
-        return is_null($severity)
-            ? []
-            : [
-                'id' => $severity->getId(),
-                'name' => $severity->getName(),
-                'level' => $severity->getLevel(),
-                'type' => $severity->getTypeAsString(),
-                'icon' => $this->iconToArray($severity->getIcon())
-            ];
+        return [
+            'id' => $severity->getId(),
+            'name' => $severity->getName(),
+            'level' => $severity->getLevel(),
+            'type' => $severity->getTypeAsString(),
+            'icon' => $this->iconToArray($severity->getIcon())
+        ];
     }
 }

--- a/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
+++ b/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
@@ -114,8 +114,16 @@ class FindHost
 
         $host->setCategories($categories);
 
+        $this->info(
+            'Fetching severity from the database for host',
+            [
+                'hostId' => $hostId,
+                'typeId' => Severity::HOST_SEVERITY_TYPE_ID
+            ]
+        );
+
         $severity = $this->severityRepository->findByResourceAndTypeId(
-            $host->getId(),
+            $hostId,
             0,
             Severity::HOST_SEVERITY_TYPE_ID
         );

--- a/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
+++ b/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
@@ -28,6 +28,7 @@ use Core\Domain\RealTime\Model\Host;
 use Core\Tag\RealTime\Domain\Model\Tag;
 use Core\Domain\RealTime\Model\Downtime;
 use Core\Domain\RealTime\Model\Acknowledgement;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Centreon\Domain\Monitoring\Host as LegacyHost;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
@@ -40,6 +41,7 @@ use Core\Application\RealTime\Repository\ReadHostgroupRepositoryInterface;
 use Core\Application\RealTime\UseCase\FindHost\FindHostPresenterInterface;
 use Core\Security\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadAcknowledgementRepositoryInterface;
+use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
 
 class FindHost
 {
@@ -54,6 +56,7 @@ class FindHost
      * @param ReadAcknowledgementRepositoryInterface $acknowledgementRepository
      * @param MonitoringServiceInterface $monitoringService
      * @param ReadTagRepositoryInterface $tagRepository
+     * @param ReadSeverityRepositoryInterface $severityRepository
      */
     public function __construct(
         private ReadHostRepositoryInterface $repository,
@@ -64,6 +67,7 @@ class FindHost
         private ReadAcknowledgementRepositoryInterface $acknowledgementRepository,
         private MonitoringServiceInterface $monitoringService,
         private ReadTagRepositoryInterface $tagRepository,
+        private ReadSeverityRepositoryInterface $severityRepository
     ) {
     }
 
@@ -109,6 +113,14 @@ class FindHost
         $categories = $this->tagRepository->findAllByResourceAndTypeId($host->getId(), 0, Tag::HOST_CATEGORY_TYPE_ID);
 
         $host->setCategories($categories);
+
+        $severity = $this->severityRepository->findByResourceAndTypeId(
+            $host->getId(),
+            0,
+            Severity::HOST_SEVERITY_TYPE_ID
+        );
+
+        $host->setSeverity($severity);
 
         /**
          * Obfuscate the passwords in Host commandLine
@@ -163,6 +175,7 @@ class FindHost
             $downtimes,
             $acknowledgement,
             $host->getCategories(),
+            $host->getSeverity()
         );
 
         $findHostResponse->timezone = $host->getTimezone();
@@ -184,7 +197,6 @@ class FindHost
         $findHostResponse->hasPassiveChecks = $host->hasPassiveChecks();
         $findHostResponse->hasActiveChecks = $host->hasActiveChecks();
         $findHostResponse->lastTimeUp = $host->getLastTimeUp();
-        $findHostResponse->severityLevel = $host->getSeverityLevel();
         $findHostResponse->checkAttempts = $host->getCheckAttempts();
         $findHostResponse->maxCheckAttempts = $host->getMaxCheckAttempts();
 

--- a/src/Core/Application/RealTime/UseCase/FindHost/FindHostResponse.php
+++ b/src/Core/Application/RealTime/UseCase/FindHost/FindHostResponse.php
@@ -28,6 +28,7 @@ use Core\Domain\RealTime\Model\Downtime;
 use Core\Domain\RealTime\Model\Hostgroup;
 use Core\Domain\RealTime\Model\HostStatus;
 use Core\Domain\RealTime\Model\Acknowledgement;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Core\Application\RealTime\Common\RealTimeResponseTrait;
 
 class FindHostResponse
@@ -132,11 +133,6 @@ class FindHostResponse
     /**
      * @var int|null
      */
-    public $severityLevel;
-
-    /**
-     * @var int|null
-     */
     public $checkAttempts;
 
     /**
@@ -175,6 +171,11 @@ class FindHostResponse
     public $categories;
 
     /**
+     * @var array<string, mixed>
+     */
+    public $severity;
+
+    /**
      * @param int $id
      * @param string $name
      * @param string $address
@@ -185,6 +186,7 @@ class FindHostResponse
      * @param Downtime[] $downtimes
      * @param Acknowledgement|null $acknowledgement,
      * @param Tag[] $categories
+     * @param Severity|null $severity
      */
     public function __construct(
         public int $id,
@@ -197,6 +199,7 @@ class FindHostResponse
         array $downtimes,
         ?Acknowledgement $acknowledgement,
         array $categories,
+        ?Severity $severity
     ) {
         $this->icon = $this->iconToArray($icon);
         $this->status = $this->statusToArray($status);
@@ -204,6 +207,7 @@ class FindHostResponse
         $this->downtimes = $this->downtimesToArray($downtimes);
         $this->acknowledgement = $this->acknowledgementToArray($acknowledgement);
         $this->categories = $this->tagsToArray($categories);
+        $this->severity = $this->severityToArray($severity);
     }
 
     /**

--- a/src/Core/Application/RealTime/UseCase/FindHost/FindHostResponse.php
+++ b/src/Core/Application/RealTime/UseCase/FindHost/FindHostResponse.php
@@ -168,12 +168,12 @@ class FindHostResponse
     /**
      * @var array<array<string, mixed>>
      */
-    public $categories;
+    public array $categories = [];
 
     /**
-     * @var array<string, mixed>
+     * @var array<string, mixed>|null
      */
-    public $severity;
+    public ?array $severity = null;
 
     /**
      * @param int $id
@@ -207,7 +207,7 @@ class FindHostResponse
         $this->downtimes = $this->downtimesToArray($downtimes);
         $this->acknowledgement = $this->acknowledgementToArray($acknowledgement);
         $this->categories = $this->tagsToArray($categories);
-        $this->severity = $this->severityToArray($severity);
+        $this->severity = is_null($severity) ? $severity : $this->severityToArray($severity);
     }
 
     /**

--- a/src/Core/Application/RealTime/UseCase/FindService/FindService.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindService.php
@@ -150,6 +150,15 @@ class FindService
 
         $service->setCategories($serviceCategories);
 
+        $this->info(
+            'Fetching severity from the database for host',
+            [
+                'hostId' => $hostId,
+                'serviceId' => $serviceId,
+                'typeId' => Severity::HOST_SEVERITY_TYPE_ID
+            ]
+        );
+
         $severity = $this->severityRepository->findByResourceAndTypeId(
             $serviceId,
             $hostId,

--- a/src/Core/Application/RealTime/UseCase/FindService/FindService.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindService.php
@@ -29,6 +29,7 @@ use Core\Domain\RealTime\Model\Service;
 use Core\Tag\RealTime\Domain\Model\Tag;
 use Core\Domain\RealTime\Model\Downtime;
 use Core\Domain\RealTime\Model\Acknowledgement;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Centreon\Domain\Monitoring\Host as LegacyHost;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Security\Domain\AccessGroup\Model\AccessGroup;
@@ -44,6 +45,7 @@ use Core\Security\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadServicegroupRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadAcknowledgementRepositoryInterface;
 use Core\Application\RealTime\UseCase\FindService\FindServicePresenterInterface;
+use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
 
 class FindService
 {
@@ -70,6 +72,7 @@ class FindService
         private ReadAcknowledgementRepositoryInterface $acknowledgementRepository,
         private MonitoringServiceInterface $monitoringService,
         private ReadTagRepositoryInterface $tagRepository,
+        private ReadSeverityRepositoryInterface $severityRepository
     ) {
     }
 
@@ -146,6 +149,14 @@ class FindService
         );
 
         $service->setCategories($serviceCategories);
+
+        $severity = $this->severityRepository->findByResourceAndTypeId(
+            $serviceId,
+            $hostId,
+            Severity::SERVICE_SEVERITY_TYPE_ID
+        );
+
+        $service->setSeverity($severity);
 
         /**
          * Obfuscate the passwords in Service commandLine
@@ -225,6 +236,7 @@ class FindService
             $acknowledgement,
             $host,
             $service->getCategories(),
+            $service->getSeverity()
         );
 
         $findServiceResponse->isFlapping = $service->isFlapping();
@@ -244,7 +256,6 @@ class FindService
         $findServiceResponse->hasPassiveChecks = $service->hasPassiveChecks();
         $findServiceResponse->hasActiveChecks = $service->hasActiveChecks();
         $findServiceResponse->lastTimeOk = $service->getLastTimeOk();
-        $findServiceResponse->severityLevel = $service->getSeverityLevel();
         $findServiceResponse->checkAttempts = $service->getCheckAttempts();
         $findServiceResponse->maxCheckAttempts = $service->getMaxCheckAttempts();
         $findServiceResponse->hasGraphData = $service->hasGraphData();

--- a/src/Core/Application/RealTime/UseCase/FindService/FindService.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindService.php
@@ -151,11 +151,11 @@ class FindService
         $service->setCategories($serviceCategories);
 
         $this->info(
-            'Fetching severity from the database for host',
+            'Fetching severity from the database for service',
             [
                 'hostId' => $hostId,
                 'serviceId' => $serviceId,
-                'typeId' => Severity::HOST_SEVERITY_TYPE_ID
+                'typeId' => Severity::SERVICE_SEVERITY_TYPE_ID
             ]
         );
 

--- a/src/Core/Application/RealTime/UseCase/FindService/FindServiceResponse.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindServiceResponse.php
@@ -172,9 +172,9 @@ class FindServiceResponse
     public $hasGraphData;
 
     /**
-     * @var array<string, mixed>
+     * @var array<string, mixed>|null
      */
-    public array $severity;
+    public ?array $severity = null;
 
     /**
      * @param int $id
@@ -209,7 +209,7 @@ class FindServiceResponse
         $this->acknowledgement = $this->acknowledgementToArray($acknowledgement);
         $this->host = $this->hostToArray($host);
         $this->categories = $this->tagsToArray($serviceCategories);
-        $this->severity = $this->severityToArray($severity);
+        $this->severity = is_null($severity) ? $severity : $this->severityToArray($severity);
     }
 
     /**

--- a/src/Core/Application/RealTime/UseCase/FindService/FindServiceResponse.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindServiceResponse.php
@@ -29,6 +29,7 @@ use Core\Domain\RealTime\Model\Downtime;
 use Core\Domain\RealTime\Model\Servicegroup;
 use Core\Domain\RealTime\Model\ServiceStatus;
 use Core\Domain\RealTime\Model\Acknowledgement;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Core\Application\RealTime\Common\RealTimeResponseTrait;
 
 class FindServiceResponse
@@ -123,11 +124,6 @@ class FindServiceResponse
     /**
      * @var int|null
      */
-    public $severityLevel;
-
-    /**
-     * @var int|null
-     */
     public $checkAttempts;
 
     /**
@@ -176,6 +172,11 @@ class FindServiceResponse
     public $hasGraphData;
 
     /**
+     * @var array<string, mixed>
+     */
+    public array $severity;
+
+    /**
      * @param int $id
      * @param int $hostId
      * @param string $name
@@ -186,6 +187,7 @@ class FindServiceResponse
      * @param Acknowledgement|null $acknowledgement
      * @param Host $host
      * @param Tag[] $serviceCategories
+     * @param Severity|null $severity
      */
     public function __construct(
         public int $id,
@@ -197,7 +199,8 @@ class FindServiceResponse
         array $downtimes,
         ?Acknowledgement $acknowledgement,
         Host $host,
-        array $serviceCategories
+        array $serviceCategories,
+        ?Severity $severity
     ) {
         $this->groups = $this->servicegroupsToArray($servicegroups);
         $this->status = $this->statusToArray($status);
@@ -206,6 +209,7 @@ class FindServiceResponse
         $this->acknowledgement = $this->acknowledgementToArray($acknowledgement);
         $this->host = $this->hostToArray($host);
         $this->categories = $this->tagsToArray($serviceCategories);
+        $this->severity = $this->severityToArray($severity);
     }
 
     /**

--- a/src/Core/Domain/RealTime/Model/Host.php
+++ b/src/Core/Domain/RealTime/Model/Host.php
@@ -27,6 +27,7 @@ use Core\Tag\RealTime\Domain\Model\Tag;
 use Core\Domain\RealTime\Model\Hostgroup;
 use Core\Domain\RealTime\Model\HostStatus;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Core\Severity\RealTime\Domain\Model\Severity;
 
 /**
  * Class representing a host entity in real time context.
@@ -140,11 +141,6 @@ class Host
     private $lastTimeUp;
 
     /**
-     * @var int|null
-     */
-    private $severityLevel;
-
-    /**
      * @var Hostgroup[]
      */
     private array $groups = [];
@@ -168,6 +164,11 @@ class Host
      * @var Tag[]
      */
     private array $categories = [];
+
+    /**
+     * @var Severity|null
+     */
+    private ?Severity $severity;
 
     /**
      * Host constructor
@@ -590,24 +591,6 @@ class Host
     }
 
     /**
-     * @param int|null $severityLevel
-     * @return self
-     */
-    public function setSeverityLevel(?int $severityLevel): self
-    {
-        $this->severityLevel = $severityLevel;
-        return $this;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getSeverityLevel(): ?int
-    {
-        return $this->severityLevel;
-    }
-
-    /**
      * @param Hostgroup $group
      * @return self
      */
@@ -733,5 +716,25 @@ class Host
         }
 
         return $this;
+    }
+
+    /**
+     * @param Severity|null $severity
+     * @return self
+     * @throws \TypeError
+     */
+    public function setSeverity(?Severity $severity): self
+    {
+        $this->severity = $severity;
+
+        return $this;
+    }
+
+    /**
+     * @return Severity|null
+     */
+    public function getSeverity(): ?Severity
+    {
+        return $this->severity;
     }
 }

--- a/src/Core/Domain/RealTime/Model/Service.php
+++ b/src/Core/Domain/RealTime/Model/Service.php
@@ -27,6 +27,7 @@ use Core\Tag\RealTime\Domain\Model\Tag;
 use Core\Domain\RealTime\Model\Servicegroup;
 use Core\Domain\RealTime\Model\ServiceStatus;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Core\Severity\RealTime\Domain\Model\Severity;
 
 class Service
 {
@@ -123,11 +124,6 @@ class Service
     private $lastTimeOk;
 
     /**
-     * @var int|null
-     */
-    private $severityLevel;
-
-    /**
      * @var Icon|null
      */
     private $icon;
@@ -156,6 +152,11 @@ class Service
      * @var Tag[]
      */
     private array $categories = [];
+
+    /**
+     * @var Severity|null
+     */
+    private ?Severity $severity;
 
     /**
      * @param int $id
@@ -542,24 +543,6 @@ class Service
     }
 
     /**
-     * @param int|null $severityLevel
-     * @return self
-     */
-    public function setSeverityLevel(?int $severityLevel): self
-    {
-        $this->severityLevel = $severityLevel;
-        return $this;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getSeverityLevel(): ?int
-    {
-        return $this->severityLevel;
-    }
-
-    /**
      *
      * @param ?Icon $icon
      * @return self
@@ -686,5 +669,25 @@ class Service
         }
 
         return $this;
+    }
+
+    /**
+     * @param Severity|null $severity
+     * @return self
+     * @throws \TypeError
+     */
+    public function setSeverity(?Severity $severity): self
+    {
+        $this->severity = $severity;
+
+        return $this;
+    }
+
+    /**
+     * @return Severity|null
+     */
+    public function getSeverity(): ?Severity
+    {
+        return $this->severity;
     }
 }

--- a/src/Core/Infrastructure/RealTime/Api/FindHost/FindHostPresenter.php
+++ b/src/Core/Infrastructure/RealTime/Api/FindHost/FindHostPresenter.php
@@ -83,19 +83,16 @@ class FindHostPresenter extends AbstractPresenter implements FindHostPresenterIn
             'icon' => $response->icon,
             'groups' => $this->hypermediaCreator->convertGroupsForPresenter($response),
             'categories' => $this->hypermediaCreator->convertCategoriesForPresenter($response),
+            'severity' => $response->severity,
         ];
 
-        $severity = null;
-
-        if (! empty($response->severity)) {
+        if ($presenterResponse['severity'] !== null) {
             /**
              * normalize the URL to the severity icon
              */
-            $severity = $response->severity;
-            $severity['icon']['url'] = $this->getBaseUri() . '/' . $response->severity['icon']['url'];
+            $presenterResponse['severity']['icon']['url'] = $this->getBaseUri()
+                . '/' . $response->severity['icon']['url'];
         }
-
-        $presenterResponse['severity'] = $severity;
 
         $acknowledgement = null;
 

--- a/src/Core/Infrastructure/RealTime/Api/FindService/FindServicePresenter.php
+++ b/src/Core/Infrastructure/RealTime/Api/FindService/FindServicePresenter.php
@@ -27,12 +27,14 @@ use Symfony\Component\HttpFoundation\Response;
 use Core\Application\Common\UseCase\ResponseStatusInterface;
 use Core\Application\Common\UseCase\AbstractPresenter;
 use Core\Application\RealTime\UseCase\FindService\FindServicePresenterInterface;
+use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Infrastructure\Common\Presenter\PresenterTrait;
 
 class FindServicePresenter extends AbstractPresenter implements FindServicePresenterInterface
 {
     use PresenterTrait;
+    use HttpUrlTrait;
 
     /**
      * @var ResponseStatusInterface|null
@@ -73,13 +75,24 @@ class FindServicePresenter extends AbstractPresenter implements FindServicePrese
             'passive_checks' => $response->hasPassiveChecks,
             'execution_time' => $response->executionTime,
             'active_checks' => $response->hasActiveChecks,
-            'severity_level' => $response->severityLevel,
             'icon' => $response->icon,
             'groups' => $this->hypermediaCreator->convertGroupsForPresenter($response),
             'parent' => $response->host,
             'monitoring_server_name' => $response->host['monitoring_server_name'],
             'categories' => $this->hypermediaCreator->convertCategoriesForPresenter($response),
         ];
+
+        $severity = null;
+
+        if (! empty($response->severity)) {
+            /**
+             * normalize the URL to the severity icon
+             */
+            $severity = $response->severity;
+            $severity['icon']['url'] = $this->getBaseUri() . '/' . $response->severity['icon']['url'];
+        }
+
+        $presenterResponse['severity'] = $severity;
 
         $acknowledgement = null;
 

--- a/src/Core/Infrastructure/RealTime/Api/FindService/FindServicePresenter.php
+++ b/src/Core/Infrastructure/RealTime/Api/FindService/FindServicePresenter.php
@@ -80,19 +80,16 @@ class FindServicePresenter extends AbstractPresenter implements FindServicePrese
             'parent' => $response->host,
             'monitoring_server_name' => $response->host['monitoring_server_name'],
             'categories' => $this->hypermediaCreator->convertCategoriesForPresenter($response),
+            'severity' => $response->severity,
         ];
 
-        $severity = null;
-
-        if (! empty($response->severity)) {
+        if ($presenterResponse['severity'] !== null) {
             /**
              * normalize the URL to the severity icon
              */
-            $severity = $response->severity;
-            $severity['icon']['url'] = $this->getBaseUri() . '/' . $response->severity['icon']['url'];
+            $presenterResponse['severity']['icon']['url'] = $this->getBaseUri()
+                . '/' . $response->severity['icon']['url'];
         }
-
-        $presenterResponse['severity'] = $severity;
 
         $acknowledgement = null;
 

--- a/src/Core/Infrastructure/RealTime/Repository/Host/DbHostFactory.php
+++ b/src/Core/Infrastructure/RealTime/Repository/Host/DbHostFactory.php
@@ -57,7 +57,6 @@ class DbHostFactory
             ->setLatency(self::getFloatOrNull($data['latency']))
             ->setExecutionTime(self::getFloatOrNull($data['execution_time']))
             ->setStatusChangePercentage(self::getFloatOrNull($data['status_change_percentage']))
-            ->setSeverityLevel(self::getIntOrNull($data['severity_level']))
             ->setNotificationEnabled((int) $data['notify'] === 1)
             ->setNotificationNumber(self::getIntOrNull($data['notification_number']))
             ->setLastStatusChange(self::createDateTimeFromTimestamp((int) $data['last_status_change']))

--- a/src/Core/Infrastructure/RealTime/Repository/Service/DbServiceFactory.php
+++ b/src/Core/Infrastructure/RealTime/Repository/Service/DbServiceFactory.php
@@ -54,7 +54,6 @@ class DbServiceFactory
             ->setLatency(self::getFloatOrNull($data['latency']))
             ->setExecutionTime(self::getFloatOrNull($data['execution_time']))
             ->setStatusChangePercentage(self::getFloatOrNull($data['status_change_percentage']))
-            ->setSeverityLevel(self::getIntOrNull($data['severity_level']))
             ->setNotificationEnabled((int) $data['notify'] === 1)
             ->setNotificationNumber(self::getIntOrNull($data['notification_number']))
             ->setLastStatusChange(self::createDateTimeFromTimestamp((int) $data['last_status_change']))

--- a/src/Core/Severity/RealTime/Application/Repository/ReadSeverityRepositoryInterface.php
+++ b/src/Core/Severity/RealTime/Application/Repository/ReadSeverityRepositoryInterface.php
@@ -37,10 +37,10 @@ interface ReadSeverityRepositoryInterface
     /**
      * Finds a Severity by id, parentId and typeId
      *
-     * @param integer $id
-     * @param integer $parentId
+     * @param integer $resourceId
+     * @param integer $parentResourceId
      * @param integer $typeId
      * @return Severity|null
      */
-    public function findByResourceAndTypeId(int $id, int $parentId, int $typeId): ?Severity;
+    public function findByResourceAndTypeId(int $resourceId, int $parentResourceId, int $typeId): ?Severity;
 }

--- a/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
+++ b/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
@@ -28,6 +28,7 @@ use Centreon\Domain\RequestParameters\RequestParameters;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
+use Core\Severity\RealTime\Domain\Model\Severity;
 
 class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeverityRepositoryInterface
 {
@@ -60,7 +61,12 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
      */
     public function findAllByTypeId(int $typeId): array
     {
-        $this->info('Fetching severities from the database');
+        $this->info(
+            'Fetching severities from the database by typeId',
+            [
+                'typeId' => $typeId
+            ]
+        );
 
         $request = 'SELECT SQL_CALC_FOUND_ROWS
             severity_id,
@@ -114,5 +120,55 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
         }
 
         return $severities;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByResourceAndTypeId(int $id, int $parentId, int $typeId): ?Severity
+    {
+        $this->info(
+            'Fetching severity from the database for resource',
+            [
+                'id' => $id,
+                'parentId' => $parentId,
+                'typeId' => $typeId
+            ]
+        );
+
+        $request = 'SELECT
+            resources.severity_id,
+            s.id,
+            s.name,
+            s.level,
+            s.type,
+            s.icon_id,
+            img_name AS `icon_name`,
+            img_path AS `icon_path`,
+            imgd.dir_name AS `icon_directory`
+        FROM `:dbstg`.resources
+        INNER JOIN `:dbstg`.severities s
+            ON s.severity_id = resources.severity_id
+        INNER JOIN `:db`.view_img img
+            ON s.icon_id = img.img_id
+        LEFT JOIN `:db`.view_img_dir_relation imgdr
+            ON imgdr.img_img_id = img.img_id
+        INNER JOIN `:db`.view_img_dir imgd
+            ON imgd.dir_id = imgdr.dir_dir_parent_id
+        WHERE resources.id = :id AND resources.parent_id = :parentId AND s.type = :typeId';
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+
+        $statement->bindValue(':id', $id, \PDO::PARAM_INT);
+        $statement->bindValue(':parentId', $parentId, \PDO::PARAM_INT);
+        $statement->bindValue(':typeId', $typeId, \PDO::PARAM_INT);
+
+        $statement->execute();
+
+        if (($record = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            return DbSeverityFactory::createFromRecord($record);
+        }
+
+        return null;
     }
 }

--- a/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
+++ b/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
@@ -125,17 +125,8 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
     /**
      * @inheritDoc
      */
-    public function findByResourceAndTypeId(int $id, int $parentId, int $typeId): ?Severity
+    public function findByResourceAndTypeId(int $resourceId, int $parentResourceId, int $typeId): ?Severity
     {
-        $this->info(
-            'Fetching severity from the database for resource',
-            [
-                'id' => $id,
-                'parentId' => $parentId,
-                'typeId' => $typeId
-            ]
-        );
-
         $request = 'SELECT
             resources.severity_id,
             s.id,
@@ -155,12 +146,12 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
             ON imgdr.img_img_id = img.img_id
         INNER JOIN `:db`.view_img_dir imgd
             ON imgd.dir_id = imgdr.dir_dir_parent_id
-        WHERE resources.id = :id AND resources.parent_id = :parentId AND s.type = :typeId';
+        WHERE resources.id = :resourceId AND resources.parent_id = :parentResourceId AND s.type = :typeId';
 
         $statement = $this->db->prepare($this->translateDbName($request));
 
-        $statement->bindValue(':id', $id, \PDO::PARAM_INT);
-        $statement->bindValue(':parentId', $parentId, \PDO::PARAM_INT);
+        $statement->bindValue(':resourceId', $resourceId, \PDO::PARAM_INT);
+        $statement->bindValue(':parentResourceId', $parentResourceId, \PDO::PARAM_INT);
         $statement->bindValue(':typeId', $typeId, \PDO::PARAM_INT);
 
         $statement->execute();

--- a/src/Core/Severity/RealTime/Infrastructure/Repository/DbSeverityFactory.php
+++ b/src/Core/Severity/RealTime/Infrastructure/Repository/DbSeverityFactory.php
@@ -34,6 +34,7 @@ class DbSeverityFactory
     public static function createFromRecord(array $record): Severity
     {
         $icon = (new Icon())
+            ->setId((int) $record['icon_id'])
             ->setName($record['icon_name'])
             ->setUrl($record['icon_directory'] . DIRECTORY_SEPARATOR . $record['icon_path']);
 

--- a/tests/api/Context/RealTimeSeverityContext.php
+++ b/tests/api/Context/RealTimeSeverityContext.php
@@ -18,29 +18,11 @@
  * For more information : contact@centreon.com
  *
  */
-declare(strict_types=1);
 
-namespace Core\Severity\RealTime\Application\Repository;
+namespace Centreon\Test\Api\Context;
 
-use Core\Severity\RealTime\Domain\Model\Severity;
+use Centreon\Test\Behat\Api\Context\ApiContext;
 
-interface ReadSeverityRepositoryInterface
+class RealTimeSeverityContext extends ApiContext
 {
-    /**
-     * Returns all the severities from the RealTime of provided type id
-     *
-     * @param integer $typeId
-     * @return Severity[]
-     */
-    public function findAllByTypeId(int $typeId): array;
-
-    /**
-     * Finds a Severity by id, parentId and typeId
-     *
-     * @param integer $id
-     * @param integer $parentId
-     * @param integer $typeId
-     * @return Severity|null
-     */
-    public function findByResourceAndTypeId(int $id, int $parentId, int $typeId): ?Severity;
 }

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -4,6 +4,10 @@ default:
   gherkin:
     cache: ~
   suites:
+    realtime_severity:
+      paths: [ "%paths.base%/features/RealTimeSeverity.feature" ]
+      contexts:
+        - Centreon\Test\Api\Context\RealTimeSeverityContext
     realtime_category:
       paths: [ "%paths.base%/features/RealTimeCategory.feature" ]
       contexts:

--- a/tests/api/features/RealTimeSeverity.feature
+++ b/tests/api/features/RealTimeSeverity.feature
@@ -1,0 +1,90 @@
+Feature:
+  In order to get severities from realtime
+  As a logged in user
+  I want to find severities using api
+
+  Background:
+    Given a running instance of Centreon Web API
+    And the endpoints are described in Centreon Web API documentation
+
+    Scenario: Host severities listing
+    Given I am logged in
+    And the following CLAPI import data:
+    """
+    HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
+    HC;ADD;severity1;severity1-alias
+    HC;setparam;severity1;hc_activate;1
+    HC;setmember;severity1;test
+    HC;setseverity;severity1;42;logos/centreon.png
+    """
+    And the configuration is generated and exported
+    And I wait until host "test" is monitored
+
+    When I send a GET request to '/api/v22.10/monitoring/severities/host'
+    Then the response code should be "200"
+    And the JSON should be equal to:
+    """
+    {
+        "result": [
+            {
+                "id": 1,
+                "name": "severity1",
+                "level": 42,
+                "type": "host",
+                "icon": {
+                    "name": "centreon",
+                    "url": "logos/centreon.png"
+                }
+            }
+        ],
+        "meta": {
+            "page": 1,
+            "limit": 10,
+            "search": {},
+            "sort_by": {},
+            "total": 1
+        }
+    }
+    """
+
+    Scenario: Service severities listing
+    Given I am logged in
+    And the following CLAPI import data:
+    """
+    HOST;ADD;test;Test host;127.0.0.1;generic-host;central;
+    SERVICE;ADD;test;test_service1;Ping-LAN;
+    SC;ADD;severity1;severity1-alias
+    SC;setparam;severity1;sc_activate;1
+    SC;addservicetemplate;severity1;Ping-LAN
+    SC;setseverity;severity1;42;logos/centreon.png
+    """
+    And the configuration is generated and exported
+    And I wait until host "test" is monitored
+    And I wait until service "test_service1" from host "test" is monitored
+
+    When I send a GET request to '/api/v22.10/monitoring/severities/service'
+    Then the response code should be "200"
+    And the JSON should be equal to:
+    """
+    {
+        "result": [
+            {
+                "id": 5,
+                "name": "severity1",
+                "level": 42,
+                "type": "service",
+                "icon": {
+                    "name": "centreon",
+                    "url": "logos/centreon.png"
+                }
+            }
+        ],
+        "meta": {
+            "page": 1,
+            "limit": 10,
+            "search": {},
+            "sort_by": {},
+            "total": 1
+        }
+    }
+    """

--- a/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
@@ -231,10 +231,16 @@ it('should find the host as admin', function () {
     expect($presenter->response->acknowledgement['host_id'])->toBe($this->acknowledgement->getHostId());
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
-    expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-    expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-    expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-    expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+
+    if ($presenter->response->severity !== null) {
+        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
+        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
+        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
+        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
+    }
 });
 
 it('should find the host as non admin', function () {
@@ -331,8 +337,14 @@ it('should find the host as non admin', function () {
     expect($presenter->response->acknowledgement['entry_time'])->toBe($this->acknowledgement->getEntryTime());
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
-    expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-    expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-    expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-    expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+
+    if ($presenter->response->severity !== null) {
+        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
+        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
+        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
+        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
+    }
 });

--- a/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
@@ -232,16 +232,8 @@ it('should find the host as admin', function () {
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
 
-    expect($presenter->response->severity)->toBeInstanceOf(Severity::class);
-
     /**
-     * @var array{
-     *  'id': int,
-     *  'name': string,
-     *  'level': int,
-     *  'type': string,
-     *  'icon': array
-     * } $severity
+     * @var array<string, mixed> $severity
      */
     $severity = $presenter->response->severity;
     expect($severity['id'])->toBe($this->severity->getId());
@@ -348,13 +340,15 @@ it('should find the host as non admin', function () {
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
 
-    if ($presenter->response->severity !== null) {
-        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
-        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
-        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
-        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
-    }
+    /**
+     * @var array<string, mixed> $severity
+     */
+    $severity = $presenter->response->severity;
+    expect($severity['id'])->toBe($this->severity->getId());
+    expect($severity['name'])->toBe($this->severity->getName());
+    expect($severity['type'])->toBe($this->severity->getTypeAsString());
+    expect($severity['level'])->toBe($this->severity->getLevel());
+    expect($severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+    expect($severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+    expect($severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
 });

--- a/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
@@ -232,15 +232,25 @@ it('should find the host as admin', function () {
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
 
-    if ($presenter->response->severity !== null) {
-        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
-        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
-        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
-        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
-    }
+    expect($presenter->response->severity)->toBeInstanceOf(Severity::class);
+
+    /**
+     * @var array{
+     *  'id': int,
+     *  'name': string,
+     *  'level': int,
+     *  'type': string,
+     *  'icon': array
+     * } $severity
+     */
+    $severity = $presenter->response->severity;
+    expect($severity['id'])->toBe($this->severity->getId());
+    expect($severity['name'])->toBe($this->severity->getName());
+    expect($severity['type'])->toBe($this->severity->getTypeAsString());
+    expect($severity['level'])->toBe($this->severity->getLevel());
+    expect($severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+    expect($severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+    expect($severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
 });
 
 it('should find the host as non admin', function () {

--- a/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
@@ -22,11 +22,13 @@ declare(strict_types=1);
 
 namespace Tests\Core\Application\RealTime\UseCase\FindHost;
 
+use Core\Domain\RealTime\Model\Icon;
 use Core\Tag\RealTime\Domain\Model\Tag;
 use Core\Domain\RealTime\Model\Downtime;
 use Core\Domain\RealTime\Model\Hostgroup;
 use Tests\Core\Domain\RealTime\Model\HostTest;
 use Core\Domain\RealTime\Model\Acknowledgement;
+use Core\Severity\RealTime\Domain\Model\Severity;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Application\RealTime\UseCase\FindHost\FindHost;
@@ -40,6 +42,7 @@ use Core\Application\RealTime\Repository\ReadDowntimeRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadHostgroupRepositoryInterface;
 use Core\Security\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadAcknowledgementRepositoryInterface;
+use Core\Severity\RealTime\Application\Repository\ReadSeverityRepositoryInterface;
 
 beforeEach(function () {
     $this->repository = $this->createMock(ReadHostRepositoryInterface::class);
@@ -51,6 +54,7 @@ beforeEach(function () {
     $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
     $this->monitoringService = $this->createMock(MonitoringServiceInterface::class);
     $this->tagRepository = $this->createMock(ReadTagRepositoryInterface::class);
+    $this->severityRepository = $this->createMock(ReadSeverityRepositoryInterface::class);
 
     $this->acknowledgement = new Acknowledgement(1, 1, 10, new \DateTime('1991-09-10'));
     $this->host = HostTest::createHostModel();
@@ -60,6 +64,9 @@ beforeEach(function () {
     $this->category = new Tag(1, 'host-category-name', Tag::HOST_CATEGORY_TYPE_ID);
     $this->downtime = (new Downtime(1, 1, 10))
         ->setCancelled(false);
+
+    $icon = (new Icon())->setId(1)->setName('centreon')->setUrl('ppm/centreon.png');
+    $this->severity = new Severity(1, 'severityName', 10, Severity::HOST_SEVERITY_TYPE_ID, $icon);
 });
 
 it('FindHost not found response as admin', function () {
@@ -71,7 +78,8 @@ it('FindHost not found response as admin', function () {
         $this->downtimeRepository,
         $this->acknowledgementRepository,
         $this->monitoringService,
-        $this->tagRepository
+        $this->tagRepository,
+        $this->severityRepository
     );
 
     $this->contact
@@ -102,7 +110,8 @@ it('should present a not found response as non admin', function () {
         $this->downtimeRepository,
         $this->acknowledgementRepository,
         $this->monitoringService,
-        $this->tagRepository
+        $this->tagRepository,
+        $this->severityRepository
     );
 
     $this->contact
@@ -138,7 +147,8 @@ it('should find the host as admin', function () {
         $this->downtimeRepository,
         $this->acknowledgementRepository,
         $this->monitoringService,
-        $this->tagRepository
+        $this->tagRepository,
+        $this->severityRepository
     );
 
     $this->contact
@@ -171,6 +181,11 @@ it('should find the host as admin', function () {
         ->method('findAllByResourceAndTypeId')
         ->willReturn([$this->category]);
 
+    $this->severityRepository
+        ->expects($this->once())
+        ->method('findByResourceAndTypeId')
+        ->willReturn($this->severity);
+
     $presenter = new FindHostPresenterStub();
 
     $findHost(1, $presenter);
@@ -193,7 +208,6 @@ it('should find the host as admin', function () {
     expect($presenter->response->statusChangePercentage)->toBe($this->host->getStatusChangePercentage());
     expect($presenter->response->hasActiveChecks)->toBe($this->host->hasActiveChecks());
     expect($presenter->response->hasPassiveChecks)->toBe($this->host->hasPassiveChecks());
-    expect($presenter->response->severityLevel)->toBe($this->host->getSeverityLevel());
     expect($presenter->response->checkAttempts)->toBe($this->host->getCheckAttempts());
     expect($presenter->response->maxCheckAttempts)->toBe($this->host->getMaxCheckAttempts());
     expect($presenter->response->lastTimeUp)->toBe($this->host->getLastTimeUp());
@@ -217,6 +231,10 @@ it('should find the host as admin', function () {
     expect($presenter->response->acknowledgement['host_id'])->toBe($this->acknowledgement->getHostId());
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
+    expect($presenter->response->severity['id'])->toBe($this->severity->getId());
+    expect($presenter->response->severity['name'])->toBe($this->severity->getName());
+    expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
+    expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
 });
 
 it('should find the host as non admin', function () {
@@ -228,7 +246,8 @@ it('should find the host as non admin', function () {
         $this->downtimeRepository,
         $this->acknowledgementRepository,
         $this->monitoringService,
-        $this->tagRepository
+        $this->tagRepository,
+        $this->severityRepository
     );
 
     $this->contact
@@ -261,6 +280,11 @@ it('should find the host as non admin', function () {
         ->method('findAllByResourceAndTypeId')
         ->willReturn([$this->category]);
 
+    $this->severityRepository
+        ->expects($this->once())
+        ->method('findByResourceAndTypeId')
+        ->willReturn($this->severity);
+
     $presenter = new FindHostPresenterStub();
 
     $findHost(1, $presenter);
@@ -283,7 +307,6 @@ it('should find the host as non admin', function () {
     expect($presenter->response->statusChangePercentage)->toBe($this->host->getStatusChangePercentage());
     expect($presenter->response->hasActiveChecks)->toBe($this->host->hasActiveChecks());
     expect($presenter->response->hasPassiveChecks)->toBe($this->host->hasPassiveChecks());
-    expect($presenter->response->severityLevel)->toBe($this->host->getSeverityLevel());
     expect($presenter->response->checkAttempts)->toBe($this->host->getCheckAttempts());
     expect($presenter->response->maxCheckAttempts)->toBe($this->host->getMaxCheckAttempts());
     expect($presenter->response->lastTimeUp)->toBe($this->host->getLastTimeUp());
@@ -308,4 +331,8 @@ it('should find the host as non admin', function () {
     expect($presenter->response->acknowledgement['entry_time'])->toBe($this->acknowledgement->getEntryTime());
     expect($presenter->response->categories[0]['id'])->toBe($this->category->getId());
     expect($presenter->response->categories[0]['name'])->toBe($this->category->getName());
+    expect($presenter->response->severity['id'])->toBe($this->severity->getId());
+    expect($presenter->response->severity['name'])->toBe($this->severity->getName());
+    expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
+    expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
 });

--- a/tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
@@ -330,15 +330,17 @@ it('should find service as admin', function () {
         ->toBe($this->acknowledgement->getServiceId());
     expect($presenter->response->acknowledgement['host_id'])->toBe($this->acknowledgement->getHostId());
 
-    if ($presenter->response->severity !== null) {
-        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
-        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
-        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
-        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
-    }
+    /**
+     * @var array<string, mixed> $severity
+     */
+    $severity = $presenter->response->severity;
+    expect($severity['id'])->toBe($this->severity->getId());
+    expect($severity['name'])->toBe($this->severity->getName());
+    expect($severity['type'])->toBe($this->severity->getTypeAsString());
+    expect($severity['level'])->toBe($this->severity->getLevel());
+    expect($severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+    expect($severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+    expect($severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
 });
 
 it('FindService service found as non admin', function () {
@@ -435,13 +437,15 @@ it('FindService service found as non admin', function () {
         ->toBe($this->acknowledgement->getServiceId());
     expect($presenter->response->acknowledgement['host_id'])->toBe($this->acknowledgement->getHostId());
 
-    if ($presenter->response->severity !== null) {
-        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
-        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
-        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
-        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
-    }
+    /**
+     * @var array<string, mixed> $severity
+     */
+    $severity = $presenter->response->severity;
+    expect($severity['id'])->toBe($this->severity->getId());
+    expect($severity['name'])->toBe($this->severity->getName());
+    expect($severity['type'])->toBe($this->severity->getTypeAsString());
+    expect($severity['level'])->toBe($this->severity->getLevel());
+    expect($severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+    expect($severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+    expect($severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
 });

--- a/tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
@@ -329,10 +329,16 @@ it('should find service as admin', function () {
     expect($presenter->response->acknowledgement['service_id'])
         ->toBe($this->acknowledgement->getServiceId());
     expect($presenter->response->acknowledgement['host_id'])->toBe($this->acknowledgement->getHostId());
-    expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-    expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-    expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-    expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+
+    if ($presenter->response->severity !== null) {
+        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
+        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
+        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
+        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
+    }
 });
 
 it('FindService service found as non admin', function () {
@@ -428,8 +434,14 @@ it('FindService service found as non admin', function () {
     expect($presenter->response->acknowledgement['service_id'])
         ->toBe($this->acknowledgement->getServiceId());
     expect($presenter->response->acknowledgement['host_id'])->toBe($this->acknowledgement->getHostId());
-    expect($presenter->response->severity['id'])->toBe($this->severity->getId());
-    expect($presenter->response->severity['name'])->toBe($this->severity->getName());
-    expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
-    expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+
+    if ($presenter->response->severity !== null) {
+        expect($presenter->response->severity['id'])->toBe($this->severity->getId());
+        expect($presenter->response->severity['name'])->toBe($this->severity->getName());
+        expect($presenter->response->severity['type'])->toBe($this->severity->getTypeAsString());
+        expect($presenter->response->severity['level'])->toBe($this->severity->getLevel());
+        expect($presenter->response->severity['icon']['id'])->toBe($this->severity->getIcon()->getId());
+        expect($presenter->response->severity['icon']['name'])->toBe($this->severity->getIcon()->getName());
+        expect($presenter->response->severity['icon']['url'])->toBe($this->severity->getIcon()->getUrl());
+    }
 });

--- a/tests/php/Core/Domain/RealTime/Model/HostTest.php
+++ b/tests/php/Core/Domain/RealTime/Model/HostTest.php
@@ -118,7 +118,6 @@ class HostTest extends TestCase
             ->setIsAcknowledged(false)
             ->setActiveChecks(true)
             ->setPassiveChecks(false)
-            ->setSeverityLevel(10)
             ->setLastStatusChange(new \DateTime('1991-09-10'))
             ->setLastNotification(new \DateTime('1991-09-10'))
             ->setLastTimeUp(new \DateTime('1991-09-10'))

--- a/tests/php/Core/Domain/RealTime/Model/ServiceTest.php
+++ b/tests/php/Core/Domain/RealTime/Model/ServiceTest.php
@@ -83,7 +83,6 @@ class ServiceTest extends TestCase
             ->setIsAcknowledged(false)
             ->setActiveChecks(true)
             ->setPassiveChecks(false)
-            ->setSeverityLevel(10)
             ->setLastStatusChange(new \DateTime('1991-09-10'))
             ->setLastNotification(new \DateTime('1991-09-10'))
             ->setLastTimeOk(new \DateTime('1991-09-10'))

--- a/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
+++ b/tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
@@ -56,6 +56,7 @@ it('should present a FindSeverityResponse', function () {
     $useCase = new FindSeverity($this->repository);
 
     $icon = (new Icon())
+        ->setId(1)
         ->setName('icon-name')
         ->setUrl('ppm/icon-name.png');
 
@@ -77,6 +78,7 @@ it('should present a FindSeverityResponse', function () {
                 'level' => 50,
                 'type' => 'host',
                 'icon' => [
+                    'id' => 1,
                     'name' => 'icon-name',
                     'url' => 'ppm/icon-name.png'
                 ]


### PR DESCRIPTION
## Description

This PR follows the one regarding the listing.
This PR intends to add a new `severity` entry key for host / service detail panel.

Host detail

<img width="948" alt="image" src="https://user-images.githubusercontent.com/31647811/175970626-a328b12c-add8-42fe-8c94-b28488b669d1.png">

Service Detail

<img width="963" alt="image" src="https://user-images.githubusercontent.com/31647811/175971016-78a8e2fd-d4e0-417e-b041-d8cbaddb764c.png">


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Will be fully tested with the Feature story

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
