### PR TITLE
fix(api): fix call to api on fresh install (#11536)

### DIFF
--- a/src/EventSubscriber/UpdateEventSubscriber.php
+++ b/src/EventSubscriber/UpdateEventSubscriber.php
@@ -62,6 +62,12 @@ class UpdateEventSubscriber implements EventSubscriberInterface
      */
     public function validateCentreonWebVersionOrFail(RequestEvent $event): void
     {
+        $this->debug('Checking if database configuration file exists to know if centreon is already installed');
+        if (! file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')) {
+            $this->debug('Centreon database configuration file not found');
+            return;
+        }
+
         $this->debug('Checking if route matches updates endpoint');
         if (
             $event->getRequest()->getMethod() === Request::METHOD_PATCH


### PR DESCRIPTION
## Description

fix call to api on fresh install
this avoid to try access to database if configuration is not found

**Fixes** MON-12296

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)