### PR TITLE
fix(test): wait 8s before checking downtime is active in apiv1 test

### DIFF
--- a/tests/rest_api/realtime_rest_api.postman_collection.json
+++ b/tests/rest_api/realtime_rest_api.postman_collection.json
@@ -6730,7 +6730,7 @@
 									"  while(curDate-date < millis);",
 									"}",
 									"",
-									"wait(5000);"
+									"wait(8000);"
 								]
 							}
 						},


### PR DESCRIPTION
## Description

fix(test): wait 8s before checking downtime is active in apiv1 test

Refs: MON-14585

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)