### PR TITLE
fix(Resources/Graph): graph image after export to png when Central is in dark mode

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
@@ -2,12 +2,18 @@ import { saveAs } from 'file-saver';
 import dom2image from 'dom-to-image';
 
 interface Props {
+  bgcolor: string;
   element: HTMLElement;
   ratio: number;
   title: string;
 }
 
-const exportToPng = async ({ element, title, ratio }: Props): Promise<void> => {
+const exportToPng = async ({
+  element,
+  title,
+  ratio,
+  bgcolor,
+}: Props): Promise<void> => {
   const dateTime = new Date().toISOString().substring(0, 19);
 
   const getTranslation = (size: number): number => {
@@ -19,7 +25,7 @@ const exportToPng = async ({ element, title, ratio }: Props): Promise<void> => {
 
   return dom2image
     .toBlob(element, {
-      bgcolor: '#FFFFFF',
+      bgcolor,
       height: element.offsetHeight * ratio,
       style: {
         transform: `translate(-${translateX}px, -${translateY}px) scale(${ratio})`,

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
@@ -2,7 +2,7 @@ import { saveAs } from 'file-saver';
 import dom2image from 'dom-to-image';
 
 interface Props {
-  bgcolor: string;
+  backgroundColor: string;
   element: HTMLElement;
   ratio: number;
   title: string;

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
@@ -25,7 +25,7 @@ const exportToPng = async ({
 
   return dom2image
     .toBlob(element, {
-      bgcolor,
+      bgcolor: backgroundColor,
       height: element.offsetHeight * ratio,
       style: {
         transform: `translate(-${translateX}px, -${translateY}px) scale(${ratio})`,

--- a/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
+++ b/www/front_src/src/Resources/Graph/Performance/ExportableGraphWithTimeline/exportToPng.ts
@@ -12,7 +12,7 @@ const exportToPng = async ({
   element,
   title,
   ratio,
-  bgcolor,
+  backgroundColor,
 }: Props): Promise<void> => {
   const dateTime = new Date().toISOString().substring(0, 19);
 

--- a/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
@@ -8,6 +8,7 @@ import { Menu, MenuItem } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import SaveAsImageIcon from '@mui/icons-material/SaveAlt';
 import LaunchIcon from '@mui/icons-material/Launch';
+import { useTheme } from '@mui/material/styles';
 
 import {
   ContentWithCircularLoading,
@@ -56,6 +57,8 @@ const GraphActions = ({
   performanceGraphRef,
 }: Props): JSX.Element => {
   const classes = useStyles();
+  const theme = useTheme();
+
   const { t } = useTranslation();
   const [menuAnchor, setMenuAnchor] = useState<Element | null>(null);
   const [exporting, setExporting] = useState<boolean>(false);
@@ -95,7 +98,9 @@ const GraphActions = ({
   const convertToPng = (ratio: number): void => {
     setMenuAnchor(null);
     setExporting(true);
+    const bgcolor = theme.palette.background.default;
     exportToPng({
+      bgcolor,
       element: performanceGraphRef.current as HTMLElement,
       ratio,
       title: `${resourceName}-performance`,

--- a/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
@@ -98,7 +98,6 @@ const GraphActions = ({
   const convertToPng = (ratio: number): void => {
     setMenuAnchor(null);
     setExporting(true);
-    const bgcolor = theme.palette.background.default;
     exportToPng({
       bgcolor: theme.palette.background.default,
       element: performanceGraphRef.current as HTMLElement,

--- a/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
@@ -99,7 +99,7 @@ const GraphActions = ({
     setMenuAnchor(null);
     setExporting(true);
     exportToPng({
-      bgcolor: theme.palette.background.default,
+      backgroundColor: theme.palette.background.default,
       element: performanceGraphRef.current as HTMLElement,
       ratio,
       title: `${resourceName}-performance`,

--- a/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/GraphActions.tsx
@@ -100,7 +100,7 @@ const GraphActions = ({
     setExporting(true);
     const bgcolor = theme.palette.background.default;
     exportToPng({
-      bgcolor,
+      bgcolor: theme.palette.background.default,
       element: performanceGraphRef.current as HTMLElement,
       ratio,
       title: `${resourceName}-performance`,


### PR DESCRIPTION
fix No writings in the graph image after export to png when Central is in dark mode

- **video:** 

https://user-images.githubusercontent.com/97687698/181777390-dcda43cf-43c1-4950-8faa-8b9d3fa38ab3.mp4


