### PR TITLE
fix(pendo): correctly set locale when language is detection by browser (#11484)

### DIFF
--- a/www/api/class/centreon_ceip.class.php
+++ b/www/api/class/centreon_ceip.class.php
@@ -120,9 +120,7 @@ class CentreonCeip extends CentreonWebService
      */
     private function getVisitorInformation(): array
     {
-        $locale = $this->user->lang === 'browser'
-            ? null
-            : $this->user->lang;
+        $locale = $this->user->get_lang();
 
         $role = $this->user->admin
             ? "admin"


### PR DESCRIPTION
## Description

22.04.x version of https://github.com/centreon/centreon/pull/11484

**Fixes** # MON-14039

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
