### PR TITLE
enh(openid): handle authorization management on authentication (#11320)

### DIFF
--- a/src/Core/Contact/Application/Repository/WriteContactGroupRepositoryInterface.php
+++ b/src/Core/Contact/Application/Repository/WriteContactGroupRepositoryInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Application\Repository;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Contact\Domain\Model\ContactGroup;
+
+interface WriteContactGroupRepositoryInterface
+{
+    /**
+     * Delete all contact groups for a given user
+     *
+     * @param ContactInterface $user
+     */
+    public function deleteContactGroupsForUser(ContactInterface $user): void;
+
+    /**
+     * Insert a contact group for a given user
+     *
+     * @param ContactInterface $user
+     * @param ContactGroup $contactGroup
+     */
+    public function insertContactGroupForUser(ContactInterface $user, ContactGroup $contactGroup): void;
+}

--- a/src/Core/Contact/Infrastructure/Repository/DbWriteContactGroupRepository.php
+++ b/src/Core/Contact/Infrastructure/Repository/DbWriteContactGroupRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Contact\Infrastructure\Repository;
+
+use Core\Contact\Domain\Model\ContactGroup;
+use Centreon\Infrastructure\DatabaseConnection;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Core\Contact\Application\Repository\WriteContactGroupRepositoryInterface;
+
+class DbWriteContactGroupRepository extends AbstractRepositoryDRB implements WriteContactGroupRepositoryInterface
+{
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteContactGroupsForUser(ContactInterface $user): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            "DELETE FROM `:db`.contactgroup_contact_relation WHERE contact_contact_id = :userId"
+        ));
+        $statement->bindValue(':userId', $user->getId(), \PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insertContactGroupForUser(ContactInterface $user, ContactGroup $contactGroup): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            "INSERT INTO contactgroup_contact_relation VALUES (:userId, :contactGroupId)"
+        ));
+        $statement->bindValue(':userId', $user->getId(), \PDO::PARAM_INT);
+        $statement->bindValue(':contactGroupId', $contactGroup->getId(), \PDO::PARAM_INT);
+        $statement->execute();
+    }
+}

--- a/src/Core/Security/Application/Repository/WriteAccessGroupRepositoryInterface.php
+++ b/src/Core/Security/Application/Repository/WriteAccessGroupRepositoryInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security\Application\Repository;
+
+use Core\Security\Domain\AccessGroup\Model\AccessGroup;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+
+interface WriteAccessGroupRepositoryInterface
+{
+    /**
+     * Delete all access groups for a given user
+     *
+     * @param ContactInterface $user
+     */
+    public function deleteAccessGroupsForUser(ContactInterface $user): void;
+
+    /**
+     * Insert access groups for a given user
+     *
+     * @param ContactInterface $user
+     * @param AccessGroup[] $accessGroups
+     */
+    public function insertAccessGroupsForUser(ContactInterface $user, array $accessGroups): void;
+}

--- a/src/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
+++ b/src/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
@@ -28,20 +28,23 @@ use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Menu\Model\Page;
 use Security\Domain\Authentication\Model\Session;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Core\Security\Domain\AccessGroup\Model\AccessGroup;
 use Security\Domain\Authentication\Model\ProviderToken;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Infrastructure\Service\Exception\NotFoundException;
 use Core\Security\Domain\Authentication\AuthenticationException;
+use Core\Security\Domain\Authentication\SSOAuthenticationException;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Security\Domain\Authentication\Interfaces\OpenIdProviderInterface;
 use Security\Domain\Authentication\Interfaces\SessionRepositoryInterface;
-use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 use Core\Security\Domain\ProviderConfiguration\OpenId\Model\Configuration;
+use Core\Contact\Application\Repository\WriteContactGroupRepositoryInterface;
+use Core\Security\Application\Repository\WriteAccessGroupRepositoryInterface;
+use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
-use Core\Security\Application\ProviderConfiguration\OpenId\Repository\ReadOpenIdConfigurationRepositoryInterface;
-use Centreon\Domain\Authentication\Exception\AuthenticationException as LegacyAuthenticationException;
-use Core\Security\Domain\Authentication\SSOAuthenticationException;
 use Core\Security\Domain\ProviderConfiguration\OpenId\Exceptions\OpenIdConfigurationException;
+use Centreon\Domain\Authentication\Exception\AuthenticationException as LegacyAuthenticationException;
+use Core\Security\Application\ProviderConfiguration\OpenId\Repository\ReadOpenIdConfigurationRepositoryInterface;
 
 class LoginOpenIdSession
 {
@@ -57,6 +60,8 @@ class LoginOpenIdSession
      * @param AuthenticationRepositoryInterface $authenticationRepository
      * @param SessionRepositoryInterface $sessionRepository
      * @param DataStorageEngineInterface $dataStorageEngine
+     * @param WriteContactGroupRepositoryInterface $contactGroupRepository
+     * @param WriteAccessGroupRepositoryInterface $accessGroupRepository
      */
     public function __construct(
         private string $redirectDefaultPage,
@@ -68,6 +73,8 @@ class LoginOpenIdSession
         private AuthenticationRepositoryInterface $authenticationRepository,
         private SessionRepositoryInterface $sessionRepository,
         private DataStorageEngineInterface $dataStorageEngine,
+        private WriteContactGroupRepositoryInterface $contactGroupRepository,
+        private WriteAccessGroupRepositoryInterface $accessGroupRepository,
     ) {
     }
 
@@ -87,18 +94,8 @@ class LoginOpenIdSession
             }
             $this->provider->setConfiguration($openIdProviderConfiguration);
             $this->provider->authenticateOrFail($request->authorizationCode, $request->clientIp);
-            $user = $this->provider->getUser();
-            if ($user === null) {
-                if (!$this->provider->canCreateUser()) {
-                    throw new NotFoundException('User not found');
-                }
-                $this->info("User not found, start auto import");
-                $this->provider->createUser();
-                $user = $this->provider->getUser();
-                if ($user === null) {
-                    throw new NotFoundException('User not found');
-                }
-            }
+            $user = $this->findUserOrFail();
+            $this->updateUserACL($user);
             $sessionUserInfos = [
                 'contact_id' => $user->getId(),
                 'contact_name' => $user->getName(),
@@ -139,12 +136,14 @@ class LoginOpenIdSession
             }
         } catch (SSOAuthenticationException | NotFoundException | OpenIdConfigurationException $e) {
             $this->error('An unexpected error occurred while authenticating with OpenID', [
+                'message' => $e->getMessage(),
                 'trace' => $e->getTraceAsString()
             ]);
             $presenter->present($this->createResponse(null, $e->getMessage()));
             return;
         } catch (\Throwable $e) {
             $this->error('An unexpected error occurred while authenticating with OpenID', [
+                'message' => $e->getMessage(),
                 'trace' => $e->getTraceAsString()
             ]);
             $presenter->present($this->createResponse(
@@ -276,5 +275,162 @@ class LoginOpenIdSession
         $response->error = $error;
 
         return $response;
+    }
+
+    /**
+     * Find User in Centreon or throw an exception
+     *
+     * @return ContactInterface
+     * @throws NotFoundException
+     */
+    private function findUserOrFail(): ContactInterface
+    {
+        $user = $this->provider->getUser();
+        if ($user === null) {
+            $this->info("User not found");
+            if (! $this->provider->canCreateUser()) {
+                throw new NotFoundException('User could not be created');
+            }
+            $this->info("Start auto import");
+            $this->provider->createUser();
+            $user = $this->provider->getUser();
+            if ($user === null) {
+                throw new NotFoundException('User not found');
+            }
+            $this->info("User imported: " . $user->getName());
+        }
+
+        return $user;
+    }
+
+    /**
+     * Update User ACL On authentication
+     *
+     * @param ContactInterface $user
+     */
+    private function updateUserACL(ContactInterface $user): void
+    {
+        $userClaims = $this->getUserClaimsFromIdTokenOrUserInformation();
+        $userAccessGroups = $this->getUserAccessGroupsFromClaims($userClaims);
+        $this->updateAccessGroupsForUser($user, $userAccessGroups);
+        $this->updateContactGroupsForUser($user);
+    }
+
+    /**
+     * Parse Id Token and User Information to get claims
+     *
+     * @return string[]
+     */
+    private function getUserClaimsFromIdTokenOrUserInformation(): array
+    {
+        $userClaims = [];
+        $configuration = $this->provider->getConfiguration();
+        $idTokenPayload = $this->provider->getIdTokenPayload();
+        $userInformation = $this->provider->getUserInformation();
+        if (array_key_exists($configuration->getClaimName(), $idTokenPayload)) {
+            $userClaims = $idTokenPayload[$configuration->getClaimName()];
+        } elseif (array_key_exists($configuration->getClaimName(), $userInformation)) {
+            $userClaims = $userInformation[$configuration->getClaimName()];
+        } else {
+            $this->info(
+                "configured claim name not found in user information or id_token, " .
+                "default contact group ACL will be apply",
+                ["claim_name" => $configuration->getClaimName()]
+            );
+        }
+
+        /**
+         * Claims can sometime be listed as a string e.g: "claim1,claim2,claim3" so we explode
+         * them to handle only one format
+         */
+        if (is_string($userClaims)) {
+            $userClaims = explode(",", $userClaims);
+        }
+
+        $this->info("Claims found", [
+            "claims_value" => implode(", ", $userClaims),
+            "claim_name" => $configuration->getClaimName()
+        ]);
+
+        return $userClaims;
+    }
+
+    /**
+     * Get Access Group linked to user claims
+     *
+     * @param string[] $claims
+     * @return AccessGroup[]
+     */
+    private function getUserAccessGroupsFromClaims(array $claims): array
+    {
+        $userAccessGroups = [];
+        $configuration = $this->provider->getConfiguration();
+        foreach ($configuration->getAuthorizationRules() as $authorizationRule) {
+            if (! in_array($authorizationRule->getClaimValue(), $claims)) {
+                $this->info(
+                    "Configured Claim Value not found in user claims",
+                    ["claim_value" => $authorizationRule->getClaimValue()]
+                );
+
+                continue;
+            }
+            // We ensure here to not duplicate access group while using their id as index
+            $userAccessGroups[$authorizationRule->getAccessGroup()->getId()] = $authorizationRule->getAccessGroup();
+        }
+        return $userAccessGroups;
+    }
+
+    /**
+     * Delete and Insert Access Groups for authenticated user
+     *
+     * @param ContactInterface $user
+     * @param AccessGroup[] $userAccessGroups
+     */
+    private function updateAccessGroupsForUser(ContactInterface $user, array $userAccessGroups): void
+    {
+        try {
+            $this->info("Updating User Access Groups", [
+                "user_id" => $user->getId(),
+                "access_groups" => $userAccessGroups
+            ]);
+            $this->dataStorageEngine->startTransaction();
+            $this->accessGroupRepository->deleteAccessGroupsForUser($user);
+            $this->accessGroupRepository->insertAccessGroupsForUser($user, $userAccessGroups);
+            $this->dataStorageEngine->commitTransaction();
+        } catch (\Exception $ex) {
+            $this->dataStorageEngine->rollbackTransaction();
+            $this->error('Error during ACL update', [
+                "user_id" => $user->getId(),
+                "access_groups" => $userAccessGroups,
+                "trace" => $ex->getTraceAsString()
+            ]);
+        }
+    }
+
+    /**
+     * Delete and Insert Contact Group for authenticated user
+     *
+     * @param ContactInterface $user
+     */
+    private function updateContactGroupsForUser(ContactInterface $user): void
+    {
+        $contactGroup = $this->provider->getConfiguration()->getContactGroup();
+        try {
+            $this->info('Updating User Contact Group', [
+                "user_id" => $user->getId(),
+                "contact_group_id" => $contactGroup->getId(),
+            ]);
+            $this->dataStorageEngine->startTransaction();
+            $this->contactGroupRepository->deleteContactGroupsForUser($user);
+            $this->contactGroupRepository->insertContactGroupForUser($user, $contactGroup);
+            $this->dataStorageEngine->commitTransaction();
+        } catch (\Exception $ex) {
+            $this->dataStorageEngine->rollbackTransaction();
+            $this->error('Error during contact group update', [
+                "user_id" => $user->getId(),
+                "contact_group_id" => $contactGroup->getId(),
+                "trace" => $ex->getTraceAsString()
+            ]);
+        }
     }
 }

--- a/src/Core/Security/Domain/Authentication/SSOAuthenticationException.php
+++ b/src/Core/Security/Domain/Authentication/SSOAuthenticationException.php
@@ -167,4 +167,14 @@ class SSOAuthenticationException extends \Exception
             implode(", ", $missingAttributes)
         ));
     }
+
+    /**
+     * Exception thrown when the id_token couldn't be decoded
+     *
+     * @return self
+     */
+    public static function unableToDecodeIdToken(): self
+    {
+        return new self(_("An error occured while decoding Identity Provider ID Token"));
+    }
 }

--- a/src/Core/Security/Infrastructure/Repository/DbWriteAccessGroupRepository.php
+++ b/src/Core/Security/Infrastructure/Repository/DbWriteAccessGroupRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+* Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* For more information : contact@centreon.com
+*
+*/
+
+declare(strict_types=1);
+
+namespace Core\Security\Infrastructure\Repository;
+
+use Centreon\Infrastructure\DatabaseConnection;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Core\Security\Application\Repository\WriteAccessGroupRepositoryInterface;
+
+class DbWriteAccessGroupRepository extends AbstractRepositoryDRB implements WriteAccessGroupRepositoryInterface
+{
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteAccessGroupsForUser(ContactInterface $user): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            "DELETE FROM acl_group_contacts_relations WHERE contact_contact_id = :userId"
+        ));
+        $statement->bindValue(':userId', $user->getId(), \PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insertAccessGroupsForUser(ContactInterface $user, array $accessGroups): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            "INSERT INTO acl_group_contacts_relations VALUES (:userId, :accessGroupId)"
+        ));
+        $statement->bindValue(':userId', $user->getId(), \PDO::PARAM_INT);
+        foreach ($accessGroups as $accessGroup) {
+            $statement->bindValue(':accessGroupId', $accessGroup->getId(), \PDO::PARAM_INT);
+            $statement->execute();
+        }
+    }
+}

--- a/src/Security/Domain/Authentication/Interfaces/OpenIdProviderInterface.php
+++ b/src/Security/Domain/Authentication/Interfaces/OpenIdProviderInterface.php
@@ -57,4 +57,18 @@ interface OpenIdProviderInterface extends ProviderInterface
      * @param string|null $authorizationCode
      */
     public function authenticateOrFail(?string $authorizationCode, string $clientIp): void;
+
+    /**
+     * Get User information gathered from IdP
+     *
+     * @return array<string,mixed>
+     */
+    public function getUserInformation(): array;
+
+    /**
+     * Get information store in id_token JWT Payload
+     *
+     * @return array<string,mixed>
+     */
+    public function getIdTokenPayload(): array;
 }

--- a/tests/php/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+++ b/tests/php/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\Security\Application\UseCase\LoginOpenIdSession;
 
+use Centreon\Domain\Contact\Contact;
 use CentreonDB;
 use Pimple\Container;
 use Core\Contact\Domain\Model\ContactGroup;
@@ -34,6 +35,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Security\Domain\Authentication\Model\AuthenticationTokens;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Contact\Application\Repository\WriteContactGroupRepositoryInterface;
 use Security\Domain\Authentication\Interfaces\OpenIdProviderInterface;
 use Security\Domain\Authentication\Interfaces\SessionRepositoryInterface;
 use Core\Security\Application\UseCase\LoginOpenIdSession\LoginOpenIdSession;
@@ -43,6 +45,9 @@ use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
 use Core\Security\Application\UseCase\LoginOpenIdSession\LoginOpenIdSessionRequest;
 use Core\Security\Infrastructure\Api\LoginOpenIdSession\LoginOpenIdSessionPresenter;
 use Core\Security\Application\ProviderConfiguration\OpenId\Repository\ReadOpenIdConfigurationRepositoryInterface;
+use Core\Security\Application\Repository\WriteAccessGroupRepositoryInterface;
+use Core\Security\Domain\AccessGroup\Model\AccessGroup;
+use Core\Security\Domain\ProviderConfiguration\OpenId\Model\AuthorizationRule;
 
 beforeEach(function () {
     $this->repository = $this->createMock(ReadOpenIdConfigurationRepositoryInterface::class);
@@ -72,6 +77,9 @@ beforeEach(function () {
     $this->presenter = new LoginOpenIdSessionPresenter($this->formatter);
     $this->contact = $this->createMock(ContactInterface::class);
     $this->authenticationTokens = $this->createMock(AuthenticationTokens::class);
+    $this->contactGroupRepository = $this->createMock(WriteContactGroupRepositoryInterface::class);
+    $this->accessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class);
+    $this->contactGroup = new ContactGroup(1, 'contact_group');
 
     $this->validOpenIdConfiguration = (new Configuration())
         ->setActive(true)
@@ -92,7 +100,8 @@ beforeEach(function () {
         ->setAuthenticationType('client_secret_post')
         ->setContactTemplate(new ContactTemplate(1, 'contact_template'))
         ->setAutoImportEnabled(false)
-        ->setContactGroup(new ContactGroup(1, 'contact_group'));
+        ->setContactGroup($this->contactGroup)
+        ->setClaimName('groups');
 });
 
 it('expects to return an error message in presenter when no provider configuration are found', function () {
@@ -114,7 +123,9 @@ it('expects to return an error message in presenter when no provider configurati
         $this->authenticationService,
         $this->authenticationRepository,
         $this->sessionRepository,
-        $this->dataStorageEngine
+        $this->dataStorageEngine,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository
     );
 
     $useCase($request, $this->presenter);
@@ -144,7 +155,9 @@ it('expects to execute authenticateOrFail method from OpenIdProvider', function 
         $this->authenticationService,
         $this->authenticationRepository,
         $this->sessionRepository,
-        $this->dataStorageEngine
+        $this->dataStorageEngine,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository
     );
     $useCase($request, $this->presenter);
 });
@@ -175,10 +188,12 @@ it(
             $this->authenticationService,
             $this->authenticationRepository,
             $this->sessionRepository,
-            $this->dataStorageEngine
+            $this->dataStorageEngine,
+            $this->contactGroupRepository,
+            $this->accessGroupRepository
         );
         $useCase($request, $this->presenter);
-        expect($this->presenter->getPresentedData()->error)->toBe('User not found');
+        expect($this->presenter->getPresentedData()->error)->toBe('User could not be created');
     }
 );
 
@@ -214,10 +229,184 @@ it(
             $this->authenticationService,
             $this->authenticationRepository,
             $this->sessionRepository,
-            $this->dataStorageEngine
+            $this->dataStorageEngine,
+            $this->contactGroupRepository,
+            $this->accessGroupRepository
         );
 
         $useCase($request, $this->presenter);
         expect($this->presenter->getPresentedData()->error)->toBe('User not found');
     }
 );
+
+it('should update access groups for the authenticated user', function () {
+    $request = new LoginOpenIdSessionRequest();
+    $request->authorizationCode = 'abcde-fghij-klmno';
+    $request->clientIp = '127.0.0.1';
+    $accessGroup1 = new AccessGroup(1, "access_group_1", "access_group_1");
+    $accessGroup2 = new AccessGroup(2, "access_group_2", "access_group_2");
+    $authorizationRules = [
+        new AuthorizationRule("group1", $accessGroup1),
+        new AuthorizationRule("group2", $accessGroup2)
+    ];
+    $this->validOpenIdConfiguration->setAuthorizationRules($authorizationRules);
+
+    $this->repository
+        ->expects($this->once())
+        ->method('findConfiguration')
+        ->willReturn($this->validOpenIdConfiguration);
+
+    $this->provider
+        ->expects($this->any())
+        ->method('getConfiguration')
+        ->willReturn($this->validOpenIdConfiguration);
+
+    $contact = (new Contact())->setId(1);
+    $this->provider
+        ->expects($this->once())
+        ->method('getUser')
+        ->willReturn($contact);
+
+    $this->provider
+        ->expects($this->once())
+        ->method('getUserInformation')
+        ->willReturn(["groups" => "group1,group2"]);
+
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('deleteAccessGroupsForUser')
+        ->with($contact);
+
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('insertAccessGroupsForUser')
+        ->with($contact, [$accessGroup1->getId() => $accessGroup1, $accessGroup2->getId() => $accessGroup2]);
+
+    $useCase = new LoginOpenIdSession(
+        '/monitoring/ressources',
+        $this->repository,
+        $this->provider,
+        $this->requestStack,
+        $this->dependencyInjector,
+        $this->authenticationService,
+        $this->authenticationRepository,
+        $this->sessionRepository,
+        $this->dataStorageEngine,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository
+    );
+
+    $useCase($request, $this->presenter);
+});
+
+it('should not duplicate ACL insertion when access group is in multiple authorization rules', function () {
+    $request = new LoginOpenIdSessionRequest();
+    $request->authorizationCode = 'abcde-fghij-klmno';
+    $request->clientIp = '127.0.0.1';
+    $accessGroup1 = new AccessGroup(1, "access_group_1", "access_group_1");
+    $authorizationRules = [
+        new AuthorizationRule("group1", $accessGroup1),
+        new AuthorizationRule("group2", $accessGroup1)
+    ];
+    $this->validOpenIdConfiguration->setAuthorizationRules($authorizationRules);
+
+    $this->repository
+        ->expects($this->once())
+        ->method('findConfiguration')
+        ->willReturn($this->validOpenIdConfiguration);
+
+    $this->provider
+        ->expects($this->any())
+        ->method('getConfiguration')
+        ->willReturn($this->validOpenIdConfiguration);
+
+    $contact = (new Contact())->setId(1);
+    $this->provider
+        ->expects($this->once())
+        ->method('getUser')
+        ->willReturn($contact);
+
+    $this->provider
+        ->expects($this->once())
+        ->method('getIdTokenPayload')
+        ->willReturn([]);
+
+    $this->provider
+        ->expects($this->once())
+        ->method('getUserInformation')
+        ->willReturn(["groups" => "group1,group2"]);
+
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('deleteAccessGroupsForUser')
+        ->with($contact);
+
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('insertAccessGroupsForUser')
+        ->with($contact, [$accessGroup1->getId() => $accessGroup1]);
+
+    $useCase = new LoginOpenIdSession(
+        '/monitoring/ressources',
+        $this->repository,
+        $this->provider,
+        $this->requestStack,
+        $this->dependencyInjector,
+        $this->authenticationService,
+        $this->authenticationRepository,
+        $this->sessionRepository,
+        $this->dataStorageEngine,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository
+    );
+
+    $useCase($request, $this->presenter);
+});
+
+it('should update contact group for the authenticated user', function () {
+    $request = new LoginOpenIdSessionRequest();
+    $request->authorizationCode = 'abcde-fghij-klmno';
+    $request->clientIp = '127.0.0.1';
+
+    $this->repository
+        ->expects($this->once())
+        ->method('findConfiguration')
+        ->willReturn($this->validOpenIdConfiguration);
+
+    $this->provider
+        ->expects($this->any())
+        ->method('getConfiguration')
+        ->willReturn($this->validOpenIdConfiguration);
+
+    $contact = (new Contact())->setId(1);
+    $this->provider
+        ->expects($this->once())
+        ->method('getUser')
+        ->willReturn($contact);
+
+    $this->contactGroupRepository
+        ->expects($this->once())
+        ->method('deleteContactGroupsForUser')
+        ->with($contact);
+
+    $this->contactGroupRepository
+        ->expects($this->once())
+        ->method('insertContactGroupForUser')
+        ->with($contact, $this->contactGroup);
+
+    $useCase = new LoginOpenIdSession(
+        '/monitoring/ressources',
+        $this->repository,
+        $this->provider,
+        $this->requestStack,
+        $this->dependencyInjector,
+        $this->authenticationService,
+        $this->authenticationRepository,
+        $this->sessionRepository,
+        $this->dataStorageEngine,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository
+    );
+
+    $useCase($request, $this->presenter);
+});


### PR DESCRIPTION
## Description

This PR intends to handle authorization management on authentication.

https://www.loom.com/share/0502ced17ba9477891291af52e67d2c4

While a user login using OpenID Connect:

His contactgroup is automatically set to the one configured in OpenId Configuration
His Access Groups are automatically bind from Claims gather from Identity Provider
If contactgroup or access groups bind changes in OpenId Configuration, the new contactgroup / access groups are updated for the user at his next authentication.

**Fixes** # MON-10790

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
