### PR TITLE
fix bottom page actions list for ACL groups (MON-14759)

### DIFF
--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -71,7 +71,14 @@ $select = is_array($select) ? sanitize_input_array($select) : [];
 $acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? null, FILTER_VALIDATE_INT) ?? null;
 
 // Caution $o may already be set from the GET or from the POST.
-$postO = filter_var($_POST['o1'] ?? $_POST['o2'] ?? $o ?? null, FILTER_SANITIZE_STRING);
+if (isset($_POST['o1']) && !empty($_POST['o1'])) {
+    $postO = filter_var($_POST['o1'], FILTER_SANITIZE_STRING);
+} elseif (isset($_POST['o2']) && !empty($_POST['o2'])) {
+    $postO = filter_var($_POST['o2'], FILTER_SANITIZE_STRING);
+} elseif (isset($o) && !empty($o)) {
+    $postO = filter_var($o, FILTER_SANITIZE_STRING);
+}
+
 $o = ("" !== $postO) ? $postO : null;
 
 switch ($o) {


### PR DESCRIPTION
## Description

when you go to the acl group menu, if you try any action on an existing acl group using the actions list that is at the bottom of the acl group list. Then nothing will happen. It works fine if you use the actions list that is at the top of the acl group list

on the technical side, we can't use the php coalescing operator because $_POST['o1'] and $_POST['o2'] are never null. They are empty but always set.

**Fixes** 
IBT-730

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

**without the patch:**

- go to administration -> acl groups 
- try to duplicate an existing rule (or create a new one, it can be empty and duplicate it) using the action list that is at the bottom of the page
- nothing will happen

repeat the above steps using the action list at the top of the page, and it will successfully duplicate the acl group

**with the patch:**
repeat the above actions, it will now work using either the action list that is at the top of the page or the one at the bottom.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
