### PR TITLE
fix(serviceDetail): use correct value for last update time

### DIFF
--- a/www/include/monitoring/objectDetails/template/serviceDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/serviceDetails.ihtml
@@ -135,8 +135,8 @@
                             <tr class='list_two'>
                                 <td class="ListColLeft ColPopup">{$m_mon_last_update}</td>
                                 <td class="ListColLeft ColPopup
-                                    {if !isset($service_data.last_update) || ($service_data.last_update == 0)}
-                                "> {else} isTimestamp">{$service_data.last_update} {/if}</td>
+                                    {if !isset($service_data.status_update_time) || ($service_data.status_update_time == 0)}
+                                "> {else} isTimestamp">{$service_data.status_update_time} {/if}</td>
                             </tr>
                             {if $service_data.command_line}
                             <tr class='list_one'>


### PR DESCRIPTION
## Description

**CHERRY-PICK** of https://github.com/centreon/centreon/pull/11296

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [X] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

See jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
