### PR TITLE
Fix(platform): Issue with cross databases query when the name contains some characters

### DIFF
--- a/www/install/steps/process/installConfigurationDb.php
+++ b/www/install/steps/process/installConfigurationDb.php
@@ -92,7 +92,7 @@ try {
         $db->exec("CREATE DATABASE " . $parameters['db_configuration']);
 
         //Create table
-        $db->exec('use ' . $parameters['db_configuration']);
+        $db->exec('use `' . $parameters['db_configuration'] . '`');
         $result = splitQueries('../../createTables.sql', ';', $db, '../../tmp/createTables');
         if ("0" != $result) {
             $return['msg'] = $result;


### PR DESCRIPTION
## Description

In Centreon Web and some modules, there are some cross databases queries. If a database name contains some characters like dash the query is on error. This database name needs to be surrounded by backquoted.

This occurs in installation, it doesn’t accept DB names that has “-” inside of them for example: centreon-conf instead of centreon.

**Fixes** # MON-14216

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
