### PR TITLE
fix spelling of some words in french

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2178,7 +2178,7 @@ msgstr "Groupe de contacts"
 
 #: centreon-web/www/install/smarty_translate.php:714
 msgid "Previous"
-msgstr "Précédant"
+msgstr "Précédent"
 
 #: centreon-web/www/install/smarty_translate.php:717
 msgid "Next"
@@ -5973,7 +5973,7 @@ msgstr "Première page"
 #: centreon-web/www/include/common/pagination.php:166
 #: centreon-web/www/include/configuration/configKnowledge/pagination.php:150
 msgid "Previous page"
-msgstr "Page précédante"
+msgstr "Page précédente"
 
 #: centreon-web/www/include/common/pagination.php:167
 #: centreon-web/www/include/configuration/configKnowledge/pagination.php:151


### PR DESCRIPTION
## Description

this one is for fixing the spelling of the words previous and previous page in french. 

![fix-précédent](https://user-images.githubusercontent.com/109956462/188453191-d27848ac-7aa1-4033-9271-bffaef6a7f18.PNG)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:

In the Autodiscovery wizard in French, the “back” button is spelled “Précédant”.  We changed it to the correct spelling “Précédent”.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
