### PR TITLE
fix(hostgroup): fix display of hostgroups in select2

### DIFF
--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -333,6 +333,11 @@ class CentreonHostgroups
         if (empty($values)) {
             return $items;
         }
+        
+        $hostgroups = [];
+        foreach ($values as $value) {
+            $hostgroups = array_merge($hostgroups, explode(',', $value));
+        }
 
         // get list of authorized hostgroups
         if (!$centreon->user->access->admin) {
@@ -347,7 +352,7 @@ class CentreonHostgroups
                     'conditions' => array(
                         'hostgroup.hg_id' => array(
                             'IN',
-                            $values
+                            $hostgroups
                         )
                     )
                 ),

--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -335,6 +335,7 @@ class CentreonHostgroups
         }
         
         $hostgroups = [];
+        // $values structure: ['1,2,3,4'], keeping the foreach in case it could have more than one index
         foreach ($values as $value) {
             $hostgroups = array_merge($hostgroups, explode(',', $value));
         }
@@ -363,16 +364,14 @@ class CentreonHostgroups
         // get list of selected hostgroups
         $listValues = '';
         $queryValues = array();
-
-        foreach ($values as $k => $v) {
-            //As it happens that $v could be like "X,Y" when two hostgroups are selected, we added a second foreach
-            $multiValues = explode(',', $v);
-            foreach ($multiValues as $item) {
-                $ids = explode('-', $item);
-                $listValues .= ':hgId_' . $ids[0] . ', ';
-                $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
-            }
+        
+        foreach ($hostgroups as $item) {
+            // the below explode may not be useful 
+            $ids = explode('-', $item);
+            $listValues .= ':hgId_' . $ids[0] . ', ';
+            $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
         }
+        
         $listValues = rtrim($listValues, ', ');
         $query = 'SELECT hg_id, hg_name FROM hostgroup WHERE hg_id IN (' . $listValues . ') ORDER BY hg_name ';
         $stmt = $this->DB->prepare($query);

--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -333,7 +333,7 @@ class CentreonHostgroups
         if (empty($values)) {
             return $items;
         }
-        
+
         $hostgroups = [];
         // $values structure: ['1,2,3,4'], keeping the foreach in case it could have more than one index
         foreach ($values as $value) {
@@ -364,14 +364,14 @@ class CentreonHostgroups
         // get list of selected hostgroups
         $listValues = '';
         $queryValues = array();
-        
+
         foreach ($hostgroups as $item) {
-            // the below explode may not be useful 
+            // the below explode may not be useful
             $ids = explode('-', $item);
             $listValues .= ':hgId_' . $ids[0] . ', ';
             $queryValues['hgId_' . $ids[0]] = (int)$ids[0];
         }
-        
+
         $listValues = rtrim($listValues, ', ');
         $query = 'SELECT hg_id, hg_name FROM hostgroup WHERE hg_id IN (' . $listValues . ') ORDER BY hg_name ';
         $stmt = $this->DB->prepare($query);


### PR DESCRIPTION
## Description

This PR comes from https://github.com/centreon/centreon/pull/11305

when you use a widget such as host-monitoring or service-monitoring, you have a select2 for hostgroups. If you're a user that is not admin, and you select multiple hostgroups. The result will be filtered as expected but if you go back to the parameter edition of the widget, you'll only see one hostgroup displayed. If you click on the select2, you'll see that you still have multiple hostgroups selected but only the first one is displayed.

This is just a visual bug due to bad data formatting in the backend. It may also affect other select2 such as the servicegroup one. (will test later)

**Fixes** # MON-14490

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
