### PR TITLE
enh (UI) use new CSV exporter API in performance page to download data file

### DIFF
--- a/www/include/views/graphs/getGraphAjax.php
+++ b/www/include/views/graphs/getGraphAjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2005-2018 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -73,7 +74,8 @@ $servicesReturn = array();
 function getServiceGraphByHost($host, $isAdmin, $lca)
 {
     $listGraph = array();
-    if ($isAdmin ||
+    if (
+        $isAdmin ||
         (!$isAdmin && isset($lca[$host]))
     ) {
         $services =  getMyHostServices($host);
@@ -100,11 +102,14 @@ function getServiceGraphByHost($host, $isAdmin, $lca)
  */
 function getGraphByService($host, $svcId, $title, $isAdmin, $lca)
 {
-    if (service_has_graph($host, $svcId) &&
+    if (
+        service_has_graph($host, $svcId) &&
         ($isAdmin || (!$isAdmin && isset($lca[$host][$svcId])))
     ) {
         return array(
             'type' => 'service',
+            'host' => $host,
+            'service' => $svcId,
             'id' => $host . '_' . $svcId,
             'title' => $title
         );

--- a/www/include/views/graphs/getGraphAjax.php
+++ b/www/include/views/graphs/getGraphAjax.php
@@ -103,8 +103,8 @@ function getServiceGraphByHost($host, $isAdmin, $lca)
 function getGraphByService($host, $svcId, $title, $isAdmin, $lca)
 {
     if (
-        service_has_graph($host, $svcId) &&
-        ($isAdmin || (!$isAdmin && isset($lca[$host][$svcId])))
+        service_has_graph($host, $svcId)
+        && ($isAdmin || (!$isAdmin && isset($lca[$host][$svcId])))
     ) {
         return array(
             'type' => 'service',

--- a/www/include/views/graphs/getGraphAjax.php
+++ b/www/include/views/graphs/getGraphAjax.php
@@ -75,8 +75,8 @@ function getServiceGraphByHost($host, $isAdmin, $lca)
 {
     $listGraph = array();
     if (
-        $isAdmin ||
-        (!$isAdmin && isset($lca[$host]))
+        $isAdmin
+        || (!$isAdmin && isset($lca[$host]))
     ) {
         $services =  getMyHostServices($host);
         foreach ($services as $svcId => $svcName) {

--- a/www/include/views/graphs/getGraphAjax.php
+++ b/www/include/views/graphs/getGraphAjax.php
@@ -108,8 +108,8 @@ function getGraphByService($host, $svcId, $title, $isAdmin, $lca)
     ) {
         return array(
             'type' => 'service',
-            'host' => $host,
-            'service' => $svcId,
+            'hostId' => $host,
+            'serviceId' => $svcId,
             'id' => $host . '_' . $svcId,
             'title' => $title
         );

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -117,7 +117,7 @@ const templateGraph = ({ graphId, graphType, graphTitle, hostId, serviceId }) =>
                 </a>
                 {/if}
                 {literal}
-                <a class="actions" data-href="./centreon/api/latest/monitoring/">
+                <a class="actions" data-href="">
                     <span class="ico-18 margin_right">
                         ${pictureIcon}
                     </span>

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -117,12 +117,12 @@ const templateGraph = ({ graphId, graphType, graphTitle, hostId, serviceId }) =>
                 </a>
                 {/if}
                 {literal}
-                <a class="actions" data-href="">
+                <a class="actions" data-href="./include/views/graphs/generateGraphs/generateImage.php">
                     <span class="ico-18 margin_right">
                         ${pictureIcon}
                     </span>
                 </a>
-                <a class="actions" data-hostid="${hostId}" data-serviceid="${serviceId}" data-href="./include/views/graphs/exportData/ExportCSVServiceData.php">
+                <a class="actions download_graph_csv" data-hostid="${hostId}" data-serviceid="${serviceId}">
                     <span class="ico-18 margin_right">
                         ${csvIcon}
                     </span>
@@ -398,46 +398,71 @@ jQuery(function () {
         }
     });
 
-    /* Add events on click on action download image/CSV */
-    jQuery('.graphZone').delegate('a.actions,a.actions-simple', 'click', function (e) {
-        const $a = jQuery(this);
-        const hostId = $a.data('hostid');
-        const serviceId = $a.data('serviceid');
+    function getGraphDates(periodValue, startDateValue, endDateValue) {
         let start;
         let end;
 
-        /* Get the period */
-        if (jQuery('select[name="period"]').val() === '') {
-            start = moment.tz(
-                jQuery('input[name="alternativeDateStartDate"]').val() + ' ' + jQuery('#StartTime').val(),
-                timezone
-            );
-            end = moment.tz(
-                jQuery('input[name="alternativeDateEndDate"]').val() + ' ' + jQuery('#EndTime').val(),
-                timezone
-            );
+        if (periodValue === '') {
+            start = moment.tz(startDateValue, timezone);
+            end = moment.tz(endDateValue, timezone);
             duration = moment.duration(end.diff(start));
         } else {
-            parseInterval = jQuery('select[name="period"]').val().match(/(\d+)([a-z]+)/i);
-            duration = moment.duration(
-                parseInt(parseInterval[1], 10),
-                parseInterval[2]
-            );
+            parseInterval = periodValue.match(/(\d+)([a-z]+)/i);
+            duration = moment.duration(parseInt(parseInterval[1], 10), parseInterval[2]);
             start = moment().tz(timezone);
             end = moment().tz(timezone);
             start.subtract(parseInterval[1], parseInterval[2]);
         }
 
-        e.preventDefault();
+        return {'start': start, 'end': end};
+    }
 
-        const startDate = start.toISOString();
-        const endDate = end.toISOString();
-
+    function generateGraphCSVDownloadUrl(hostId, serviceId, startDate, endDate) {
         const location = window.location;
         const baseUrl = location .protocol + "//" + location.host + "/" + location.pathname.split('/')[1];
-        const url = baseUrl + '/api/latest/monitoring/hosts/' + hostId + '/services/' + serviceId + '/metrics/performance/download?start_date=' + startDate + '&end_date=' + endDate;
+        let url = baseUrl + '/api/latest/monitoring';
+            url+= '/hosts/' + hostId;
+            url+= '/services/' + serviceId + '/metrics/performance/download?';
+            url+= 'start_date=' + startDate;
+            url+= '&end_date=' + endDate;
 
-        window.location = url;
+        return url;
+    }
+
+    function generateChartActionURL(baseUrl, chartId, startDate, endDate) {
+        if (baseUrl.indexOf('?') !== -1) {
+            baseUrl += '&';
+        } else {
+            baseUrl += '?';
+        }
+
+        return baseUrl + 'chartId=' + chartId + '&start=' + startDate + '&end=' + endDate;
+    }
+
+    function generateActionURL(elmnt) {
+        const period = jQuery('select[name="period"]').val();
+        const startDate = jQuery('input[name="alternativeDateStartDate"]').val() + ' ' + jQuery('#StartTime').val();
+        const endDate = jQuery('input[name="alternativeDateEndDate"]').val() + ' ' + jQuery('#EndTime').val();
+
+        const dates = getGraphDates(period, startDate, endDate);
+
+        if (elmnt.hasClass('download_graph_csv')) {
+            const hostId = elmnt.data('hostid');
+            const serviceId = elmnt.data('serviceid');
+
+            return generateGraphCSVDownloadUrl(hostId, serviceId, dates.start.toISOString(), dates.end.toISOString())
+        }
+
+        const baseUrl = elmnt.data('href');
+        const chartId = elmnt.parents('.graph').data('graphId');
+
+        return generateChartActionURL(baseUrl, chartId, dates.start.unix(), dates.end.unix());
+    }
+
+    /* Add events on click on action download image/CSV */
+    jQuery('.graphZone').delegate('a.actions,a.actions-simple', 'click', function (e) {
+        e.preventDefault();
+        window.location = generateActionURL(jQuery(this));
     });
 
     /* Remove a chart */

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -417,10 +417,23 @@ jQuery(function () {
         return {'start': start, 'end': end};
     }
 
+    function extractBaseUrlFromUrl(url) {
+        const scriptNamePos = url.indexOf('main.get.php');
+        if (scriptNamePos === -1) {
+            throw 'Unable to extract base url from URL';
+        }
+
+        const baseUrl = url.substring(0, scriptNamePos);
+        if (baseUrl.charAt(baseUrl.length - 1) !== '/') {
+            return baseUrl + '/';
+        }
+
+        return baseUrl;
+    }
+
     function generateGraphCSVDownloadUrl(hostId, serviceId, startDate, endDate) {
-        const location = window.location;
-        const baseUrl = location .protocol + "//" + location.host + "/" + location.pathname.split('/')[1];
-        let url = baseUrl + '/api/latest/monitoring';
+        const baseUrl = extractBaseUrlFromUrl(window.location.href);
+        let url = baseUrl + 'api/latest/monitoring';
             url+= '/hosts/' + hostId;
             url+= '/services/' + serviceId + '/metrics/performance/download?';
             url+= 'start_date=' + startDate;

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -94,7 +94,7 @@ var tooManyChartMsg = "{t}You cannot add more charts. The maximum charts is {/t}
 {literal}
 
 var charts = [];
-const templateGraph = ({ graphId, graphType, graphTitle }) => {
+const templateGraph = ({ graphId, graphType, graphTitle, hostId, serviceId }) => {
     var closeIcon = "{/literal}{$removeIcon}{literal}";
     var csvIcon = "{/literal}{$csvIcon}{literal}";
     var pictureIcon = "{/literal}{$pictureIcon}{literal}";
@@ -117,12 +117,12 @@ const templateGraph = ({ graphId, graphType, graphTitle }) => {
                 </a>
                 {/if}
                 {literal}
-                <a class="actions" data-href="./include/views/graphs/generateGraphs/generateImage.php">
+                <a class="actions" data-href="./centreon/api/latest/monitoring/">
                     <span class="ico-18 margin_right">
                         ${pictureIcon}
                     </span>
                 </a>
-                <a class="actions" data-href="./include/views/graphs/exportData/ExportCSVServiceData.php">
+                <a class="actions" data-hostid="${hostId}" data-serviceid="${serviceId}" data-href="./include/views/graphs/exportData/ExportCSVServiceData.php">
                     <span class="ico-18 margin_right">
                         ${csvIcon}
                     </span>
@@ -211,7 +211,7 @@ function initRefresh() {
   });
 }
 
-function addChart(id, name, times) {
+function addChart(id, name, times, hostId, serviceId) {
     var refreshInterval;
     var parseInterval;
     var datepickerFormat = jQuery("#StartDate").datepicker("option", "dateFormat");
@@ -255,7 +255,9 @@ function addChart(id, name, times) {
             graphId: id,
             graphType: 'service',
             graphTitle: name,
-            status: true
+            status: true,
+            hostId: hostId,
+            serviceId: serviceId,
         })
     );
     jQuery('#graph-' + id).centreonGraph(times);
@@ -299,7 +301,7 @@ function loadChart(chart, callback) {
                     alert(tooManyChartMsg);
                     break;
                 }
-                addChart(data[i].id, data[i].title, times);
+                addChart(data[i].id, data[i].title, times, data[i].host, data[i].service);
             }
             displayNav(end);
             if (typeof callback == 'function') {
@@ -398,11 +400,11 @@ jQuery(function () {
 
     /* Add events on click on action download image/CSV */
     jQuery('.graphZone').delegate('a.actions,a.actions-simple', 'click', function (e) {
-        var $a = jQuery(this);
-        var baseUrl = $a.data('href');
-        var chartId = $a.parents('.graph').data('graphId');
-        var start;
-        var end;
+        const $a = jQuery(this);
+        const hostId = $a.data('hostid');
+        const serviceId = $a.data('serviceid');
+        let start;
+        let end;
 
         /* Get the period */
         if (jQuery('select[name="period"]').val() === '') {
@@ -427,14 +429,15 @@ jQuery(function () {
         }
 
         e.preventDefault();
-        if (baseUrl.indexOf('?') !== -1) {
-            baseUrl += '&';
-        } else {
-            baseUrl += '?';
-        }
 
-        baseUrl += 'chartId=' + chartId + '&start=' + start.unix() + '&end=' + end.unix();
-        window.location = baseUrl;
+        const startDate = start.toISOString();
+        const endDate = end.toISOString();
+
+        const location = window.location;
+        const baseUrl = location .protocol + "//" + location.host + "/" + location.pathname.split('/')[1];
+        const url = baseUrl + '/api/latest/monitoring/hosts/' + hostId + '/services/' + serviceId + '/metrics/performance/download?start_date=' + startDate + '&end_date=' + endDate;
+
+        window.location = url;
     });
 
     /* Remove a chart */

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -301,7 +301,7 @@ function loadChart(chart, callback) {
                     alert(tooManyChartMsg);
                     break;
                 }
-                addChart(data[i].id, data[i].title, times, data[i].host, data[i].service);
+                addChart(data[i].id, data[i].title, times, data[i].hostId, data[i].serviceId);
             }
             displayNav(end);
             if (typeof callback == 'function') {


### PR DESCRIPTION
## Description

This PR replaces the usage from old export script on performance page with new export API

**Fixes** # MON-14503

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- on the => Monitoring > Resources Status page click on the row with graph data
- on graphs tab click on "go to performance page" button
- on the performance page click on csv buton
- A file download dialog should be open and generated file would be created from new exporter API

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
