### PR TITLE
fix(upgrade): fix method call to find available upgrade

### DIFF
--- a/www/install/step_upgrade/process/process_step4.php
+++ b/www/install/step_upgrade/process/process_step4.php
@@ -53,7 +53,7 @@ try {
 $current = $next;
 
 $updateReadRepository = $kernel->getContainer()->get(ReadUpdateRepositoryInterface::class);
-$availableUpdates = $updateReadRepository->getOrderedAvailableUpdates($current);
+$availableUpdates = $updateReadRepository->findOrderedAvailableUpdates($current);
 $next = empty($availableUpdates) ? '' : array_shift($availableUpdates);
 
 $_SESSION['CURRENT_VERSION'] = $current;


### PR DESCRIPTION
## Description

fix method call to find available upgrade

thanks @jeremyjaouen for the catch

**Fixes** MON-12296

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)