### PR TITLE
fix(ci): fix debian packaging with freshly instanciated jenkins slave

### DIFF
--- a/ci/scripts/centreon-deb-package.sh
+++ b/ci/scripts/centreon-deb-package.sh
@@ -33,10 +33,9 @@ for i in lang/* ; do
 done
 rm -rf lang
 
-# Generate API documentation.
-apt install -y npm && sleep 30
-npm install -g redoc-cli
-/usr/local/bin/redoc-cli bundle --options.hideDownloadButton=true doc/API/centreon-api-v${MAJOR_VERSION}.yaml -o ../centreon-api-v${MAJOR_VERSION}.html
+# Install npm dependency
+apt-get update
+apt install -y npm
 
 # Make tar with original content
 cd ..


### PR DESCRIPTION
## Description

fix debian packaging with freshly instanciated jenkins slave
api doc build is not needed

**Fixes** MON-14377

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI pipeline