### PR TITLE
Clean(platform): Remove deprecated switch in encodePass() method

### DIFF
--- a/src/CentreonLegacy/Core/Utils/Utils.php
+++ b/src/CentreonLegacy/Core/Utils/Utils.php
@@ -216,7 +216,7 @@ class Utils
                 $encodePassword = password_hash($password, PASSWORD_BCRYPT);
                 break;
             default:
-                $encodePassword .= 'md5__' . md5($password);
+                $encodePassword = password_hash($password, PASSWORD_BCRYPT);
                 break;
         }
         return $encodePassword;

--- a/src/CentreonLegacy/Core/Utils/Utils.php
+++ b/src/CentreonLegacy/Core/Utils/Utils.php
@@ -208,6 +208,10 @@ class Utils
     public function encodePass($password, $algo = 'md5')
     {
         $encodePassword = '';
+        /*
+         * Users passwords must be verified as md5 encrypted
+         * before they can be encrypted as bcrypt.
+         */
         switch ($algo) {
             case 'md5':
                 $encodePassword .= 'md5__' . md5($password);

--- a/src/CentreonLegacy/Core/Utils/Utils.php
+++ b/src/CentreonLegacy/Core/Utils/Utils.php
@@ -212,9 +212,6 @@ class Utils
             case 'md5':
                 $encodePassword .= 'md5__' . md5($password);
                 break;
-            case PASSWORD_BCRYPT:
-                $encodePassword = password_hash($password, PASSWORD_BCRYPT);
-                break;
             default:
                 $encodePassword = password_hash($password, PASSWORD_BCRYPT);
                 break;

--- a/src/CentreonLegacy/Core/Utils/Utils.php
+++ b/src/CentreonLegacy/Core/Utils/Utils.php
@@ -212,9 +212,6 @@ class Utils
             case 'md5':
                 $encodePassword .= 'md5__' . md5($password);
                 break;
-            case 'sha1':
-                $encodePassword .= 'sha1__' . sha1($password);
-                break;
             case PASSWORD_BCRYPT:
                 $encodePassword = password_hash($password, PASSWORD_BCRYPT);
                 break;


### PR DESCRIPTION
## Description

As new password encryption use new algo, md5 and sha1 are not useful anymore but we prefer to keep md5 for now.

**Fixes** # MON-12738

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
