### PR TITLE
fix(openid): correctly set contact_location while creating session

### DIFF
--- a/src/Centreon/Domain/Contact/Contact.php
+++ b/src/Centreon/Domain/Contact/Contact.php
@@ -167,9 +167,9 @@ class Contact implements UserInterface, ContactInterface
     private $timezone;
 
     /**
-     * @var string
+     * @var int
      */
-    private string $timezoneId;
+    private int $timezoneId;
 
     /**
      * @var string|null $locale locale of the user
@@ -193,14 +193,21 @@ class Contact implements UserInterface, ContactInterface
      */
     private $theme;
 
-    public function setTimezoneId(string $timezoneId): self
+    /**
+     * @param int $timezoneId
+     * @return self
+     */
+    public function setTimezoneId(int $timezoneId): self
     {
         $this->timezoneId = $timezoneId;
 
         return $this;
     }
 
-    public function getTimezoneId(): string
+    /**
+     * @return int
+     */
+    public function getTimezoneId(): int
     {
         return $this->timezoneId;
     }

--- a/src/Centreon/Domain/Contact/Contact.php
+++ b/src/Centreon/Domain/Contact/Contact.php
@@ -167,6 +167,11 @@ class Contact implements UserInterface, ContactInterface
     private $timezone;
 
     /**
+     * @var string
+     */
+    private string $timezoneId;
+
+    /**
      * @var string|null $locale locale of the user
      */
     private $locale;
@@ -187,6 +192,18 @@ class Contact implements UserInterface, ContactInterface
      * @var string|null
      */
     private $theme;
+
+    public function setTimezoneId(string $timezoneId): self
+    {
+        $this->timezoneId = $timezoneId;
+
+        return $this;
+    }
+
+    public function getTimezoneId(): string
+    {
+        return $this->timezoneId;
+    }
 
     /**
      * @return int

--- a/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
+++ b/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
@@ -26,7 +26,10 @@ use Centreon\Domain\Menu\Model\Page;
 
 interface ContactInterface
 {
-    public function getTimezoneId(): string;
+    /**
+     * @return int Returns the timezone id
+     */
+    public function getTimezoneId(): int;
 
     /**
      * @return int Returns the contact id

--- a/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
+++ b/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
@@ -26,6 +26,8 @@ use Centreon\Domain\Menu\Model\Page;
 
 interface ContactInterface
 {
+    public function getTimezoneId(): string;
+
     /**
      * @return int Returns the contact id
      */

--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -421,6 +421,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             ->setAccessToApiRealTime($contact['reach_api_rt'] === '1')
             ->setAccessToApiConfiguration($contact['reach_api'] === '1')
             ->setTimezone(new \DateTimeZone($contactTimezoneName))
+            ->setTimezoneId($contact['contact_location'])
             ->setLocale($contactLocale)
             ->setDefaultPage($page)
             ->setUseDeprecatedPages($contact['show_deprecated_pages'] === '1')

--- a/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -421,7 +421,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             ->setAccessToApiRealTime($contact['reach_api_rt'] === '1')
             ->setAccessToApiConfiguration($contact['reach_api'] === '1')
             ->setTimezone(new \DateTimeZone($contactTimezoneName))
-            ->setTimezoneId($contact['contact_location'])
+            ->setTimezoneId((int) $contact['contact_location'])
             ->setLocale($contactLocale)
             ->setDefaultPage($page)
             ->setUseDeprecatedPages($contact['show_deprecated_pages'] === '1')

--- a/src/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
+++ b/src/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
@@ -106,7 +106,7 @@ class LoginOpenIdSession
                 'contact_autologin_key' => '',
                 'contact_admin' => $user->isAdmin() ? '1' : '0',
                 'default_page' => $user->getDefaultPage(),
-                'contact_location' => $user->getLocale(),
+                'contact_location' => $user->getTimezoneId(),
                 'show_deprecated_pages' => $user->isUsingDeprecatedPages(),
                 'reach_api' => $user->hasAccessToApiConfiguration() ? 1 : 0,
                 'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0

--- a/src/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
+++ b/src/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSession.php
@@ -106,7 +106,7 @@ class LoginOpenIdSession
                 'contact_autologin_key' => '',
                 'contact_admin' => $user->isAdmin() ? '1' : '0',
                 'default_page' => $user->getDefaultPage(),
-                'contact_location' => $user->getTimezoneId(),
+                'contact_location' => (string) $user->getTimezoneId(),
                 'show_deprecated_pages' => $user->isUsingDeprecatedPages(),
                 'reach_api' => $user->hasAccessToApiConfiguration() ? 1 : 0,
                 'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0


### PR DESCRIPTION
## Description

This PR Intends to fix an issue where contact_location wasn't correctly set while authenticating through OpenID Connect.
Previously we set the locale as contact_location instead of timezone.id 


**Fixes** # MON-14227

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
