### PR TITLE
feat(select2): adds poller acl into the select2 list

### DIFF
--- a/www/class/centreonInstance.class.php
+++ b/www/class/centreonInstance.class.php
@@ -297,7 +297,11 @@ class CentreonInstance
         $stmt->execute();
         while ($data = $stmt->fetch()) {
             $hide = false;
-            if (!$centreon->user->access->admin && count($pollerAcl) && !in_array($data['id'], array_keys($pollerAcl))) {
+            if (
+                ! $centreon->user->access->admin
+                && count($pollerAcl)
+                && !in_array($data['id'], array_keys($pollerAcl))
+            ) {
                 $hide = true;
             }
             $items[] = array(

--- a/www/class/centreonInstance.class.php
+++ b/www/class/centreonInstance.class.php
@@ -266,7 +266,7 @@ class CentreonInstance
             return $items;
         }
 
-        # get list of authorized pollers
+        // get list of authorized pollers
         if (!$centreon->user->access->admin) {
             $pollerAcl = $centreon->user->access->getPollers();
         }

--- a/www/class/centreonInstance.class.php
+++ b/www/class/centreonInstance.class.php
@@ -257,20 +257,31 @@ class CentreonInstance
      */
     public function getObjectForSelect2($values = array(), $options = array())
     {
+        global $centreon;
+
         $selectedInstances = '';
         $items = array();
+
+        if (empty($values)) {
+            return $items;
+        }
+
+        # get list of authorized pollers
+        if (!$centreon->user->access->admin) {
+            $pollerAcl = $centreon->user->access->getPollers();
+        }
+
         $listValues = '';
         $queryValues = array();
-        if (!empty($values)) {
-            foreach ($values as $k => $v) {
-                $listValues .= ':instance' . $v . ',';
-                $queryValues['instance' . $v] = (int)$v;
+        foreach ($values as $k => $v) {
+            $multipleValues = explode(',', $v);
+            foreach ($multipleValues as $item) {
+                $listValues .= ':pId_' . $item . ', ';
+                $queryValues['pId_' . $item] = (int)$item;
             }
-            $listValues = rtrim($listValues, ',');
-            $selectedInstances .= "AND rel.instance_id IN ($listValues) ";
-        } else {
-            $listValues .= '""';
         }
+        $listValues = rtrim($listValues, ', ');
+        $selectedInstances .= " AND rel.instance_id IN ($listValues) ";
 
         $query = 'SELECT DISTINCT p.name as name, p.id  as id FROM cfg_resource r, nagios_server p, ' .
             'cfg_resource_instance_relations rel ' .
@@ -280,17 +291,19 @@ class CentreonInstance
             ' ORDER BY p.name';
 
         $stmt = $this->db->prepare($query);
-        if (!empty($queryValues)) {
-            foreach ($queryValues as $key => $id) {
-                $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
-            }
+        foreach ($queryValues as $key => $id) {
+            $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
         }
         $stmt->execute();
-
         while ($data = $stmt->fetch()) {
+            $hide = false;
+            if (!$centreon->user->access->admin && count($pollerAcl) && !in_array($data['id'], array_keys($pollerAcl))) {
+                $hide = true;
+            }
             $items[] = array(
                 'id' => $data['id'],
-                'text' => $data['name']
+                'text' => $data['name'],
+                'hide' => $hide
             );
         }
 


### PR DESCRIPTION
## Description

The PDO request try to bind a string of multiple id separated with comma, instead of binding each id
+ adds poller acl into the select2 list
this is mostly a rip-off of #7119

**Fixes** MON-10870

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)