### PR TITLE
fix display issue in hostgroup select2

### DIFF
--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -333,6 +333,11 @@ class CentreonHostgroups
         if (empty($values)) {
             return $items;
         }
+        
+        $hostgroups = [];
+        foreach ($values as $value) {
+            $hostgroups = array_merge($hostgroups, explode(',', $value));
+        }
 
         // get list of authorized hostgroups
         if (!$centreon->user->access->admin) {
@@ -347,7 +352,7 @@ class CentreonHostgroups
                     'conditions' => array(
                         'hostgroup.hg_id' => array(
                             'IN',
-                            $values
+                            $hostgroups
                         )
                     )
                 ),

--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -335,6 +335,7 @@ class CentreonHostgroups
         }
         
         $hostgroups = [];
+        // $values structure: ['1,2,3,4'], keeping the foreach in case it could have more than one index
         foreach ($values as $value) {
             $hostgroups = array_merge($hostgroups, explode(',', $value));
         }
@@ -363,16 +364,14 @@ class CentreonHostgroups
         // get list of selected hostgroups
         $listValues = '';
         $queryValues = array();
-
-        foreach ($values as $k => $v) {
-            //As it happens that $v could be like "X,Y" when two hostgroups are selected, we added a second foreach
-            $multiValues = explode(',', $v);
-            foreach ($multiValues as $item) {
-                $ids = explode('-', $item);
-                $listValues .= ':hgId_' . $ids[0] . ', ';
-                $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
-            }
+        
+        foreach ($hostgroups as $item) {
+            // the below explode may not be useful 
+            $ids = explode('-', $item);
+            $listValues .= ':hgId_' . $ids[0] . ', ';
+            $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
         }
+        
         $listValues = rtrim($listValues, ', ');
         $query = 'SELECT hg_id, hg_name FROM hostgroup WHERE hg_id IN (' . $listValues . ') ORDER BY hg_name ';
         $stmt = $this->DB->prepare($query);

--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -333,7 +333,7 @@ class CentreonHostgroups
         if (empty($values)) {
             return $items;
         }
-        
+
         $hostgroups = [];
         // $values structure: ['1,2,3,4'], keeping the foreach in case it could have more than one index
         foreach ($values as $value) {
@@ -364,14 +364,14 @@ class CentreonHostgroups
         // get list of selected hostgroups
         $listValues = '';
         $queryValues = array();
-        
+
         foreach ($hostgroups as $item) {
-            // the below explode may not be useful 
+            // the below explode may not be useful
             $ids = explode('-', $item);
             $listValues .= ':hgId_' . $ids[0] . ', ';
             $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
         }
-        
+
         $listValues = rtrim($listValues, ', ');
         $query = 'SELECT hg_id, hg_name FROM hostgroup WHERE hg_id IN (' . $listValues . ') ORDER BY hg_name ';
         $stmt = $this->DB->prepare($query);


### PR DESCRIPTION
## Description

when you use a widget such as host-monitoring or service-monitoring, you have a select2 for hostgroups. If you're a user that is not admin, and you select multiple hostgroups. The result will be filtered as expected but if you go back to the parameter edition of the widget, you'll only see one hostgroup displayed. If you click on the select2, you'll see that you still have multiple hostgroups selected but only the first one is displayed. 

This is just a visual bug due to bad data formatting in the backend. It may also affect other select2 such as the servicegroup one. (will test later)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

without the patch:
![select2_hg_bug](https://user-images.githubusercontent.com/7352865/176356968-8771e724-fddd-4645-a0e2-f574044fb3a7.gif)

1. create 3 hostgroups (you need more than one at least)
2. export your configuration (not mandatory but do it anyway)
3. log in with a non admin user (they can see all resources, access all menus, we don't care, they just need to not be admin)
4. add a host-monitoring widget
5. in the widget parameter, select more than one hostgroup in the hostgroup filter
6. save the widget parameter
7. go back to the widget parameter, you'll only have 1 hostgroup displayed
8. click on the select2, you'll notice that only 1 hostgroup was displayed but all the hostgroups you've selected are still selected

with the patch

you don't need to repeat steps from 1 to 6
![select2_hg_fix](https://user-images.githubusercontent.com/7352865/176356983-28d9936f-c34b-44b8-b555-c756b5bdcc91.gif)

7. go back to the widget parameter, you'll have all your hostgroups displayed and when you click on the select2 they still are selected

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
