### PR TITLE
fix(debian): reload symfony cache on pkg upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def stableBranch = "22.04.x"
 def devBranch = "dev-22.04.x"
 env.REF_BRANCH = stableBranch
 env.PROJECT='centreon-web'
-if (env.BRANCH_NAME.startsWith('release-')) {
+if (env.CHANGE_BRANCH.startsWith('hotfix-') || env.BRANCH_NAME.startsWith('release-')) {
   env.BUILD = 'RELEASE'
   env.REPO = 'testing'
   env.DELIVERY_STAGE = 'Delivery to testing'

--- a/ci/debian/centreon-web.postinst
+++ b/ci/debian/centreon-web.postinst
@@ -57,4 +57,10 @@ if [ "$1" = "configure" ] ; then
   fi
 
 fi
+
+# rebuild symfony cache on upgrade
+if [ -n "$2" ]; then
+  su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear --no-warmup"
+fi
+
 exit 0


### PR DESCRIPTION
## Description

reload symfony cache on pkg upgrade

**Fixes** MON-14520

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)