### PR TITLE
fix(upgrade): Correctly Parse SQL Comments (#11658)

### DIFF
--- a/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
+++ b/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
@@ -287,7 +287,7 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      */
     private function isSqlComment(string $line): bool
     {
-        return str_starts_with('--', trim($line));
+        return str_starts_with(trim($line), '--');
     }
 
     /**


### PR DESCRIPTION
## Description

This PR intends to fix an issue while updating centreon, where SQL comments wasn't correctly parsed.

**Fixes** # MON-14848

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
