### PR TITLE
fix(debian): wrong directory for env files for php

### DIFF
--- a/ci/debian/centreon-web.postinst
+++ b/ci/debian/centreon-web.postinst
@@ -18,8 +18,8 @@ if [ "$1" = "configure" ] ; then
       /usr/share/centreon/www \
       /usr/share/centreon/GPL_LIB/SmartyCache
     chmod 0664 \
-      /usr/share/centreon/www/.env \
-      /usr/share/centreon/www/.env.local.php
+      /usr/share/centreon/.env \
+      /usr/share/centreon/.env.local.php
   fi
 
   # Replace macros ----


### PR DESCRIPTION
Huge error made when trying to fix an issue on debian.  follow up of https://github.com/centreon/centreon/pull/11414