### PR TITLE
fix(resource-status): add missing alias to Host detail factory

### DIFF
--- a/src/Core/Infrastructure/RealTime/Repository/Host/DbHostFactory.php
+++ b/src/Core/Infrastructure/RealTime/Repository/Host/DbHostFactory.php
@@ -76,7 +76,8 @@ class DbHostFactory
             ->setLastCheck(self::createDateTimeFromTimestamp((int) $data['last_check']))
             ->setLastTimeUp(self::createDateTimeFromTimestamp((int) $data['last_time_up']))
             ->setMaxCheckAttempts(self::getIntOrNull($data['max_check_attempts']))
-            ->setCheckAttempts(self::getIntOrNull($data['check_attempt']));
+            ->setCheckAttempts(self::getIntOrNull($data['check_attempt']))
+            ->setAlias($data['alias']);
 
         $nextCheck = self::createDateTimeFromTimestamp(
             (int) $data['active_checks'] === 1 ? (int) $data['next_check'] : null


### PR DESCRIPTION
## Description

This PR intends to fix an issue of missing alias data regarding the detaill of a Host in Resource Status

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Set an alias for the Host
It should be displayed in the detail panel of the host in Resource Status

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
