### PR TITLE
enh(resources): use resource types filtering as 'providers'

### DIFF
--- a/config/packages/Centreon.yaml
+++ b/config/packages/Centreon.yaml
@@ -227,6 +227,8 @@ services:
             calls:
                 - method: setSqlRequestTranslator
                   arguments: ['@sqlRequestTranslator']
+        Core\Domain\RealTime\ResourceTypeInterface:
+            tags: ['monitoring.resource.type']
         Core\Infrastructure\RealTime\Hypermedia\HypermediaProviderInterface:
             tags: ['realtime.hypermedia']
         Core\Security\Application\ProviderConfiguration\Repository\ReadProviderConfigurationsRepositoryInterface:
@@ -253,7 +255,6 @@ services:
     Core\Security\Infrastructure\Api\FindProviderConfigurations\FindProviderConfigurationsPresenter:
         arguments: [!tagged_iterator 'authentication.provider.presenters']
 
-
     Centreon\Infrastructure\Monitoring\Resource\ResourceRepositoryRDB:
         calls:
             - method: setSqlRequestTranslator
@@ -261,10 +262,6 @@ services:
             - method: setProviders
               arguments: [!tagged_iterator 'monitoring.resource.providers']
 
-    Centreon\Infrastructure\Monitoring\Resource\DbReadResourceRepository:
-        calls:
-            - method: setSqlRequestTranslator
-              arguments: ['@sqlRequestTranslator']
 
     Core\Infrastructure\RealTime\Hypermedia\HypermediaCreator:
         class: Core\Infrastructure\RealTime\Hypermedia\HypermediaCreator

--- a/config/packages/validator/validation.yaml
+++ b/config/packages/validator/validation.yaml
@@ -187,13 +187,10 @@ Centreon\Domain\Monitoring\ResourceFilter:
             - Type:
                 type: array
                 groups: [Default]
-            - Choice:
-                choices:
-                    - service
-                    - host
-                    - metaservice
-                multiple: true
-                groups: [Default]
+            - All:
+                - Type:
+                    type: string
+                    groups: [Default]
         states:
             - Type:
                 type: array

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,6 +33,8 @@ services:
     _instanceof:
         Security\Domain\Authentication\Interfaces\ProviderInterface:
             tags: ['authentication.providers']
+        Core\Domain\RealTime\ResourceTypeInterface:
+            tags: ['monitoring.resource.type']
 
     EventSubscriber\:
         resource: '../src/EventSubscriber/*'
@@ -90,3 +92,14 @@ services:
 
     Security\Domain\Authentication\Model\ProviderFactory:
         arguments: [!tagged_iterator 'authentication.providers']
+
+    Centreon\Infrastructure\Monitoring\Resource\DbReadResourceRepository:
+        arguments:
+            $resourceTypes: !tagged_iterator 'monitoring.resource.type'
+        calls:
+            - method: setSqlRequestTranslator
+              arguments: ['@sqlRequestTranslator']
+
+    Centreon\Application\Controller\MonitoringResourceController:
+        arguments:
+            $resourceTypes: !tagged_iterator 'monitoring.resource.type'

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16916,3 +16916,6 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories d'h�
 
 msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
 msgstr "Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera tronqué à l'enregistrement"
+
+msgid "Unsupported resource type provided"
+msgstr "Type de resource fourni non supporté"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16917,5 +16917,5 @@ msgstr "Une erreur s'est produite lors de la récupération des catégories d'h�
 msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
 msgstr "Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera tronqué à l'enregistrement"
 
-msgid "Unsupported resource type provided"
-msgstr "Type de resource fourni non supporté"
+msgid "Resource type provided not supported"
+msgstr "Type de ressource fourni non supporté"

--- a/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
+++ b/src/Centreon/Infrastructure/Monitoring/Resource/DbReadResourceRepository.php
@@ -139,7 +139,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
      */
     public function filterByAccessGroups(?array $accessGroups): ResourceRepositoryInterface
     {
-        $this->accessGroups = $accessGroups === null ? [] : $accessGroups;
+        $this->accessGroups = $accessGroups ?? [];
         return $this;
     }
 
@@ -328,7 +328,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements Resource
     {
         return array_filter(
             $resources,
-            fn(ResourceEntity $resource) => $resource->hasGraph(),
+            fn (ResourceEntity $resource) => $resource->hasGraph(),
         );
     }
 

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/AbstractResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/AbstractResourceType.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Domain\RealTime\Model\ResourceTypes;
+
+use Core\Domain\RealTime\ResourceTypeInterface;
+
+abstract class AbstractResourceType implements ResourceTypeInterface
+{
+    protected string $type = '';
+
+    protected int $id = -1;
+
+    /**
+     * @inheritDoc
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isValidFor(string $type): bool
+    {
+        return $type === $this->type;
+    }
+}

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/AbstractResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/AbstractResourceType.php
@@ -26,7 +26,7 @@ use Core\Domain\RealTime\ResourceTypeInterface;
 
 abstract class AbstractResourceType implements ResourceTypeInterface
 {
-    protected string $type = '';
+    protected string $name = '';
 
     protected int $id = -1;
 
@@ -41,16 +41,16 @@ abstract class AbstractResourceType implements ResourceTypeInterface
     /**
      * @inheritDoc
      */
-    public function getType(): string
+    public function getName(): string
     {
-        return $this->type;
+        return $this->name;
     }
 
     /**
      * @inheritDoc
      */
-    public function isValidFor(string $type): bool
+    public function isValidFor(string $name): bool
     {
-        return $type === $this->type;
+        return $name === $this->name;
     }
 }

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/HostResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/HostResourceType.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Domain\RealTime\Model\ResourceTypes;
+
+class HostResourceType extends AbstractResourceType
+{
+    /**
+     * @var string $type
+     */
+    protected string $type = 'host';
+
+    /**
+     * @var integer $id
+     */
+    protected int $id = 1;
+}

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/HostResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/HostResourceType.php
@@ -24,13 +24,16 @@ namespace Core\Domain\RealTime\Model\ResourceTypes;
 
 class HostResourceType extends AbstractResourceType
 {
+    public const HOST_RESOURCE_TYPE_NAME = 'host',
+                 HOST_RESOURCE_TYPE_ID = 1;
+
     /**
-     * @var string $type
+     * @var string $name
      */
-    protected string $type = 'host';
+    protected string $name = self::HOST_RESOURCE_TYPE_NAME;
 
     /**
      * @var integer $id
      */
-    protected int $id = 1;
+    protected int $id = self::HOST_RESOURCE_TYPE_ID;
 }

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/MetaServiceResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/MetaServiceResourceType.php
@@ -24,13 +24,16 @@ namespace Core\Domain\RealTime\Model\ResourceTypes;
 
 class MetaServiceResourceType extends AbstractResourceType
 {
+    public const META_SERVICE_RESOURCE_TYPE_NAME = 'metaservice',
+                 META_SERVICE_RESOURCE_TYPE_ID = 2;
+
     /**
-     * @var string $type
+     * @var string $name
      */
-    protected string $type = 'metaservice';
+    protected string $name = self::META_SERVICE_RESOURCE_TYPE_NAME;
 
     /**
      * @var integer $id
      */
-    protected int $id = 2;
+    protected int $id = self::META_SERVICE_RESOURCE_TYPE_ID;
 }

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/MetaServiceResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/MetaServiceResourceType.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Domain\RealTime\Model\ResourceTypes;
+
+class MetaServiceResourceType extends AbstractResourceType
+{
+    /**
+     * @var string $type
+     */
+    protected string $type = 'metaservice';
+
+    /**
+     * @var integer $id
+     */
+    protected int $id = 2;
+}

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/ServiceResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/ServiceResourceType.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Domain\RealTime\Model\ResourceTypes;
+
+class ServiceResourceType extends AbstractResourceType
+{
+    /**
+     * @var string $type
+     */
+    protected string $type = 'service';
+
+    /**
+     * @var integer $id
+     */
+    protected int $id = 0;
+}

--- a/src/Core/Domain/RealTime/Model/ResourceTypes/ServiceResourceType.php
+++ b/src/Core/Domain/RealTime/Model/ResourceTypes/ServiceResourceType.php
@@ -24,13 +24,15 @@ namespace Core\Domain\RealTime\Model\ResourceTypes;
 
 class ServiceResourceType extends AbstractResourceType
 {
+    public const SERVICE_RESOURCE_TYPE_NAME = 'service',
+                 SERVICE_RESOURCE_TYPE_ID = 0;
     /**
-     * @var string $type
+     * @var string $name
      */
-    protected string $type = 'service';
+    protected string $name = self::SERVICE_RESOURCE_TYPE_NAME;
 
     /**
      * @var integer $id
      */
-    protected int $id = 0;
+    protected int $id = self::SERVICE_RESOURCE_TYPE_ID;
 }

--- a/src/Core/Domain/RealTime/ResourceTypeInterface.php
+++ b/src/Core/Domain/RealTime/ResourceTypeInterface.php
@@ -32,7 +32,7 @@ interface ResourceTypeInterface
     /**
      * @return string
      */
-    public function getType(): string;
+    public function getName(): string;
 
     /**
      * @param string $type

--- a/src/Core/Domain/RealTime/ResourceTypeInterface.php
+++ b/src/Core/Domain/RealTime/ResourceTypeInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Core\Domain\RealTime;
+
+interface ResourceTypeInterface
+{
+    /**
+     * @return integer
+     */
+    public function getId(): int;
+
+    /**
+     * @return string
+     */
+    public function getType(): string;
+
+    /**
+     * @param string $type
+     * @return bool
+     */
+    public function isValidFor(string $type): bool;
+}


### PR DESCRIPTION
First PR of the integration of Anomaly Detection services into Resource Status.
This PR intends to use resources types as 'providers' to ease the integration of the type 'anomaly-detection'

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Fully tested afterwards

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
