### PR TITLE
SNYK: Sanitize and bind generateImage queries 22.04

### DIFF
--- a/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/www/include/views/graphs/generateGraphs/generateImage.php
@@ -95,6 +95,8 @@ if (!empty($userName) && !empty($token)) {
     } else {
         die('Invalid token');
     }
+} else {
+    throw new \Exception('Username and token query strings must be set.');
 }
 
 $index = filter_var(
@@ -182,19 +184,37 @@ if (!$isAdmin) {
     $dbstorage = new CentreonDB('centstorage');
 
     $aclGroups = $acl->getAccessGroupsString();
-    $sql = "SELECT host_id, service_id FROM index_data WHERE id = " .$pearDB->escape($index);
-    $res = $dbstorage->query($sql);
-    if (!$res->rowCount()) {
+    $sql = "SELECT host_id, service_id FROM index_data WHERE id = :index_data_id";
+    $statement = $dbstorage->prepare($sql);
+    $statement->bindValue(':index_data_id', (int) $index, \PDO::PARAM_INT);
+    $statement->execute();
+    if (!$statement->rowCount()) {
         die('Graph not found');
     }
-    $row = $res->fetch();
-    unset($res);
+    $row = $statement->fetch(\PDO::FETCH_ASSOC);
+    unset($statement);
     $hostId = $row['host_id'];
     $serviceId = $row['service_id'];
-    $sql = "SELECT service_id FROM centreon_acl WHERE host_id = $hostId AND service_id = $serviceId
-        AND group_id IN ($aclGroups)";
-    $res = $pearDBO->query($sql);
-    if (!$res->rowCount()) {
+    $aclGroupsExploded = explode(',', $aclGroups);
+    if (empty($aclGroupsExploded)) {
+        throw new \Exception('Access denied');
+    }
+
+    $aclGroupsQueryBinds = [];
+    foreach ($aclGroupsExploded as $key => $value) {
+        $aclGroupsQueryBinds[':acl_group_' . $key] = $value;
+    }
+    $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
+    $sql = "SELECT service_id FROM centreon_acl WHERE host_id = :host_id AND service_id = :service_id
+        AND group_id IN ($aclGroupBinds)";
+    $statement = $pearDBO->prepare($sql);
+    $statement->bindValue(':host_id', (int) $hostId, \PDO::PARAM_INT);
+    $statement->bindValue(':service_id', (int) $serviceId, \PDO::PARAM_INT);
+    foreach ($aclGroupsQueryBinds as $key => $value) {
+        $statement->bindValue($key, (int) $value, \PDO::PARAM_INT);
+    }
+    $statement->execute();
+    if (!$statement->rowCount()) {
         die('Access denied');
     }
 }


### PR DESCRIPTION
## Description

Sanitizing and binding generate image queries to reduce surface attacks and cleaning up some of legacy code.

Preview: 
![image](https://user-images.githubusercontent.com/97593234/183688466-e4957e8f-ded4-411f-b2e4-8ae2f0e6f3eb.png)

**Fixes** # MON-14499

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
