### PR TITLE
fix(web): enable the deletion of text parameters on contacts

### DIFF
--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -694,7 +694,6 @@ function updateContact_MC($contact_id = null)
         return;
     }
 
-    $ret = array();
     $ret = $form->getSubmitValues();
 
     // Remove all parameters that have an empty value in order to keep

--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -697,7 +697,8 @@ function updateContact_MC($contact_id = null)
     $ret = array();
     $ret = $form->getSubmitValues();
 
-    // Remove all parameters that have an empty value in order to keep the contact properties that have not been modified
+    // Remove all parameters that have an empty value in order to keep
+    // the contact properties that have not been modified
     foreach ($ret as $name => $value) {
         if (is_string($value) && empty($value)) {
             unset($ret[$name]);

--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -696,6 +696,14 @@ function updateContact_MC($contact_id = null)
 
     $ret = array();
     $ret = $form->getSubmitValues();
+
+    // Remove all parameters that have an empty value in order to keep the contact properties that have not been modified
+    foreach ($ret as $name => $value) {
+        if (is_string($value) && empty($value)) {
+            unset($ret[$name]);
+        }
+    }
+
     $bindParams = sanitizeFormContactParameters($ret);
     $rq = "UPDATE contact SET ";
     foreach (array_keys($bindParams) as $token) {
@@ -1280,15 +1288,13 @@ function sanitizeFormContactParameters(array $ret): array
             case 'contact_address5':
             case 'contact_address6':
                 if (
-                    $inputValue = filter_var(
+                    ($inputValue = filter_var(
                         $inputValue ?? "",
                         FILTER_SANITIZE_STRING,
                         FILTER_FLAG_NO_ENCODE_QUOTES
-                    )
+                    )) !== false
                 ) {
-                    if (!empty($inputValue)) {
-                        $bindParams[':' . $inputName] = [\PDO::PARAM_STR => $inputValue];
-                    }
+                    $bindParams[':' . $inputName] = [\PDO::PARAM_STR => $inputValue];
                 }
                 break;
         }


### PR DESCRIPTION
## Description

It was impossible to undefined contact parameters when they were already defined.

**Fixes** MON-14206

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)