### PR TITLE
fix(widget): add empty value for poller filter

### DIFF
--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -89,6 +89,7 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
                     );
                 }
 
+                $tab = array(null => null);
                 while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
                     $tab[$record['id']] = $record['name'];
                 }

--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -89,7 +89,7 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
                     );
                 }
 
-                $tab = [];
+                $tab = [null => null];
                 while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
                     $tab[$record['id']] = $record['name'];
                 }

--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -89,7 +89,7 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
                     );
                 }
 
-                $tab = array(null => null);
+                $tab = [];
                 while (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
                     $tab[$record['id']] = $record['name'];
                 }


### PR DESCRIPTION
## Description

Fix the poller filter in the widget preferences.
We have to let the user select an empty line.



**Fixes** MON-14174

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

