### PR TITLE
(fix)MON-14742 Escape database name in CentACL

### DIFF
--- a/www/class/centreon-partition/mysqlTable.class.php
+++ b/www/class/centreon-partition/mysqlTable.class.php
@@ -423,7 +423,7 @@ class MysqlTable
     public function exists()
     {
         try {
-            $DBRESULT = $this->db->query("use " . $this->schema);
+            $DBRESULT = $this->db->query("use `" . $this->schema . "`");
         } catch (\PDOException $e) {
             throw new Exception(
                 "SQL Error: Cannot use database "

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -236,7 +236,7 @@ class PartEngine
      */
     public function createParts($table, $db, $createPastPartitions): void
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if ($table->exists()) {
             throw new Exception("Warning: Table " . $tableName . " already exists\n");
         }
@@ -253,7 +253,7 @@ class PartEngine
         }
 
         try {
-            $dbResult = $db->query("use " . $table->getSchema());
+            $dbResult = $db->query("use `" . $table->getSchema() . "`");
         } catch (\PDOException $e) {
             throw new Exception(
                 "SQL Error: Cannot use database "
@@ -325,7 +325,7 @@ class PartEngine
             $condition = $this->purgeDailyPartitionCondition($table);
         }
 
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Error: Table " . $tableName . " does not exists\n");
         }
@@ -364,7 +364,7 @@ class PartEngine
      */
     public function migrate($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
 
         $db->query("SET bulk_insert_buffer_size= 1024 * 1024 * 256");
 
@@ -411,7 +411,7 @@ class PartEngine
      */
     public function updateParts($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
 
         //verifying if table is partitioned
         if ($this->isPartitioned($table, $db) === false) {
@@ -433,7 +433,7 @@ class PartEngine
      */
     public function optimizeTablePartitions($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Optimize error: Table " . $tableName . " does not exists\n");
         }
@@ -472,7 +472,7 @@ class PartEngine
      */
     public function listParts($table, $db, $throwException = true)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Parts list error: Table " . $tableName . " does not exists\n");
         }
@@ -521,7 +521,7 @@ class PartEngine
      */
     public function backupParts($table, $db)
     {
-        $tableName = $table->getSchema() . "." . $table->getName();
+        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Error: Table " . $tableName . " does not exists\n");
         }

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -82,7 +82,7 @@ $checkMysqlVersion = "SHOW VARIABLES WHERE Variable_name LIKE 'version%'";
 
 // creating the user - mandatory for MySQL DB
 $alterQuery = "ALTER USER :dbUser@:host IDENTIFIED WITH mysql_native_password BY :dbPass";
-$query = "GRANT ALL PRIVILEGES ON %s.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
+$query = "GRANT ALL PRIVILEGES ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
 $flushQuery = "FLUSH PRIVILEGES";
 
 try {

--- a/www/install/steps/process/insertBaseConf.php
+++ b/www/install/steps/process/insertBaseConf.php
@@ -65,7 +65,7 @@ try {
  * Create tables
  */
 try {
-    $result = $link->query('use ' . $parameters['db_configuration']);
+    $result = $link->query('use `' . $parameters['db_configuration'] . '`');
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_configuration'] . '" database');
     }

--- a/www/install/steps/process/insertBaseConf.php
+++ b/www/install/steps/process/insertBaseConf.php
@@ -65,7 +65,7 @@ try {
  * Create tables
  */
 try {
-    $result = $link->query('use `' . $parameters['db_configuration'] . '`');
+    $result = $link->query(sprintf('use `%s`', $parameters['db_configuration']));
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_configuration'] . '" database');
     }

--- a/www/install/steps/process/installConfigurationDb.php
+++ b/www/install/steps/process/installConfigurationDb.php
@@ -82,7 +82,7 @@ if ($open_files_limit < 32000) {
 }
 
 try {
-    $link->exec("CREATE DATABASE " . $parameters['db_configuration']);
+    $link->exec("CREATE DATABASE `" . $parameters['db_configuration'] . "`");
 } catch (\PDOException $e) {
     if (!is_file('../../tmp/createTables')) {
         $return['msg'] = $e->getMessage();
@@ -94,7 +94,7 @@ try {
 /**
  * Create tables
  */
-$link->exec('use ' . $parameters['db_configuration']);
+$link->exec("use `" . $parameters['db_configuration'] . "`");
 $result = splitQueries('../../createTables.sql', ';', $link, '../../tmp/createTables');
 if ("0" != $result) {
     $return['msg'] = $result;

--- a/www/install/steps/process/installConfigurationDb.php
+++ b/www/install/steps/process/installConfigurationDb.php
@@ -82,7 +82,7 @@ if ($open_files_limit < 32000) {
 }
 
 try {
-    $link->exec("CREATE DATABASE `" . $parameters['db_configuration'] . "`");
+    $link->exec(sprintf('CREATE DATABASE `%s`', $parameters['db_configuration']));
 } catch (\PDOException $e) {
     if (!is_file('../../tmp/createTables')) {
         $return['msg'] = $e->getMessage();
@@ -94,7 +94,7 @@ try {
 /**
  * Create tables
  */
-$link->exec("use `" . $parameters['db_configuration'] . "`");
+$link->exec(sprintf('use `%s`', $parameters['db_configuration']));
 $result = splitQueries('../../createTables.sql', ';', $link, '../../tmp/createTables');
 if ("0" != $result) {
     $return['msg'] = $result;

--- a/www/install/steps/process/installStorageDb.php
+++ b/www/install/steps/process/installStorageDb.php
@@ -61,7 +61,7 @@ try {
 }
 
 try {
-    $link->exec("CREATE DATABASE `" . $parameters['db_storage'] . "`");
+    $link->exec(sprintf('CREATE DATABASE `%s`', $parameters['db_storage']));
 } catch (\PDOException $e) {
     if (!is_file('../../tmp/createTablesCentstorage')) {
         $return['msg'] = $e->getMessage();
@@ -79,7 +79,7 @@ $macros = array_merge(
 );
 
 try {
-    $result = $link->query("use `" . $parameters['db_storage'] . "`");
+    $result = $link->query(sprintf('use `%s`', $parameters['db_storage']));
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_storage'] . '" database');
     }

--- a/www/install/steps/process/installStorageDb.php
+++ b/www/install/steps/process/installStorageDb.php
@@ -61,7 +61,7 @@ try {
 }
 
 try {
-    $link->exec("CREATE DATABASE " . $parameters['db_storage']);
+    $link->exec("CREATE DATABASE `" . $parameters['db_storage'] . "`");
 } catch (\PDOException $e) {
     if (!is_file('../../tmp/createTablesCentstorage')) {
         $return['msg'] = $e->getMessage();
@@ -79,7 +79,7 @@ $macros = array_merge(
 );
 
 try {
-    $result = $link->query('use ' . $parameters['db_storage']);
+    $result = $link->query("use `" . $parameters['db_storage'] . "`");
     if (!$result) {
         throw new \Exception('Cannot access to "' . $parameters['db_storage'] . '" database');
     }


### PR DESCRIPTION
## Description

Fixed issue of using special characters (i.e. "-") in db names during fresh install.

**Fixes** # MON-14742

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use `centreon-config` and `centreon-storage` as db name on a central server

Update ACL
`update acl_groups set acl_group_changed = 1;`

Run manually ACL cron:
`/usr/bin/php /usr/share/centreon/cron/centAcl.php`

Check that no error appear in term

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
