### PR TITLE
fix(autoload): Add classmap to fix autoload with legacy classes #11492

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
             "Tests\\": "tests/php/",
             "Centreon\\Test\\Api\\": "tests/api/"
         },
-        "classmap": ["www/class/"],
+        "classmap": ["www/class/", "lib/Centreon"],
         "files" : [
             "GPL_LIB/smarty-plugins/function.eval.php",
             "www/api/exceptions.php",


### PR DESCRIPTION
## Description

Backport of #11492
When using CLAPI, some classes are not correctly loaded.
The goal of this PR is to include the parent directory directly in the classmap directive of composer.json in order to automatically load all classes located in this directory.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create an import file containing the following data: 
```
CONTACT;setparam;user;enable_one_click_export;0
STPL;setparam;NRPE-Windows-Service;service_parallelize_check;2
```
and try to import it using clapi:
`centreon -u USER -p 'PWD' -i testimportclapi.txt`

No exception error should appear.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
