### PR TITLE
Clean formMyAccount old password saved in session 21.04

### DIFF
--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -384,9 +384,6 @@ $sessionKeyFreeze = 'administration-form-my-account-freeze';
 
 if ($form->validate()) {
     updateContactInDB($centreon->user->get_id());
-    if ($form->getSubmitValue("contact_passwd")) {
-        $centreon->user->passwd = md5($form->getSubmitValue("contact_passwd"));
-    }
     $o = null;
     $features = $form->getSubmitValue('features');
 


### PR DESCRIPTION
## Description
A password converted to md5 is still generated and saved in user’s session using the form submit result.

This password is in a deprecated.

**Fixes** # (MON-12740)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
