### PR TITLE
SNYK: Sanitize and bind ACL actions queries 21.04.x

### DIFF
--- a/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -170,20 +170,24 @@ function multipleActionInDB($actions = array(), $nbrDup = array())
                     $query = "SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations " .
                         " WHERE acl_action_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
+                    $query = "INSERT INTO acl_group_actions_relations VALUES (:acl_action_id, :acl_group_id)";
+                    $statement =  $pearDB->prepare($query);
                     while ($cct = $dbResult->fetch()) {
-                        $query = "INSERT INTO acl_group_actions_relations VALUES ('" .
-                            $maxId["MAX(acl_action_id)"] . "', '" . $cct["acl_group_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':acl_action_id', (int) $maxId["MAX(acl_action_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':acl_group_id', (int) $cct["acl_group_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                     }
 
                     # Duplicate Actions
                     $query = "SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules " .
                         "WHERE acl_action_rule_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
+                    $query = "INSERT INTO acl_actions_rules VALUES (NULL, :acl_action_id, :acl_action_name)";
+                    $statement = $pearDB->prepare($query);
                     while ($acl = $dbResult->fetch()) {
-                        $query = "INSERT INTO acl_actions_rules VALUES (NULL, '" . $maxId["MAX(acl_action_id)"] .
-                            "', '" . $acl["acl_action_name"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':acl_action_id', (int) $maxId["MAX(acl_action_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':acl_action_name', $acl["acl_action_name"], \PDO::PARAM_STR);
+                        $statement->execute();
                     }
 
                     $dbResult->closeCursor();
@@ -298,8 +302,10 @@ function updateGroupActions($aclActionId, $ret = array())
     }
     global $form, $pearDB;
 
-    $rq = "DELETE FROM acl_group_actions_relations WHERE acl_action_id = '" . $aclActionId . "'";
-    $dbResult = $pearDB->query($rq);
+    $rq = "DELETE FROM acl_group_actions_relations WHERE acl_action_id = :acl_action_id";
+    $statement = $pearDB->prepare($rq);
+    $statement->bindValue(':acl_action_id', (int) $aclActionId, \PDO::PARAM_INT);
+    $statement->execute();
     if (isset($_POST["acl_groups"])) {
         foreach ($_POST["acl_groups"] as $id) {
             $rq = "INSERT INTO acl_group_actions_relations ";
@@ -325,8 +331,10 @@ function updateRulesActions($aclActionId, $ret = array())
         return;
     }
 
-    $rq = "DELETE FROM acl_actions_rules WHERE acl_action_rule_id = '" . $aclActionId . "'";
-    $dbResult = $pearDB->query($rq);
+    $rq = "DELETE FROM acl_actions_rules WHERE acl_action_rule_id = :acl_action_rule_id";
+    $statement = $pearDB->prepare($rq);
+    $statement->bindValue(':acl_action_rule_id', (int) $aclActionId, \PDO::PARAM_INT);
+    $statement->execute();
 
     $actions = array();
     $actions = listActions();


### PR DESCRIPTION
## Description

Sanitizing and binding ACL actions queries to avoid surface attacks and cleaning up some of legacy code.

Preview:

![image](https://user-images.githubusercontent.com/97593234/182801194-ccd5a8d0-ad75-49de-ade6-7cf203d3764f.png)

**Fixes** # MON-14497

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
