### PR TITLE
SNYK: Sanitize and bind Broker listing queries 21.10.x

### DIFF
--- a/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+++ b/www/include/configuration/configCentreonBroker/listCentreonBroker.php
@@ -125,6 +125,12 @@ $style = "one";
 $elemArr = array();
 $centreonToken = createCSRFToken();
 
+$statementBrokerInfo = $pearDB->prepare(
+    "SELECT COUNT(DISTINCT(config_group_id)) as num " .
+    "FROM cfg_centreonbroker_info " .
+    "WHERE config_group = :config_group " .
+    "AND config_id = :config_id"
+);
 
 for ($i = 0; $config = $dbResult->fetch(); $i++) {
     $moptions = "";
@@ -148,23 +154,16 @@ for ($i = 0; $config = $dbResult->fetch(); $i++) {
         . "style=\"margin-bottom:0px;\" name='dupNbr[" . $config['config_id'] . "]'></input>";
 
     // Number of output
-    $res = $pearDB->query(
-        "SELECT COUNT(DISTINCT(config_group_id)) as num " .
-        "FROM cfg_centreonbroker_info " .
-        "WHERE config_group = 'output' " .
-        "AND config_id = " . $config['config_id']
-    );
-    $row = $res->fetch();
+    $statementBrokerInfo->bindValue(':config_id', (int) $config['config_id'], \PDO::PARAM_INT);
+    $statementBrokerInfo->bindValue(':config_group', 'output', \PDO::PARAM_STR);
+    $statementBrokerInfo->execute();
+    $row = $statementBrokerInfo->fetch(\PDO::FETCH_ASSOC);
     $outputNumber = $row["num"];
 
     // Number of input
-    $res = $pearDB->query(
-        "SELECT COUNT(DISTINCT(config_group_id)) as num " .
-        "FROM cfg_centreonbroker_info " .
-        "WHERE config_group = 'input' " .
-        "AND config_id = " . $config['config_id']
-    );
-    $row = $res->fetch();
+    $statementBrokerInfo->bindValue(':config_group', 'input', \PDO::PARAM_STR);
+    $statementBrokerInfo->execute();
+    $row = $statementBrokerInfo->fetch(\PDO::FETCH_ASSOC);
     $inputNumber = $row["num"];
 
     // Number of logger


### PR DESCRIPTION
## Description

Sanitizing and binding Broker listing input output count queries to avoid surface attacks and cleaning up legacy code.

Preview: 
![image](https://user-images.githubusercontent.com/97593234/183053375-f1c5a5af-8297-4bd6-92dc-b1c21fc79160.png)

**Fixes** # MON-14498

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
