### PR TITLE
(fix) issue with db names using special chars during fresh install

### DIFF
--- a/www/install/steps/process/installConfigurationDb.php
+++ b/www/install/steps/process/installConfigurationDb.php
@@ -82,7 +82,7 @@ if ($open_files_limit < 32000) {
 }
 
 try {
-    $link->exec("CREATE DATABASE " . $parameters['db_configuration']);
+    $link->exec("CREATE DATABASE `" . $parameters['db_configuration'] . "`");
 } catch (\PDOException $e) {
     if (!is_file('../../tmp/createTables')) {
         $return['msg'] = $e->getMessage();
@@ -94,7 +94,7 @@ try {
 /**
  * Create tables
  */
-$link->exec('use ' . $parameters['db_configuration']);
+$link->exec("use `" . $parameters['db_configuration'] . "`");
 $result = splitQueries('../../createTables.sql', ';', $link, '../../tmp/createTables');
 if ("0" != $result) {
     $return['msg'] = $result;

--- a/www/install/steps/process/installStorageDb.php
+++ b/www/install/steps/process/installStorageDb.php
@@ -61,7 +61,7 @@ try {
 }
 
 try {
-    $link->exec("CREATE DATABASE " . $parameters['db_storage']);
+    $link->exec("CREATE DATABASE `" . $parameters['db_storage'] . "`");
 } catch (\PDOException $e) {
     if (!is_file('../../tmp/createTablesCentstorage')) {
         $return['msg'] = $e->getMessage();
@@ -79,7 +79,7 @@ $macros = array_merge(
 );
 
 try {
-    $result = $link->query('use ' . $parameters['db_storage']);
+    $result = $link->query("use `" . $parameters['db_storage'] . "`");
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_storage'] . '" database');
     }


### PR DESCRIPTION
## Description

Fixed an issue with database names using special characters (i.e. "-") during fresh install of Centreon.

**Fixes** # MON-14742

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use `centreon-config` and `centreon-storage` as db name on a central server

Update ACL

update acl_groups set acl_group_changed = 1;
Run manually ACL cron:

`/usr/bin/php /usr/share/centreon/cron/centAcl.php`
Check that no error appear in term

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
