### PR TITLE
fix(packaging): give sufficient rights on .env and .env.local.php for…

### DIFF
--- a/ci/debian/centreon-web.postinst
+++ b/ci/debian/centreon-web.postinst
@@ -17,7 +17,7 @@ if [ "$1" = "configure" ] ; then
     chmod -R 0775 \
       /usr/share/centreon/www \
       /usr/share/centreon/GPL_LIB/SmartyCache
-    chmod -R 0664 \
+    chmod 0664 \
       /usr/share/centreon/www/.env \
       /usr/share/centreon/www/.env.local.php
   fi

--- a/ci/debian/centreon-web.postinst
+++ b/ci/debian/centreon-web.postinst
@@ -17,7 +17,9 @@ if [ "$1" = "configure" ] ; then
     chmod -R 0775 \
       /usr/share/centreon/www \
       /usr/share/centreon/GPL_LIB/SmartyCache
-  
+    chmod -R 0664 \
+      /usr/share/centreon/www/.env \
+      /usr/share/centreon/www/.env.local.php
   fi
 
   # Replace macros ----


### PR DESCRIPTION
… debian

This PR intends to give .env and .env.local.php files the same rights as the ones provided for other distributions (el7, alma8)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Example: Try to save the Administration -> Parameters -> Monitoring page.
No error should be displayed regarding the rights on .env.local.php file.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
