### PR TITLE
removed old variable userCrypted and the use of it (#11334)

### DIFF
--- a/www/class/centreonUser.class.php
+++ b/www/class/centreonUser.class.php
@@ -56,7 +56,6 @@ class CentreonUser
     public $groupListStr;
     public $access;
     public $log;
-    public $userCrypted;
     protected $token;
     public $default_page;
     private $showDeprecatedPages;
@@ -107,7 +106,6 @@ class CentreonUser
          * Initiate Log Class
          */
         $this->log = new CentreonUserLog($this->user_id, $pearDB);
-        $this->userCrypted = md5($this->alias);
 
         /**
          * Init rest api auth


### PR DESCRIPTION
## Description

An old variable $userCrypted use md5 on user’s alias.

Kindly check what it is intended for and if it could be removed.
If not, kindly use another method.
file :  www/class/centreonUser.class.php


PS : already merged in develop
**Fixes** # MON-12741

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)


#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
