### PR TITLE
Snyk : Sanitize and bind listServiceCategories queries

### DIFF
--- a/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -119,12 +119,12 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 $elemArr = array();
 $centreonToken = createCSRFToken();
 
+$statement = $pearDB->prepare("SELECT COUNT(*) FROM `service_categories_relation` WHERE `sc_id` = :sc_id");
 for ($i = 0; $sc = $dbResult->fetch(); $i++) {
     $moptions = "";
-    $dbResult2 = $pearDB->query(
-        "SELECT COUNT(*) FROM `service_categories_relation` WHERE `sc_id` = '" . $sc['sc_id'] . "'"
-    );
-    $nb_svc = $dbResult2->fetch();
+    $statement->bindValue(':sc_id', (int) $sc['sc_id'], \PDO::PARAM_INT);
+    $statement->execute();
+    $nb_svc = $statement->fetch();
 
     $selectedElements = $form->addElement('checkbox', "select[" . $sc['sc_id'] . "]");
 


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

### Where

www/include/configuration/configObject/service_categories/listServiceCategories.php

Lines:

- 124

### Globally:

sanitize if possible each variables inserted in a query

use PDO prepared statement and bind() method

Do not use $pearDB->escape on which is for examples useless on integers and on non closed HTML tags (svg, img, etc)

Verify that IDs are saved as integers in the database before binding them

**Fixes** #MON-14701

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

![image](https://user-images.githubusercontent.com/108519266/187171765-fb38e00e-83ba-44a4-8daf-c58eca25faca.png)

- Access to “Configuration  >  Services  >  Categories” menu
- Check if the “Number of linked services” count are correctly and legitly displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
