### PR TITLE
Snyk: Sanitize and bind media sync queries

### DIFF
--- a/www/include/options/media/images/syncDir.php
+++ b/www/include/options/media/images/syncDir.php
@@ -142,12 +142,8 @@ print "<b>&nbsp;&nbsp;" . _("Media Detection") . "</b>";
         }
     }
 
-    /**
-     * @param $picture
-     * @param $dirpath
-     * @param $dir_id
-     * @param CentreonDB $pearDB
-     * @return int|mixed
+    /*
+     * inserts $dir_id/$picture into DB if not registered yet
      */
     function checkPicture($picture, $dirpath, $dir_id, $pearDB)
     {
@@ -207,7 +203,7 @@ print "<b>&nbsp;&nbsp;" . _("Media Detection") . "</b>";
             $statement->execute();
             return $data['img_id'];
         } else {
-            $data = $DBRESULT->fetchRow();
+            $data = $statement->fetchRow(\PDO::FETCH_ASSOC);
             return 0;
         }
     }


### PR DESCRIPTION
## Description

Sanitizing and binding media sync queries to reduce surface attacks and cleaning up legacy code.

**Fixes** # MON-14357

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
