### PR TITLE
Sanitized and bound queries (#11413) (#11445) (#11456)

### DIFF
--- a/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
@@ -124,10 +124,12 @@ function multipleHostGroupDependencyInDB($dependencies = array(), $nbrDup = arra
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_hgParents"] = "";
+                    $query = "INSERT INTO dependency_hostgroupParent_relation VALUES (:max_id, :hg_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($hg = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_hostgroupParent_relation VALUES ('" .
-                            $maxId["MAX(dep_id)"] . "', '" . $hg["hostgroup_hg_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':max_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':hg_id', (int) $hg["hostgroup_hg_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_hgParents"] .= $hg["hostgroup_hg_id"] . ",";
                     }
                     $fields["dep_hgParents"] = trim($fields["dep_hgParents"], ",");
@@ -136,10 +138,12 @@ function multipleHostGroupDependencyInDB($dependencies = array(), $nbrDup = arra
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_hgChilds"] = "";
+                    $query = "INSERT INTO dependency_hostgroupChild_relation VALUES (:max_id, :hg_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($hg = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_hostgroupChild_relation VALUES ('" .
-                            $maxId["MAX(dep_id)"] . "', '" . $hg["hostgroup_hg_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':max_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':hg_id', (int) $hg["hostgroup_hg_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_hgChilds"] .= $hg["hostgroup_hg_id"] . ",";
                     }
                     $fields["dep_hgChilds"] = trim($fields["dep_hgChilds"], ",");


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

File:  www/include/configuration/configObject/hostgroup_dependency/DB-Func.php

Lines: 130 - 142
infos : recently merged to develop + dev-21.10.x +  dev-21.04.x
**Fixes** # MON-14360

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create a hostgroup dependency

Duplicate it

Check duplicate object

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).