### PR TITLE
fix (trap): Removal of the restriction on the uniqueness of the OID of a trap

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9079,10 +9079,6 @@ msgstr "Compruebe si el servicio está parado"
 msgid "Preexec definition"
 msgstr "Definiendo el comando PREEXEC"
 
-#: centreon-web/www/include/configuration/configObject/traps/formTraps.php:360
-msgid "The same OID element already exists"
-msgstr "El mismo OID ya existe."
-
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:368
 msgid "Advanced matching rules"
 msgstr "Reglas de correspondencia avanzadas"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9564,10 +9564,6 @@ msgstr "Contrôle si le service est en plage de maintenance"
 msgid "Preexec definition"
 msgstr "Définition de la commande PREEXEC"
 
-#: centreon-web/www/include/configuration/configObject/traps/formTraps.php:360
-msgid "The same OID element already exists"
-msgstr "Le même OID existe déjà"
-
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:368
 msgid "Advanced matching rules"
 msgstr "Règles de correspondance avancées"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -10237,10 +10237,6 @@ msgstr "Checagem de Manutenção"
 msgid "Preexec definition"
 msgstr "Definição de pré-execução"
 
-#: centreon-web/www/include/configuration/configObject/traps/formTraps.php:376
-msgid "The same OID element already exists"
-msgstr "O mesmo OID já existe"
-
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:384
 msgid "Advanced matching rules"
 msgstr "Regras de correspondencia avançada"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -10238,10 +10238,6 @@ msgstr "Checagem de Manutenção"
 msgid "Preexec definition"
 msgstr "Definição de pré-execução"
 
-#: centreon-web/www/include/configuration/configObject/traps/formTraps.php:376
-msgid "The same OID element already exists"
-msgstr "O mesmo OID já existe"
-
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:384
 msgid "Advanced matching rules"
 msgstr "Regras de correspondencia avançada"

--- a/www/class/centreonTraps.class.php
+++ b/www/class/centreonTraps.class.php
@@ -172,37 +172,6 @@ class CentreonTraps
 
     /**
      *
-     * tests if trap already exists
-     * @param $oid
-     */
-    public function testTrapExistence($oid = null)
-    {
-        if ($oid !== null && $this->testOidFormat($oid) === true) {
-            $id = null;
-            if (isset($this->form)) {
-                $id = $this->form->getSubmitValue('traps_id');
-            }
-            $query = "SELECT traps_oid, traps_id FROM traps WHERE traps_oid = :oid ";
-
-            $statement = $this->db->prepare($query);
-            $statement->bindValue(':oid', $oid, \PDO::PARAM_STR);
-            $statement->execute();
-
-            $trap = $statement->fetch(\PDO::FETCH_ASSOC);
-
-            /**
-             * If the trap already existing return false to trigger an error with the form validation rule
-             */
-            if ($statement->rowCount() >= 1 && $trap["traps_id"] != $id) {
-                return false;
-            } else {
-                return true;
-            }
-        }
-    }
-
-    /**
-     *
      * Delete Traps
      * @param $traps
      */

--- a/www/include/configuration/configObject/traps/formTraps.php
+++ b/www/include/configuration/configObject/traps/formTraps.php
@@ -380,10 +380,8 @@ $form->addRule('traps_name', _("Compulsory Name"), 'required');
 $form->addRule('traps_oid', _("Compulsory Name"), 'required');
 $form->addRule('manufacturer_id', _("Compulsory Name"), 'required');
 $form->addRule('traps_args', _("Compulsory Name"), 'required');
-$form->registerRule('exist', 'callback', [$trapObj, "testTrapExistence"]);
 $form->registerRule('wellFormated', 'callback', [$trapObj, "testOidFormat"]);
 $form->addRule('traps_oid', _("Bad OID Format"), 'wellFormated');
-$form->addRule('traps_oid', _("The same OID element already exists"), 'exist');
 $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _("Required fields"));
 
 /*


### PR DESCRIPTION
## Description

Currently, an error appears when we try to save an existing trap because a test is performed on the uniqueness of the OID.
This PR aims to remove the restriction on the uniqueness of the OID of a trap.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Open an existing trap and try to save it. No error messages should appear.

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
