### PR TITLE
fix(clapi): Don't check password policy while adding contact template

### DIFF
--- a/tests/clapi_export/clapi-configuration.txt
+++ b/tests/clapi_export/clapi-configuration.txt
@@ -552,7 +552,7 @@ ENGINECFG;setparam;Centreon Engine Central;log_level_comments;err
 ENGINECFG;setparam;Centreon Engine Central;log_level_macros;err
 ENGINECFG;setparam;Centreon Engine Central;log_level_process;info
 ENGINECFG;setparam;Centreon Engine Central;log_level_runtime;err
-CONTACTTPL;ADD;contact_template;contact_template;;$2y$10$Yf78oIppk6wC7hMtDd0TKeXByb1kVD5IGvAEF/g.F4KtiMSbXvpT.;0;1;;local
+CONTACTTPL;ADD;contact_template;contact_template;;0;1;;local
 CONTACTTPL;setparam;contact_template;hostnotifopt;n
 CONTACTTPL;setparam;contact_template;servicenotifopt;n
 CONTACTTPL;setparam;contact_template;contact_js_effects;0
@@ -566,7 +566,7 @@ CONTACTTPL;setparam;contact_template;contact_activate;1
 CONTACTTPL;setparam;contact_template;show_deprecated_pages;0
 CONTACTTPL;setparam;contact_template;contact_ldap_last_sync;0
 CONTACTTPL;setparam;contact_template;contact_ldap_required_sync;0
-CONTACTTPL;ADD;test_name;test_contact-template;;$2y$10$BqnZdxhI2wz1Ot/exXd73eOngqA2RPeBmjxSSyEzSygFXo3L9guAW;0;1;;local
+CONTACTTPL;ADD;test_name;test_contact-template;;0;1;;local
 CONTACTTPL;setparam;test_contact-template;hostnotifopt;n
 CONTACTTPL;setparam;test_contact-template;servicenotifopt;n
 CONTACTTPL;setparam;test_contact-template;contact_js_effects;0

--- a/tests/rest_api/rest_api.postman_collection.json
+++ b/tests/rest_api/rest_api.postman_collection.json
@@ -12122,7 +12122,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"action\": \"add\",\n  \"object\": \"contacttpl\",\n  \"values\": \"test_name;test_alias;test@localhost;Centreon@2022;0;0;en_US;ldap\"\n}"
+							"raw": "{\n  \"action\": \"add\",\n  \"object\": \"contacttpl\",\n  \"values\": \"test_name;test_alias;test@localhost;0;0;en_US;ldap\"\n}"
 						},
 						"url": {
 							"raw": "http://{{url}}/centreon/api/index.php?action=action&object=centreon_clapi",
@@ -12986,7 +12986,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"action\": \"add\",\n  \"object\": \"contacttpl\",\n  \"values\": \"{{ctpl_name2}};{{ctpl_alias2}};test@localhost;Centreon@2022;0;0;en_US;ldap\"\n}"
+							"raw": "{\n  \"action\": \"add\",\n  \"object\": \"contacttpl\",\n  \"values\": \"{{ctpl_name2}};{{ctpl_alias2}};test@localhost;0;0;en_US;ldap\"\n}"
 						},
 						"url": {
 							"raw": "http://{{url}}/centreon/api/index.php?action=action&object=centreon_clapi",

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -286,7 +286,7 @@ class CentreonContact extends CentreonObject
     }
 
     /**
-     * Initiliaze user information
+     * Initialize user information
      *
      * @param array<int,mixed> $params
      */

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -264,6 +264,7 @@ class CentreonContact extends CentreonObject
         if (count($params) < $this->nbOfCompulsoryParams) {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
+        $this->addParams = [];
         $this->initUniqueField($params);
         $this->initUserInformation($params);
         $this->initPassword($params);

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -114,6 +114,11 @@ class CentreonContact extends CentreonObject
     protected $timezoneObject;
 
     /**
+     * @var array<string,mixed>
+     */
+    protected $addParams = [];
+
+    /**
      * Constructor
      *
      * @return void
@@ -259,52 +264,108 @@ class CentreonContact extends CentreonObject
         if (count($params) < $this->nbOfCompulsoryParams) {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
+        $this->initUniqueField($params);
+        $this->initUserInformation($params);
+        $this->initPassword($params);
+        $this->initUserAccess($params);
+        $this->initLang($params);
+        $this->initAuthenticationType($params);
 
-        $addParams = array();
-        $params[self::ORDER_UNIQUENAME] = str_replace(" ", "_", $params[self::ORDER_UNIQUENAME]);
-        $addParams[$this->object->getUniqueLabelField()] = $params[self::ORDER_UNIQUENAME];
-        $addParams['contact_name'] = $this->checkIllegalChar($params[self::ORDER_NAME]);
-        $addParams['contact_email'] = $params[self::ORDER_MAIL];
+        $this->params = array_merge($this->params, $this->addParams);
+        $this->checkParameters();
+    }
 
-        if (password_needs_rehash($params[self::ORDER_PASS], \CentreonAuth::PASSWORD_HASH_ALGORITHM)) {
+    /**
+     * Initialize Unique Field
+     *
+     * @param array<int,mixed> $params
+     */
+    protected function initUniqueField(array $params): void
+    {
+        $this->addParams[$this->object->getUniqueLabelField()] = str_replace(" ", "_", $params[static::ORDER_UNIQUENAME]);
+    }
+
+    /**
+     * Initiliaze user information
+     *
+     * @param array<int,mixed> $params
+     */
+    protected function initUserInformation(array $params): void
+    {
+        $this->addParams['contact_name'] = $this->checkIllegalChar($params[static::ORDER_NAME]);
+        $this->addParams['contact_email'] = $params[static::ORDER_MAIL];
+    }
+
+    /**
+     * Initialize password
+     *
+     * @param array<int,mixed> $params
+     */
+    protected function initPassword(array $params): void
+    {
+        if (password_needs_rehash($params[static::ORDER_PASS], \CentreonAuth::PASSWORD_HASH_ALGORITHM)) {
             $contact = new \CentreonContact($this->db);
             try {
-                $contact->respectPasswordPolicyOrFail($params[self::ORDER_PASS], null);
+                $contact->respectPasswordPolicyOrFail($params[static::ORDER_PASS], null);
             } catch (\Throwable $e) {
                 throw new CentreonClapiException($e->getMessage(), $e->getCode(), $e);
             }
-            $addParams['contact_passwd'] = password_hash(
-                $params[self::ORDER_PASS],
+            $this->addParams['contact_passwd'] = password_hash(
+                $params[static::ORDER_PASS],
                 \CentreonAuth::PASSWORD_HASH_ALGORITHM
             );
         } else {
-            $addParams['contact_passwd'] = $params[self::ORDER_PASS];
+            $this->addParams['contact_passwd'] = $params[static::ORDER_PASS];
         }
+    }
 
-        $addParams['contact_admin'] = $params[self::ORDER_ADMIN];
-        if ($addParams['contact_admin'] == '') {
-            $addParams['contact_admin'] = '0';
+    /**
+     * Initialize user access
+     *
+     * @param array<int,mixed> $params
+     */
+    protected function initUserAccess(array $params): void
+    {
+        $this->addParams['contact_admin'] = $params[static::ORDER_ADMIN];
+        if ($this->addParams['contact_admin'] == '') {
+            $this->addParams['contact_admin'] = '0';
         }
-        $addParams['contact_oreon'] = $params[self::ORDER_ACCESS];
-        if ($addParams['contact_oreon'] == '') {
-            $addParams['contact_oreon'] = '1';
+        $this->addParams['contact_oreon'] = $params[static::ORDER_ACCESS];
+        if ($this->addParams['contact_oreon'] == '') {
+            $this->addParams['contact_oreon'] = '1';
         }
+    }
+
+    /**
+     * Initialize user langage
+     *
+     * @param array<int,mixed> $params
+     */
+    protected function initLang(array $params): void
+    {
         if (
-            empty($params[self::ORDER_LANG])
-            || strtolower($params[self::ORDER_LANG]) === "browser"
-            || strtoupper(substr($params[self::ORDER_LANG], -6)) === '.UTF-8'
+            empty($params[static::ORDER_LANG])
+            || strtolower($params[static::ORDER_LANG]) === "browser"
+            || strtoupper(substr($params[static::ORDER_LANG], -6)) === '.UTF-8'
         ) {
-            $completeLanguage = $params[self::ORDER_LANG];
+            $completeLanguage = $params[static::ORDER_LANG];
         } else {
-            $completeLanguage = $params[self::ORDER_LANG] . '.UTF-8';
+            $completeLanguage = $params[static::ORDER_LANG] . '.UTF-8';
         }
         if ($this->checkLang($completeLanguage) == false) {
-            throw new CentreonClapiException(self::UNKNOWN_LOCALE);
+            throw new CentreonClapiException(static::UNKNOWN_LOCALE);
         }
-        $addParams['contact_lang'] = $completeLanguage;
-        $addParams['contact_auth_type'] = $params[self::ORDER_AUTHTYPE];
-        $this->params = array_merge($this->params, $addParams);
-        $this->checkParameters();
+        $this->addParams['contact_lang'] = $completeLanguage;
+    }
+
+    /**
+     * Initialize authentication type
+     *
+     * @param array<int, mixed> $params
+     */
+    protected function initAuthenticationType(array $params): void
+    {
+        $this->addParams['contact_auth_type'] = $params[static::ORDER_AUTHTYPE];
     }
 
     /**

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -282,7 +282,11 @@ class CentreonContact extends CentreonObject
      */
     protected function initUniqueField(array $params): void
     {
-        $this->addParams[$this->object->getUniqueLabelField()] = str_replace(" ", "_", $params[static::ORDER_UNIQUENAME]);
+        $this->addParams[$this->object->getUniqueLabelField()] = str_replace(
+            " ",
+            "_",
+            $params[static::ORDER_UNIQUENAME]
+        );
     }
 
     /**

--- a/www/class/centreon-clapi/centreonContactTemplate.class.php
+++ b/www/class/centreon-clapi/centreonContactTemplate.class.php
@@ -85,6 +85,7 @@ class CentreonContactTemplate extends CentreonContact
         if (count($params) < $this->nbOfCompulsoryParams) {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
+        $this->addParams = [];
         $this->initUniqueField($params);
         $this->initUserInformation($params);
         $this->initUserAccess($params);

--- a/www/class/centreon-clapi/centreonContactTemplate.class.php
+++ b/www/class/centreon-clapi/centreonContactTemplate.class.php
@@ -44,6 +44,14 @@ class CentreonContactTemplate extends CentreonContact
         'TP'
     );
 
+    public const ORDER_NAME = 0;
+    public const ORDER_UNIQUENAME = 1;
+    public const ORDER_MAIL = 2;
+    public const ORDER_ADMIN = 3;
+    public const ORDER_ACCESS = 4;
+    public const ORDER_LANG = 5;
+    public const ORDER_AUTHTYPE = 6;
+
     /**
      * Constructor
      *
@@ -55,5 +63,35 @@ class CentreonContactTemplate extends CentreonContact
         $this->params['contact_register'] = 0;
         $this->register = 0;
         $this->action = "CONTACTTPL";
+        $this->insertParams = [
+            'contact_name',
+            'contact_alias',
+            'contact_email',
+            'contact_admin',
+            'contact_oreon',
+            'contact_lang',
+            'contact_auth_type'
+        ];
+        $this->nbOfCompulsoryParams = count($this->insertParams);
+    }
+
+    /**
+     * @param $parameters
+     * @throws CentreonClapiException
+     */
+    public function initInsertParameters($parameters)
+    {
+        $params = explode($this->delim, $parameters);
+        if (count($params) < $this->nbOfCompulsoryParams) {
+            throw new CentreonClapiException(self::MISSINGPARAMETER);
+        }
+        $this->initUniqueField($params);
+        $this->initUserInformation($params);
+        $this->initUserAccess($params);
+        $this->initLang($params);
+        $this->initAuthenticationType($params);
+
+        $this->params = array_merge($this->params, $this->addParams);
+        $this->checkParameters();
     }
 }


### PR DESCRIPTION
## Description

This PR intends to fix a bug where we check password policy while adding contact template.

```
# centreon -u admin -p Centreon\!2021 -o CONTACTTPL -a ADD -v "user;user;user@mail.com;;1;1;en_US;local"
Your password must be 12 characters long and must contain : uppercase characters, lowercase characters, numbers, special characters among '@$!%*?&'.
```

contact template doesn't have password, so we remove this field from the command parameters, and also remove the password policy check for object CONTACTTPL

**Fixes** # MON-13935

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
