### PR TITLE
fix(clapi): require bootstrap.php breaks some class loading (#11434)

### DIFF
--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -49,6 +49,14 @@ require_once _CENTREON_PATH_ . "www/class/centreonAuth.LDAP.class.php";
 require_once _CENTREON_PATH_ . 'www/class/centreonLog.class.php';
 require_once realpath(dirname(__FILE__) . "/../centreonSession.class.php");
 
+if (! function_exists('loadDependencyInjector')) {
+	function loadDependencyInjector()
+	{
+		global $dependencyInjector;
+		return $dependencyInjector;
+	}
+}
+
 
 /**
  * General Centreon Management

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -36,7 +36,6 @@
 
 namespace CentreonClapi;
 
-require_once __DIR__ . '/../../../bootstrap.php';
 require_once "centreonObject.class.php";
 require_once "centreonUtils.class.php";
 require_once "centreonTimePeriod.class.php";


### PR DESCRIPTION
Class centreonContact is the only to require 'bootstrap.php' but then other import can failed with class not found exception.

Refs: #11434
Signed-off-by: Grégory Marigot <gmarigot@teicee.com>

## Description

Importing with CLAPI can failed with a "class not found" exception.

It seems to failed with lines that can be imported successfully when they are alone. The responsability could be a precedent import line with CONTACT or CONTACTTPL object. So I suspect the class centreonContact to break class loading for some next objects.

By studying the code in `centreonContact.class.php` i found curious the `require_once __DIR__ . '/../../../bootstrap.php';` because it was the only class in centreon-clapi to do it... And trying without this require solves all the import problems!

**Fixes** #11434

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

This is a sample file to import:
```
CONTACT;ADD;Notify-by-email-workhours;Notify-by-email-workhours;mail@example.org;p4ssw0rd@TEST;0;1;browser;local
STPL;addcontactgroup;default_notification;Guest
```

Which failed without this PR:
```
PHP Fatal error:  Uncaught Error: Class "Centreon_Object_Service" not found in /usr/share/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php:88
Stack trace:
#0 /usr/share/centreon/www/class/centreon-clapi/centreonAPI.class.php(980): CentreonClapi\CentreonServiceTemplate->__construct()
#1 /usr/share/centreon/www/class/centreon-clapi/centreonAPI.class.php(845): CentreonClapi\CentreonAPI->iniObject()
#2 /usr/share/centreon/www/class/centreon-clapi/centreonAPI.class.php(815): CentreonClapi\CentreonAPI->launchActionForImport()
#3 /usr/share/centreon/bin/centreon(196): CentreonClapi\CentreonAPI->import()
#4 {main}
  thrown in /usr/share/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php on line 88
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
