### PR TITLE
Rename metrics/download API to metrics/performance/download API

### DIFF
--- a/config/routes/Centreon/monitoring/metric.yaml
+++ b/config/routes/Centreon/monitoring/metric.yaml
@@ -31,7 +31,7 @@ monitoring.metric.getServicePerformanceMetrics:
 
 monitoring.metric.downloadPerformanceMetrics:
     methods: GET
-    path: /monitoring/hosts/{hostId}/services/{serviceId}/metrics/download
+    path: /monitoring/hosts/{hostId}/services/{serviceId}/metrics/performance/download
     requirements:
         hostId: '\d+'
         serviceId: '\d+'

--- a/doc/API/centreon-api-v22.10.yaml
+++ b/doc/API/centreon-api-v22.10.yaml
@@ -3400,7 +3400,7 @@ paths:
           $ref: '#/components/responses/NotFoundHostOrService'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/{host_id}/services/{service_id}/metrics/download:
+  /monitoring/hosts/{host_id}/services/{service_id}/metrics/performance/download:
     get:
       tags:
         - Metrics


### PR DESCRIPTION
## Description

This PR renames exising API route name ````metrics/download```` to ````metrics/performance/download```` API:

**Fixes** #MON-14675

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Request the API like : ```${HOST}/centreon/api/latest/monitoring/hosts/`${HOST_ID}/services/`${SERVICE_ID}/metrics/performance/download?start_date=2022-08-01T00:00:22Z&end_date=2022-08-08T18:00:22Z```



## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
