### PR TITLE
Fix: In Acces group the second select not working [ACL]

### DIFF
--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -71,8 +71,14 @@ $select = is_array($select) ? sanitize_input_array($select) : [];
 $acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? null, FILTER_VALIDATE_INT) ?? null;
 
 // Caution $o may already be set from the GET or from the POST.
-$postO = filter_var($_POST['o1'] ?? $_POST['o2'] ?? $o ?? null, FILTER_SANITIZE_STRING);
-$o = ("" !== $postO) ? $postO : null;
+$postO = filter_var(
+    $_POST['o1'] ?? $_POST['o2'] ?? null,
+    FILTER_VALIDATE_REGEXP,
+    array("options" => array("regexp" => "/([a|c|d|m|s|u|w]{1})/"))
+);
+if ($postO !== false) {
+    $o = $postO;
+}
 
 switch ($o) {
     case "a":

--- a/www/include/options/accessLists/groupsACL/groupsConfig.php
+++ b/www/include/options/accessLists/groupsACL/groupsConfig.php
@@ -72,9 +72,9 @@ $acl_group_id = filter_var($_GET['acl_group_id'] ?? $_POST['acl_group_id'] ?? nu
 
 // Caution $o may already be set from the GET or from the POST.
 $postO = filter_var(
-    $_POST['o1'] ?? $_POST['o2'] ?? null,
+    $_POST['o1'] ?? $_POST['o2'] ?? $o ?? null,
     FILTER_VALIDATE_REGEXP,
-    array("options" => array("regexp" => "/([a|c|d|m|s|u|w]{1})/"))
+    ["options" => ["regexp" => "/^(a|c|d|m|s|u|w)$/"]]
 );
 if ($postO !== false) {
     $o = $postO;


### PR DESCRIPTION
## Description

Second select (under the list) wasn't working, this should take care of it and should work as intended.

**Fixes** # MON-13785

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
