### PR TITLE
Fix[platform]: Clean AppKey usage by 22.10 upgrade script

### DIFF
--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -564,7 +564,6 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         } else {
             $data = [
                 'ip' => $serverIP,
-                'app_key' => '',
                 'version' => '',
                 'is_connected' => '1',
                 'created_at' => $date,

--- a/www/install/php/Update-22.10.0-beta.1.php
+++ b/www/install/php/Update-22.10.0-beta.1.php
@@ -36,6 +36,9 @@ try {
     $errorMessage = "Unable to delete 'appKey' information from database";
     $pearDB->query("DELETE FROM `informations` WHERE `key` = 'appKey'");
 
+    $errorMessage = "Unable to drop 'app_key' from remote_servers table";
+    $pearDB->query("ALTER TABLE remote_servers DROP COLUMN `app_key`");
+
     $pearDB->commit();
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {

--- a/www/install/php/Update-22.10.0-beta.1.php
+++ b/www/install/php/Update-22.10.0-beta.1.php
@@ -35,9 +35,10 @@ try {
 
     $errorMessage = "Unable to delete 'appKey' information from database";
     $pearDB->query("DELETE FROM `informations` WHERE `key` = 'appKey'");
-
-    $errorMessage = "Unable to drop 'app_key' from remote_servers table";
-    $pearDB->query("ALTER TABLE remote_servers DROP COLUMN `app_key`");
+    if ($pearDB->isColumnExist('remote_servers', 'app_key') === 1) {
+        $errorMessage = "Unable to drop 'app_key' from remote_servers table";
+        $pearDB->query("ALTER TABLE remote_servers DROP COLUMN `app_key`");
+    }
 
     $pearDB->commit();
 } catch (\Exception $e) {

--- a/www/install/php/Update-22.10.0-beta.1.php
+++ b/www/install/php/Update-22.10.0-beta.1.php
@@ -35,12 +35,12 @@ try {
 
     $errorMessage = "Unable to delete 'appKey' information from database";
     $pearDB->query("DELETE FROM `informations` WHERE `key` = 'appKey'");
+    $pearDB->commit();
+
     if ($pearDB->isColumnExist('remote_servers', 'app_key') === 1) {
         $errorMessage = "Unable to drop 'app_key' from remote_servers table";
         $pearDB->query("ALTER TABLE remote_servers DROP COLUMN `app_key`");
     }
-
-    $pearDB->commit();
 } catch (\Exception $e) {
     if ($pearDB->inTransaction()) {
         $pearDB->rollBack();

--- a/www/install/sql/centreon/Update-DB-22.10.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-22.10.0-beta.1.sql
@@ -122,5 +122,3 @@ ALTER TABLE cfg_nagios MODIFY `enable_predictive_service_dependency_checks` enum
 ALTER TABLE cfg_nagios MODIFY `debug_verbosity` enum('0','1');
 
 ALTER TABLE contact DROP COLUMN `enable_one_click_export`;
-
-ALTER TABLE remote_servers DROP COLUMN `app_key`;


### PR DESCRIPTION
## Description

Cleaning appkey by 22.10 upgrade script.

**Fixes** # MON-12739

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
