### PR TITLE
SNYK: Sanitize and bind Meta-Services dependency queries

### DIFF
--- a/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -115,7 +115,7 @@ function multipleMetaServiceDependencyInDB($dependencies = array(), $nbrDup = ar
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $statement = $pearDB->prepare("INSERT INTO dependency_metaserviceParent_relation " .
-                        "VALUES ( :maxId, :metaId)");
+                        "VALUES (:maxId, :metaId)");
                     while ($ms = $dbResult->fetch()) {
                         $statement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
                         $statement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);

--- a/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -114,19 +114,23 @@ function multipleMetaServiceDependencyInDB($dependencies = array(), $nbrDup = ar
                     $query = "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation " .
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
+                    $statement = $pearDB->prepare("INSERT INTO dependency_metaserviceParent_relation " .
+                        "VALUES ( :maxId, :metaId)");
                     while ($ms = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_metaserviceParent_relation " .
-                            "VALUES ('" . $maxId["MAX(dep_id)"] . "', '" . $ms["meta_service_meta_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                     }
                     $dbResult->closeCursor();
                     $query = "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation " .
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
+                    $childStatement = $pearDB->prepare("INSERT INTO dependency_metaserviceChild_relation " .
+                        "VALUES (:maxId, :metaId)");
                     while ($ms = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_metaserviceChild_relation VALUES ('" .
-                            $maxId["MAX(dep_id)"] . "', '" . $ms["meta_service_meta_id"] . "')";
-                        $pearDB->query($query);
+                        $childStatement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $childStatement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);
+                        $childStatement->execute();
                     }
                     $dbResult->closeCursor();
                 }


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

www/include/configuration/configObject/metaservice_dependency/DB-Func.php

Lines:

+120

+129
Globally:

sanitize if possible each variables inserted in a query

use PDO prepared statement and bind() method

Do not use $pearDB->escape on which is for examples useless on integers and on non closed HTML tags (svg, img, etc)

Verify that IDs are saved as integers in the database before binding them.

**Fixes** # MON-14500

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Configuration > notifications > meta-service
![image](https://user-images.githubusercontent.com/108519266/183697530-cf8ee8f0-f91e-4d6c-abcf-50f25f15b33c.png)


Create a dependency between two hosts

Set the host as passive and using the forced status, trigger a notification as expected

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
