### PR TITLE
fix(api): do not init db connection in event subscriber

### DIFF
--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -3707,7 +3707,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: ["installed_version", "has_upgrade_available"]
+                required: ["is_installed", "has_upgrade_available"]
                 properties:
                   is_installed:
                     type: boolean

--- a/src/EventSubscriber/UpdateEventSubscriber.php
+++ b/src/EventSubscriber/UpdateEventSubscriber.php
@@ -47,6 +47,10 @@ class UpdateEventSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
+        if (! file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')) {
+            return [];
+        }
+
         return [
             KernelEvents::REQUEST => [
                 ['validateCentreonWebVersionOrFail', 35],
@@ -55,19 +59,13 @@ class UpdateEventSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * validation centreon web installed version
+     * validate centreon web installed version when update endpoint is called
      *
      * @param RequestEvent $event
      * @throws \Exception
      */
     public function validateCentreonWebVersionOrFail(RequestEvent $event): void
     {
-        $this->debug('Checking if database configuration file exists to know if centreon is already installed');
-        if (! file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')) {
-            $this->debug('Centreon database configuration file not found');
-            return;
-        }
-
         $this->debug('Checking if route matches updates endpoint');
         if (
             $event->getRequest()->getMethod() === Request::METHOD_PATCH

--- a/tests/api/Context/PlatformInstallationStatusContext.php
+++ b/tests/api/Context/PlatformInstallationStatusContext.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+namespace Centreon\Test\Api\Context;
+
+use Centreon\Test\Behat\Api\Context\ApiContext;
+
+class PlatformInstallationStatusContext extends ApiContext
+{
+    /**
+     * Remove centreon databases, configuration file and symfony cache
+     *
+     * @Given Centreon Web is not installed
+     */
+    public function centreonWebIsNotInstalled()
+    {
+        $this->getContainer()->execute(
+            'mysql -e "DROP DATABASE centreon_storage"',
+            'web'
+        );
+        $this->getContainer()->execute(
+            'mysql -e "DROP DATABASE centreon"',
+            'web'
+        );
+        $this->getContainer()->execute(
+            'rm -f /etc/centreon/centreon.conf.php',
+            'web'
+        );
+        $this->getContainer()->execute(
+            'rm -rf /var/cache/centreon/symfony',
+            'web'
+        );
+    }
+}

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -81,9 +81,9 @@ default:
       contexts:
         - Centreon\Test\Api\Context\PlatformInformationContext
     platform_fresh_install:
-      paths: [ "%paths.base%/features/PlatformFreshInstall.feature" ]
+      paths: [ "%paths.base%/features/PlatformInstallationStatus.feature" ]
       contexts:
-        - Centreon\Test\Api\Context\PlatformFreshInstallContext
+        - Centreon\Test\Api\Context\PlatformInstallationStatusContext
     platform_update:
       paths: [ "%paths.base%/features/PlatformUpdate.feature" ]
       contexts:

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -80,6 +80,10 @@ default:
       paths: [ "%paths.base%/features/PlatformInformation.feature" ]
       contexts:
         - Centreon\Test\Api\Context\PlatformInformationContext
+    platform_fresh_install:
+      paths: [ "%paths.base%/features/PlatformFreshInstall.feature" ]
+      contexts:
+        - Centreon\Test\Api\Context\PlatformFreshInstallContext
     platform_update:
       paths: [ "%paths.base%/features/PlatformUpdate.feature" ]
       contexts:

--- a/tests/api/features/PlatformInstallationStatus.feature
+++ b/tests/api/features/PlatformInstallationStatus.feature
@@ -1,0 +1,18 @@
+Feature:
+    In order to maintain centreon platform
+    As an administrator
+    I want to known the platform installation status
+
+    Background:
+        Given a running instance of Centreon Web API
+        And the endpoints are described in Centreon Web API documentation
+
+    Scenario: Update platform information
+        When I send a GET request to '/api/latest/platform/installation/status'
+        Then the response code should be "200"
+        And the JSON node "is_installed" should be equal to true
+
+        Given Centreon Web is not installed
+        When I send a GET request to '/api/latest/platform/installation/status'
+        Then the response code should be "200"
+        And the JSON node "is_installed" should be equal to false


### PR DESCRIPTION
## Description

do not init db connection in event subscriber
add api integration test

**Fixes** MON-12296

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)