### PR TITLE
fix(debian): fix centreon.ini and autoconfigure timezone

### DIFF
--- a/ci/debian/centreon-web.postinst
+++ b/ci/debian/centreon-web.postinst
@@ -62,4 +62,18 @@ if [ -n "$2" ]; then
   su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear --no-warmup"
 fi
 
+# Try auto configure timezone for php
+
+timezone=$(/usr/bin/php -r '
+  $timezoneName = timezone_name_from_abbr(trim(shell_exec("date \"+%Z\"")));
+  if (preg_match("/Time zone: (\S+)/", shell_exec("timedatectl"), $matches)) {
+    $timezoneName = $matches[1];
+  }
+  if (date_default_timezone_set($timezoneName) === false) {
+    $timezoneName = "UTC";
+  }
+  echo $timezoneName;
+' 2>/dev/null)
+sed -i "s#^date.timezone = .*#date.timezone = ${timezone}#" /etc/php/8.0/mods-available/centreon.ini
+
 exit 0

--- a/ci/debian/extra/centreon-web/centreon.ini
+++ b/ci/debian/extra/centreon-web/centreon.ini
@@ -1,1 +1,5 @@
+max_execution_time = 300
+session.use_strict_mode = 1
+session.gc_maxlifetime = 7200
+expose_php = Off
 date.timezone = UTC


### PR DESCRIPTION
## Description

Fix missing configurations to Centreon in `php.ini` and try auto configure the timezone 

**Fixes** MON-14425

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)