### PR TITLE
fix(ui): fix svg display in legacy monitoring pages (#11659)

### DIFF
--- a/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
@@ -38,7 +38,10 @@
                         <xsl:element name="a">
                             <xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
                             <xsl:attribute name="isreact">true</xsl:attribute>
-                            <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                            <xsl:element name="span">
+                                <xsl:attribute name="class">svgs</xsl:attribute>
+                                <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                            </xsl:element>
                         </xsl:element>
                         <xsl:element name="a">
                             <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>

--- a/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
@@ -32,7 +32,10 @@
 			<xsl:element name="a">
 			  	<xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
                 <xsl:attribute name="isreact">true</xsl:attribute>
-                <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                <xsl:element name="span">
+                    <xsl:attribute name="class">svgs</xsl:attribute>
+                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                </xsl:element>
 			</xsl:element>
 			<xsl:element name="a">
 			  	<xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>

--- a/www/include/monitoring/status/ServicesHostGroups/xsl/serviceGridByHG.xsl
+++ b/www/include/monitoring/status/ServicesHostGroups/xsl/serviceGridByHG.xsl
@@ -87,11 +87,17 @@
 					<xsl:element name="a">
 					  	<xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
 						<xsl:attribute name="isreact">true</xsl:attribute>
-                        <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+						<xsl:element name="span">
+                            <xsl:attribute name="class">svgs</xsl:attribute>
+                            <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+						</xsl:element>
 					</xsl:element>
 					<xsl:element name="a">
 					  	<xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                        <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+						<xsl:element name="span">
+                            <xsl:attribute name="class">svgs</xsl:attribute>
+                            <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+						</xsl:element>
 					</xsl:element>
 				</td>
 				<xsl:if test="//i/s = 1">
@@ -122,5 +128,8 @@
 </xsl:for-each>
 </table>
 <div id="div_popup" class="popup_volante"><div class="container-load"></div><div id="popup-container-display"></div></div>
+<script type="text/javascript">
+	$(displaySvgOnXSL());
+</script>
 </xsl:template>
 </xsl:stylesheet>

--- a/www/include/monitoring/status/ServicesHostGroups/xsl/serviceSummaryByHG.xsl
+++ b/www/include/monitoring/status/ServicesHostGroups/xsl/serviceSummaryByHG.xsl
@@ -97,11 +97,17 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
                                 <xsl:attribute name="isreact">true</xsl:attribute>
-                                <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                <xsl:element name="span">
+                                    <xsl:attribute name="class">svgs</xsl:attribute>
+                                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                </xsl:element>
                             </xsl:element>
                             <xsl:element name="a">
                                 <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                                <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                <xsl:element name="span">
+                                    <xsl:attribute name="class">svgs</xsl:attribute>
+                                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                </xsl:element>
                             </xsl:element>
                         </td>
                         <xsl:if test="//i/s = 1">
@@ -173,5 +179,8 @@
             <div class="container-load"></div>
             <div id="popup-container-display"></div>
         </div>
+        <script type="text/javascript">
+	        $(displaySvgOnXSL());
+        </script>
     </xsl:template>
 </xsl:stylesheet>

--- a/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceGridBySG.xsl
+++ b/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceGridBySG.xsl
@@ -49,11 +49,17 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
                                 <xsl:attribute name="isreact">true</xsl:attribute>
-                                <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                <xsl:element name="span">
+                                    <xsl:attribute name="class">svgs</xsl:attribute>
+                                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                </xsl:element>
                             </xsl:element>
                             <xsl:element name="a">
                                 <xsl:attribute name="href">main.php?p=20401&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                                <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                <xsl:element name="span">
+                                    <xsl:attribute name="class">svgs</xsl:attribute>
+                                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                </xsl:element>
                             </xsl:element>
                         </td>
                         <xsl:if test="//i/s = 1">
@@ -90,5 +96,8 @@
             <div class="container-load"></div>
             <div id="popup-container-display"></div>
         </div>
+        <script type="text/javascript">
+	        $(displaySvgOnXSL());
+        </script>
     </xsl:template>
 </xsl:stylesheet>

--- a/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceSummaryBySG.xsl
+++ b/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceSummaryBySG.xsl
@@ -42,11 +42,17 @@
 			<td class="ListColLeft" style="white-space:nowrap;width:37px;">
 				<xsl:element name="a">
 				  	<xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
-                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                    <xsl:element name="span">
+                        <xsl:attribute name="class">svgs</xsl:attribute>
+                        <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                    </xsl:element>
 				</xsl:element>
 				<xsl:element name="a">
 				  	<xsl:attribute name="href">main.php?p=20401&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
-                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                    <xsl:element name="span">
+                        <xsl:attribute name="class">svgs</xsl:attribute>
+                        <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                    </xsl:element>
 				</xsl:element>
 			</td>
             <xsl:if test="//i/s = 1">
@@ -119,5 +125,8 @@
 </xsl:for-each>
 </table>
 <div id="div_popup" class="popup_volante"><div class="container-load"></div><div id="popup-container-display"></div></div>
+<script type="text/javascript">
+	$(displaySvgOnXSL());
+</script>
 </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
## Description

fix svg display in legacy monitoring pages for firefox

**Fixes** MON-14869

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)