### PR TITLE
fix(conf) fix parent template display in service template listing

### DIFF
--- a/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -62,7 +62,7 @@
             <td class="ListColLeft resizeTitle"><a
                     href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias}</a></td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_retry}</td>
-            <td class="ListColRight">{$elemArr[elem].RowMenu_parent}</td>
+            <td class="ListColLeft">{$elemArr[elem].RowMenu_parent}</td>
             <td class="ListColCenter"><span
                     class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
             <td class="ListColRight" align="right">{if $mode_access == 'w'}{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>

--- a/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
@@ -176,7 +176,8 @@ for ($i = 0; $service = $dbResult->fetch(); $i++) {
         foreach ($tplArr as $key => $value) {
             $value = str_replace('#S#', "/", $value);
             $value = str_replace('#BS#', "\\", $value);
-            $tplStr .= "&nbsp;->&nbsp;<a href='main.php?p=60206&o=c&service_id=" . $key . "'>" . $value . "</a>";
+            $tplStr .= "&nbsp;->&nbsp;<a href='main.php?p=60206&o=c&service_id=" . $key . "'>"
+            . htmlentities($value) . "</a>";
         }
     }
 
@@ -232,7 +233,7 @@ for ($i = 0; $service = $dbResult->fetch(); $i++) {
         "RowMenu_select" => $selectedElements->toHtml(),
         "RowMenu_desc" => htmlentities($service["service_description"]),
         "RowMenu_alias" => htmlentities($service["service_alias"]),
-        "RowMenu_parent" => htmlentities($tplStr),
+        "RowMenu_parent" => $tplStr,
         "RowMenu_icon" => $svc_icon,
         "RowMenu_retry" => htmlentities(
             "$normal_check_interval $normal_units / $retry_check_interval $retry_units"


### PR DESCRIPTION
## Description

Parent templates column doesn't display properly in service templates listing :
![image-20220901-085039](https://user-images.githubusercontent.com/88387848/187878052-69366e87-0d5e-4f0e-9e1f-96b1d01cba46.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
