### PR TITLE
feat(packaging): add php grpc, protobuf modules as dependencies

### DIFF
--- a/ci/debian/control
+++ b/ci/debian/control
@@ -89,6 +89,8 @@ Depends:
     php8.0-ldap,
     php8.0-readline,
     php8.0-sqlite3,
+    php8.0-grpc,
+    php8.0-protobuf,
     php-pear,
     ntp,
     rrdtool,


### PR DESCRIPTION
## Description

This PR intends to add 2 new dependencies for centreon-web (for debian packaging).
Those dependencies are 2 new PHP modules that will be used to interact with centreon-engine GRPc APIs

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Tested with full feature

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
