### PR TITLE
fix(UI): Include host_id when selecting ServiceGroups on dashreports 

### DIFF
--- a/www/include/reporting/dashboard/DB-Func.php
+++ b/www/include/reporting/dashboard/DB-Func.php
@@ -467,7 +467,7 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
         . $aclCondition . " "
         . $servicesSubquery . " "
         . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysOfWeek . ") "
-        . "GROUP BY las.service_id";
+        . "GROUP BY las.host_id, las.service_id";
     $statement = $pearDBO->prepare($rq);
 
     foreach ($bindValues as $bindName => $bindParams) {


### PR DESCRIPTION
## Description

In dashboard reports by servicegroups, sort services by host_id,service_id to improve display when a service is linked to several hosts

**Fixes** #  MON-14325-include-host-id-when-selecting-service-groups-on-dashboard-reports
merged to develop
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
Create 02 hosts

Create a Service by host

On the field "Linked with Hosts" select the 02 hosts that you have created.

Create a Services Group and select the 02 services that you have created.

Apply the changes

Go to Reporting > Dashboard > Service Groups select the Service Group that you have created.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).