### PR TITLE
Sanitize and bind service group dependecies queries 21.10.x

### DIFF
--- a/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -128,10 +128,13 @@ function multipleServiceGroupDependencyInDB($dependencies = array(), $nbrDup = a
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_sgParents"] = "";
+                    $query = "INSERT INTO dependency_servicegroupParent_relation " .
+                             "VALUES (:dep_id, :servicegroup_sg_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($sg = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_servicegroupParent_relation " .
-                            "VALUES ('" . $maxId["MAX(dep_id)"] . "', '" . $sg["servicegroup_sg_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':servicegroup_sg_id', (int) $sg["servicegroup_sg_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_sgParents"] .= $sg["servicegroup_sg_id"] . ",";
                     }
                     $fields["dep_sgParents"] = trim($fields["dep_sgParents"], ",");
@@ -140,10 +143,13 @@ function multipleServiceGroupDependencyInDB($dependencies = array(), $nbrDup = a
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["dep_sgChilds"] = "";
+                    $query = "INSERT INTO dependency_servicegroupChild_relation " .
+                             "VALUES (:dep_id, :servicegroup_sg_id)";
+                    $statement = $pearDB->prepare($query);
                     while ($sg = $dbResult->fetch()) {
-                        $query = "INSERT INTO dependency_servicegroupChild_relation " .
-                            "VALUES ('" . $maxId["MAX(dep_id)"] . "', '" . $sg["servicegroup_sg_id"] . "')";
-                        $pearDB->query($query);
+                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
+                        $statement->bindValue(':servicegroup_sg_id', (int) $sg["servicegroup_sg_id"], \PDO::PARAM_INT);
+                        $statement->execute();
                         $fields["dep_sgChilds"] .= $sg["servicegroup_sg_id"] . ",";
                     }
                     $fields["dep_sgChilds"] = trim($fields["dep_sgChilds"], ",");


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code.

**Fixes** # MON-14666

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
