### PR TITLE
fix(cron): Escape database name in CentACL 21.10.x 

### DIFF
--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -172,15 +172,15 @@ try {
      * Remove data from old groups (deleted groups)
      */
     $aclGroupToDelete = "SELECT DISTINCT acl_group_id
-        FROM " . $centreonDbName . ".acl_groups WHERE acl_group_activate = '1'";
-    $aclGroupToDelete2 = "SELECT DISTINCT acl_group_id FROM " . $centreonDbName . ".acl_res_group_relations";
-    $pearDB->beginTransaction();
+        FROM `" . $centreonDbName . "`.acl_groups WHERE acl_group_activate = '1'";
+    $aclGroupToDelete2 = "SELECT DISTINCT acl_group_id FROM `" . $centreonDbName . "`.acl_res_group_relations";
+    $pearDBO->beginTransaction();
     try {
         $pearDBO->query("DELETE FROM centreon_acl WHERE group_id NOT IN (" . $aclGroupToDelete . ")");
         $pearDBO->query("DELETE FROM centreon_acl WHERE group_id NOT IN (" . $aclGroupToDelete2 . ")");
-        $pearDB->commit();
+        $pearDBO->commit();
     } catch (\PDOException $e) {
-        $pearDB->rollBack();
+        $pearDBO->rollBack();
         $centreonLog->insertLog(
             2,
             "CentACL CRON: failed to delete old groups relations"


### PR DESCRIPTION
## Description

Some SQL query doesn’t work with a database containing some special characters (e.g - ) into the ACL CRON.  The database name should be surrounded by backquotes in the query strings:

**Fixes** # MON-14394

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
