### PR TITLE
(fix) service status : encoding issue on status page

### DIFF
--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2019 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -35,17 +36,17 @@
 
 // Require configuration.
 require_once realpath(__DIR__ . "/../../../../../../bootstrap.php");
-include_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
+require_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
 
 // Require Specific XML / Ajax Class
-include_once _CENTREON_PATH_ . "www/class/centreonXMLBGRequest.class.php";
-include_once _CENTREON_PATH_ . "www/class/centreonInstance.class.php";
-include_once _CENTREON_PATH_ . "www/class/centreonCriticality.class.php";
-include_once _CENTREON_PATH_ . "www/class/centreonMedia.class.php";
+require_once _CENTREON_PATH_ . "www/class/centreonXMLBGRequest.class.php";
+require_once _CENTREON_PATH_ . "www/class/centreonInstance.class.php";
+require_once _CENTREON_PATH_ . "www/class/centreonCriticality.class.php";
+require_once _CENTREON_PATH_ . "www/class/centreonMedia.class.php";
 
 // Require common Files.
-include_once _CENTREON_PATH_ . "www/include/monitoring/status/Common/common-Func.php";
-include_once _CENTREON_PATH_ . "www/include/common/common-Func.php";
+require_once _CENTREON_PATH_ . "www/include/monitoring/status/Common/common-Func.php";
+require_once _CENTREON_PATH_ . "www/include/common/common-Func.php";
 
 // Create XML Request Objects
 CentreonSession::start();
@@ -142,7 +143,7 @@ if ($outputToSearch) {
 }
 
 $tabOrder = [];
-$tabOrder["criticality_id"] = " ORDER BY isnull " .$order . ", criticality " . $order . ", h.name, s.description ";
+$tabOrder["criticality_id"] = " ORDER BY isnull " . $order . ", criticality " . $order . ", h.name, s.description ";
 $tabOrder["host_name"] = " ORDER BY h.name " . $order . ", s.description ";
 $tabOrder["service_description"] = " ORDER BY s.description " . $order . ", h.name";
 $tabOrder["current_state"] = " ORDER BY s.state " . $order . ", h.name, s.description";
@@ -480,7 +481,7 @@ if (!$sqlError) {
         $obj->XML->writeElement("sc", $obj->colorService[$data["state"]]);
         $obj->XML->writeElement("cs", _($obj->statusService[$data["state"]]), false);
         $obj->XML->writeElement("ssc", $data["state"]);
-        $obj->XML->writeElement("po", CentreonUtils::escapeSecure($pluginShortOuput));
+        $obj->XML->writeElement("po", htmlspecialchars(htmlspecialchars($pluginShortOuput)));
         $obj->XML->writeElement(
             "ca",
             $data["current_attempt"] . "/" . $data["max_check_attempts"]


### PR DESCRIPTION
## Description

**Fixes** # (issue)
MON-14190

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] develop

<h2> How this pull request can be tested ? </h2>

- Create a test-xss file in the tmp folder.
- in this file add:
`<img onerror='alert("tmp2")' src="foo" width=0 height=0>"test"`
- Go to configuration > commands > checks and create a new check: `cat /tmp/test-xss`
- Link this check to a service linked to a valid host and export the configuration.
- enable deprecated pages display.
 - go to monitoring > status details > services. 
 - any popup shouldn't launched


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
