### PR TITLE
Snyk: Sanitize and bind ACL service dependency queries dev-21.10.x

### DIFF
--- a/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -127,10 +127,12 @@ function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array(
                     $query = "SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_hostPar"] = "";
+                    $query = "INSERT INTO dependency_hostChild_relation VALUES (:dep_id, :host_host_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($host = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_hostChild_relation VALUES ('" . $maxId["MAX(dep_id)"] .
-                            "', '" . $host["host_host_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':host_host_id', (int) $host["host_host_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_hostPar"] .= $host["host_host_id"] . ",";
                     }
                     $fields["dep_hostPar"] = trim($fields["dep_hostPar"], ",");
@@ -138,21 +140,36 @@ function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array(
                     $query = "SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_hSvPar"] = "";
+                    $query = "INSERT INTO dependency_serviceParent_relation 
+                        VALUES (:dep_id, :service_service_id, :host_host_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($service = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_serviceParent_relation VALUES ('" .
-                            $maxId["MAX(dep_id)"] . "', '" . $service["service_service_id"] . "', '" .
-                            $service["host_host_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(
+                            ':service_service_id',
+                            (int) $service["service_service_id"],
+                            \PDO::PARAM_INT
+                        );
+                        $statement->bindValue(':host_host_id', (int) $service["host_host_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_hSvPar"] .= $service["service_service_id"] . ",";
                     }
                     $fields["dep_hSvPar"] = trim($fields["dep_hSvPar"], ",");
                     $query = "SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_hSvChi"] = "";
+                    $query = "INSERT INTO dependency_serviceChild_relation 
+                        VALUES (:dep_id, :service_service_id, :host_host_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($service = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_serviceChild_relation VALUES ('" . $maxId["MAX(dep_id)"] .
-                            "', '" . $service["service_service_id"] . "', '" . $service["host_host_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(
+                            ':service_service_id',
+                            (int) $service["service_service_id"],
+                            \PDO::PARAM_INT
+                        );
+                        $statement->bindValue(':host_host_id', (int) $service["host_host_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_hSvChi"] .= $service["service_service_id"] . ",";
                     }
                     $fields["dep_hSvChi"] = trim($fields["dep_hSvChi"], ",");


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code.

Snyk CLI result preview:
![image](https://user-images.githubusercontent.com/97593234/179121263-02c53a22-61ae-480b-ade1-66c3782a28fb.png)

**Fixes** # MON-14257

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
