### PR TITLE
SNYK: Sanitize and bind generateImage queries

### DIFF
--- a/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/www/include/views/graphs/generateGraphs/generateImage.php
@@ -95,6 +95,8 @@ if (!empty($userName) && !empty($token)) {
     } else {
         die('Invalid token');
     }
+} else {
+    throw new \Exception('Username and token query strings must be set.');
 }
 
 $index = filter_var(

--- a/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/www/include/views/graphs/generateGraphs/generateImage.php
@@ -196,6 +196,10 @@ if (!$isAdmin) {
     $hostId = $row['host_id'];
     $serviceId = $row['service_id'];
     $aclGroupsExploded = explode(',', $aclGroups);
+    $aclGroupsQueryBinds = [];
+    if (empty($aclGroupsExploded)) {
+        throw new \Exception('Access denied');
+    }
     foreach ($aclGroupsExploded as $key => $value) {
         $aclGroupsQueryBinds[':acl_group_' . $key] = $value;
     }

--- a/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/www/include/views/graphs/generateGraphs/generateImage.php
@@ -196,10 +196,11 @@ if (!$isAdmin) {
     $hostId = $row['host_id'];
     $serviceId = $row['service_id'];
     $aclGroupsExploded = explode(',', $aclGroups);
-    $aclGroupsQueryBinds = [];
     if (empty($aclGroupsExploded)) {
         throw new \Exception('Access denied');
     }
+
+    $aclGroupsQueryBinds = [];
     foreach ($aclGroupsExploded as $key => $value) {
         $aclGroupsQueryBinds[':acl_group_' . $key] = $value;
     }


### PR DESCRIPTION
## Description

Sanitizing and binding generate image queries to reduce surface attacks and cleaning up some of legacy code.

Preview: 
![image](https://user-images.githubusercontent.com/97593234/183688466-e4957e8f-ded4-411f-b2e4-8ae2f0e6f3eb.png)

**Fixes** # MON-14499

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
