### PR TITLE
SNYK :Sanitize and bind in centreon connector queries

### DIFF
--- a/www/class/centreonConnector.class.php
+++ b/www/class/centreonConnector.class.php
@@ -35,40 +35,40 @@
 
 /*
  *  Class that contains various methods for managing connectors
- * 
+ *
  * Usage example:
- * 
+ *
  * <?php
  * require_once realpath(dirname(__FILE__) . "/../../config/centreon.config.php");
  * require_once _CENTREON_PATH_ . 'www/class/centreonConnector.class.php';
  * require_once _CENTREON_PATH_ . 'www/class/centreonDB.class.php';
- * 
+ *
  * $connector = new CentreonConnector(new CentreonDB);
- * 
+ *
  * //$connector->create(array(
  * //    'name' => 'jackyse',
  * //    'description' => 'some jacky',
  * //    'command_line' => 'ls -la',
  * //    'enabled' => true
  * //        ), true);
- * 
+ *
  * //$connector->update(10, array(
  * //    'name' => 'soapy',
  * //    'description' => 'Lorem ipsum',
  * //    'enabled' => true,
  * //    'command_line' => 'ls -laph --color'
  * //));
- * 
+ *
  * //$connector->getList(false, 20, false);
- * 
+ *
  * //$connector->delete(10);
- * 
+ *
  * //$connector->read(7);
- * 
+ *
  * //$connector->copy(1, 5, true);
- * 
+ *
  * //$connector->count(false);
- * 
+ *
  * //$connector->isNameAvailable('norExists');
  */
 
@@ -165,11 +165,13 @@ class CentreonConnector
                 throw new RuntimeException('Field id for connector not selected in query or connector not inserted');
             } else {
                 if (isset($connector["command_id"])) {
+                    $statement = $this->dbConnection->prepare("UPDATE `command` " .
+                        "SET connector_id = :conId WHERE `command_id` = :value");
                     foreach ($connector["command_id"] as $key => $value) {
                         try {
-                            $query = "UPDATE `command` SET connector_id = '" . $lastId['id'] . "' " .
-                                "WHERE `command_id` = '" . $value . "'";
-                            $this->dbConnection->query($query);
+                            $statement->bindValue(':conId', (int) $lastId['id'], \PDO::PARAM_INT);
+                            $statement->bindValue(':value', (int) $value, \PDO::PARAM_INT);
+                            $statement->execute();
                         } catch (\PDOException $e) {
                             throw new RuntimeException('Cannot update connector');
                         }


### PR DESCRIPTION
## Description
Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

**Where**

www/class/centreonConnector.class.php

Lines: 172

**Globally:**

sanitize if possible each variables inserted in a query

use PDO prepared statement and bind() method

Do not use $pearDB->escape on which is for examples useless on integers and on non closed HTML tags (svg, img, etc)

Verify that IDs are saved as integers in the database before binding them
**Fixes** # MON-14700

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Access to “Configuration  >  Commands  >  Connectors” menu

- Create a connector and fill all the fields
-
- Check if the fields are correcty filled with new infos.
![image](https://user-images.githubusercontent.com/108519266/185577517-fed1368b-1cd9-4512-a389-7c6d4a1b7aaa.png)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
