### PR TITLE
MON-14425 fix centreon.ini and autoconfigure timezone

### DIFF
--- a/ci/debian/centreon-web.postinst
+++ b/ci/debian/centreon-web.postinst
@@ -63,4 +63,17 @@ if [ -n "$2" ]; then
   su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear --no-warmup"
 fi
 
+# Try auto configure timezone for php
+timezone=$(/usr/bin/php -r '
+  $timezoneName = timezone_name_from_abbr(trim(shell_exec("date \"+%Z\"")));
+  if (preg_match("/Time zone: (\S+)/", shell_exec("timedatectl"), $matches)) {
+    $timezoneName = $matches[1];
+  }
+  if (date_default_timezone_set($timezoneName) === false) {
+    $timezoneName = "UTC";
+  }
+  echo $timezoneName;
+' 2>/dev/null)
+sed -i "s#^date.timezone = .*#date.timezone = ${timezone}#" /etc/php/8.0/mods-available/centreon.ini
+
 exit 0

--- a/ci/debian/extra/centreon-web/centreon.ini
+++ b/ci/debian/extra/centreon-web/centreon.ini
@@ -1,1 +1,5 @@
+max_execution_time = 300
+session.use_strict_mode = 1
+session.gc_maxlifetime = 7200
+expose_php = Off
 date.timezone = UTC


### PR DESCRIPTION
## Description

Fix missing configurations to Centreon in php.ini and try auto configure the timezone

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
