### PR TITLE
fix(clapi): Check that user is admin to use clapi (#11631)

### DIFF
--- a/www/api/class/centreon_clapi.class.php
+++ b/www/api/class/centreon_clapi.class.php
@@ -230,7 +230,7 @@ class CentreonClapi extends CentreonWebService implements CentreonWebServiceDiIn
     {
         if (
             parent::authorize($action, $user, $isInternal)
-            || ($user && $user->hasAccessRestApiConfiguration())
+            || ($user && $user->is_admin())
         ) {
             return true;
         }


### PR DESCRIPTION
## Description

This PR intends to check that user is admin to use clapi 

**Fixes** # MON-12771

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
