### PR TITLE
fix(sql): manage databases with dash in name 22.04 (#11368)

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1088,14 +1088,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
               AND srv.enabled = \'1\'
             INNER JOIN `:dbstg`.instances i
               ON i.instance_id = h.instance_id
-            LEFT JOIN :dbstg.hosts_hostgroups hhg
+            LEFT JOIN `:dbstg`.hosts_hostgroups hhg
               ON hhg.host_id = h.host_id
-            LEFT JOIN :dbstg.hostgroups hg
+            LEFT JOIN `:dbstg`.hostgroups hg
               ON hg.hostgroup_id = hhg.hostgroup_id
-            LEFT JOIN :dbstg.services_servicegroups ssg
+            LEFT JOIN `:dbstg`.services_servicegroups ssg
               ON ssg.service_id = srv.service_id
               AND ssg.host_id = h.host_id
-            LEFT JOIN :dbstg.customvariables cv
+            LEFT JOIN `:dbstg`.customvariables cv
               ON (cv.service_id = srv.service_id
               AND cv.host_id = srv.host_id AND cv.name = \'CRITICALITY_LEVEL\')';
 
@@ -1453,8 +1453,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request =
             'SELECT DISTINCT 
               srv.service_id, srv.display_name, srv.description, srv.host_id, srv.state
-            FROM :dbstg.services srv
-            INNER JOIN :dbstg.hosts h
+            FROM `:dbstg`.services srv
+            INNER JOIN `:dbstg`.hosts h
               ON h.host_id = srv.host_id
               AND h.enabled = \'1\'
               AND h.name NOT LIKE \'_Module_BAM%\''
@@ -1516,8 +1516,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 srv.description,
                 srv.host_id,
                 srv.state
-            FROM :dbstg.services srv
-            INNER JOIN :dbstg.hosts h
+            FROM `:dbstg`.services srv
+            INNER JOIN `:dbstg`.hosts h
               ON h.host_id = srv.host_id
               AND h.enabled = \'1\'
               AND h.name NOT LIKE \'_Module_BAM%\''
@@ -1573,7 +1573,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 srv.host_id,
                 srv.state
             FROM `:dbstg`.`services` srv
-            INNER JOIN :dbstg.`hosts` h
+            INNER JOIN `:dbstg`.`hosts` h
               ON h.host_id = srv.host_id
               AND h.enabled = \'1\'
               AND h.name NOT LIKE \'_Module_BAM%\'

--- a/www/class/centreon-partition/mysqlTable.class.php
+++ b/www/class/centreon-partition/mysqlTable.class.php
@@ -422,7 +422,7 @@ class MysqlTable
     public function exists()
     {
         try {
-            $DBRESULT = $this->db->query("use " . $this->schema);
+            $DBRESULT = $this->db->query("use `" . $this->schema . "`");
         } catch (\PDOException $e) {
             throw new Exception(
                 "SQL Error: Cannot use database "

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -236,7 +236,7 @@ class PartEngine
      */
     public function createParts($table, $db, $createPastPartitions): void
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if ($table->exists()) {
             throw new Exception("Warning: Table " . $tableName . " already exists\n");
         }
@@ -253,7 +253,7 @@ class PartEngine
         }
 
         try {
-            $dbResult = $db->query("use " . $table->getSchema());
+            $dbResult = $db->query("use `" . $table->getSchema() . "`");
         } catch (\PDOException $e) {
             throw new Exception(
                 "SQL Error: Cannot use database "
@@ -325,7 +325,7 @@ class PartEngine
             $condition = $this->purgeDailyPartitionCondition($table);
         }
 
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Error: Table " . $tableName . " does not exists\n");
         }
@@ -364,7 +364,7 @@ class PartEngine
      */
     public function migrate($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
 
         $db->query("SET bulk_insert_buffer_size= 1024 * 1024 * 256");
 
@@ -411,7 +411,7 @@ class PartEngine
      */
     public function updateParts($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
 
         //verifying if table is partitioned
         if ($this->isPartitioned($table, $db) === false) {
@@ -433,7 +433,7 @@ class PartEngine
      */
     public function optimizeTablePartitions($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Optimize error: Table " . $tableName . " does not exists\n");
         }
@@ -472,7 +472,7 @@ class PartEngine
      */
     public function listParts($table, $db, $throwException = true)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Parts list error: Table " . $tableName . " does not exists\n");
         }
@@ -521,7 +521,7 @@ class PartEngine
      */
     public function backupParts($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Error: Table " . $tableName . " does not exists\n");
         }

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -92,7 +92,7 @@ $mandatoryPrivileges = [
     'CREATE VIEW',
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
-$query = "GRANT " . $privilegesQuery . " ON %s.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
+$query = "GRANT " . $privilegesQuery . " ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
 $flushQuery = "FLUSH PRIVILEGES";
 
 try {

--- a/www/install/steps/process/insertBaseConf.php
+++ b/www/install/steps/process/insertBaseConf.php
@@ -65,7 +65,7 @@ try {
  * Create tables
  */
 try {
-    $result = $link->query('use ' . $parameters['db_configuration']);
+    $result = $link->query('use `' . $parameters['db_configuration'] . '`');
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_configuration'] . '" database');
     }

--- a/www/install/steps/process/installConfigurationDb.php
+++ b/www/install/steps/process/installConfigurationDb.php
@@ -89,7 +89,7 @@ try {
 
     //If it doesn't exist, create it
     if ($result = $statementShowDatabase->fetch(\PDO::FETCH_ASSOC) === false) {
-        $db->exec("CREATE DATABASE " . $parameters['db_configuration']);
+        $db->exec('CREATE DATABASE `' . $parameters['db_configuration'] . '`');
 
         //Create table
         $db->exec('use ' . $parameters['db_configuration']);
@@ -115,7 +115,7 @@ try {
         }
     }
     //Create table
-    $db->exec('use ' . $parameters['db_configuration']);
+    $db->exec('use `' . $parameters['db_configuration'] . '`');
     $result = splitQueries('../../createTables.sql', ';', $db, '../../tmp/createTables');
     if ("0" != $result) {
         $return['msg'] = $result;

--- a/www/install/steps/process/installStorageDb.php
+++ b/www/install/steps/process/installStorageDb.php
@@ -68,7 +68,7 @@ try {
 
     //If it doesn't exist, create it
     if ($result = $statementShowDatabase->fetch(\PDO::FETCH_ASSOC) === false) {
-        $db->exec("CREATE DATABASE " . $parameters['db_storage']);
+        $db->exec('CREATE DATABASE `' . $parameters['db_storage'] . '`');
     } else {
         //If it exist, check if database is empty (no tables)
         $statement = $db->prepare(
@@ -90,7 +90,7 @@ try {
         $step->getEngineConfiguration(),
         $step->getBrokerConfiguration()
     );
-    $result = $db->query('use ' . $parameters['db_storage']);
+    $result = $db->query('use `' . $parameters['db_storage'] . '`');
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_storage'] . '" database');
     }


### PR DESCRIPTION
## Description

manage databases with dash in name (ex: `centreon-monitoring`)

**Fixes** MON-14296

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)