### PR TITLE
MON-14501 - sanitize query in centreonXmlbgRequest class

### DIFF
--- a/www/class/centreonXMLBGRequest.class.php
+++ b/www/class/centreonXMLBGRequest.class.php
@@ -221,11 +221,11 @@ class CentreonXMLBGRequest
 
     private function isUserAdmin()
     {
-        $query = "SELECT contact_admin, contact_id FROM contact " .
-            "WHERE contact.contact_id = '" . CentreonDB::escape($this->user_id) . "' LIMIT 1";
-        $dbResult = $this->DB->query($query);
-        $admin = $dbResult->fetchRow();
-        $dbResult->closeCursor();
+        $statement = $this->DB->prepare("SELECT contact_admin, contact_id FROM contact " .
+            "WHERE contact.contact_id = :userId LIMIT 1");
+        $statement->bindValue(":userId", (int) $this->user_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $admin = $statement->fetchRow();
         if ($admin !== false && $admin["contact_admin"]) {
             $this->is_admin = 1;
         } else {

--- a/www/class/centreonXMLBGRequest.class.php
+++ b/www/class/centreonXMLBGRequest.class.php
@@ -226,6 +226,7 @@ class CentreonXMLBGRequest
         $statement->bindValue(":userId", (int) $this->user_id, \PDO::PARAM_INT);
         $statement->execute();
         $admin = $statement->fetchRow();
+        $statement->closeCursor();
         if ($admin !== false && $admin["contact_admin"]) {
             $this->is_admin = 1;
         } else {


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

www/class/centreonXMLBGRequest.class.php

Line 226

What

Globally:

sanitize if possible each variables inserted in a query

use PDO prepared statement and bind() method

Do not use $pearDB->escape on which is for examples useless on integers and on non closed HTML tags (svg, img, etc)

Verify that IDs are saved as integers in the database before binding them

**Fixes** # MON-14501

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

With a non admin user, go to “Monitoring > Status Details > Services Grid” menu and check if you can see result
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
