### PR TITLE
Remove empty dataset from graph export file

### DIFF
--- a/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -78,24 +78,19 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
     private function generateDataBinQuery(array $metrics): string
     {
         $metricIds = [];
-        $metricNames = [];
         $subQueryColumns = [];
         $subQueryPattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS %s';
         foreach ($metrics as $metric) {
             $subQueryColumns[] = sprintf($subQueryPattern, $metric->getId(), $metric->getName());
             $metricIds[] = $metric->getId();
-            $metricNames[] = $metric->getName();
         }
 
-        $subQuery = sprintf(
-            'SELECT id_metric, %s FROM `:dbstg`.data_bin WHERE ctime >= :start AND ctime < :end GROUP BY time',
-            join(', ', ['ctime AS time', ...$subQueryColumns])
-        );
+        $pattern = 'SELECT %s FROM `:dbstg`.data_bin WHERE ';
+        $pattern .= ' ctime >= :start AND ctime < :end AND id_metric IN (%s) GROUP BY time';
 
         return sprintf(
-            'SELECT %s FROM (%s) as s WHERE s.id_metric IN (%s)',
-            join(',', ['time', ...$metricNames]),
-            $subQuery,
+            $pattern,
+            join(', ', ['ctime AS time', ...$subQueryColumns]),
             join(',', $metricIds)
         );
     }

--- a/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -56,19 +56,8 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
         $this->db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
         $this->db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
-        $columns = ['ctime AS time'];
-        $pattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS %s';
-        foreach ($metrics as $metric) {
-            $columns[] = sprintf($pattern, $metric->getId(), $metric->getName());
-        }
-
-        $query = sprintf(
-            'SELECT %s FROM `:dbstg`.data_bin WHERE ctime >= :start AND ctime < :end GROUP BY time',
-            join(',', $columns)
-        );
-
+        $query = $this->generateDataBinQuery($metrics);
         $statement = $this->db->prepare($this->translateDbName($query));
-
         $statement->bindValue(':start', $startDate->getTimestamp(), PDO::PARAM_INT);
         $statement->bindValue(':end', $endDate->getTimestamp(), PDO::PARAM_INT);
         $statement->execute();
@@ -78,6 +67,37 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
         }
 
         $statement->closeCursor();
+    }
+
+    /**
+     * Generates SQL query statement to extract metric data from table data_bin
+     *
+     * @param  array<Metric> $metrics
+     * @return string
+     */
+    private function generateDataBinQuery(array $metrics): string
+    {
+        $metricIds = [];
+        $metricNames = [];
+        $subQueryColumns = [];
+        $subQueryPattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS %s';
+        foreach ($metrics as $metric) {
+            $subQueryColumns[] = sprintf($subQueryPattern, $metric->getId(), $metric->getName());
+            $metricIds[] = $metric->getId();
+            $metricNames[] = $metric->getName();
+        }
+
+        $subQuery = sprintf(
+            'SELECT id_metric, %s FROM `:dbstg`.data_bin WHERE ctime >= :start AND ctime < :end GROUP BY time',
+            join(', ', ['ctime AS time', ...$subQueryColumns])
+        );
+
+        return sprintf(
+            'SELECT %s FROM (%s) as s WHERE s.id_metric IN (%s)',
+            join(',', ['time', ...$metricNames]),
+            $subQuery,
+            join(',', $metricIds)
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

** This PR fixes empty records issue on data_bin extraction as CSV file

**Fixes** 
MON-13543

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Export CSV file from from Monitoring > Performances > Graphs
- Export the CSV file from Resource Status > Graph tab with the same date span
- Both file should be the same (without rows with 0)

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
