### PR TITLE
fix(widgets): retrieve possibility to not select poller in preferences

### DIFF
--- a/www/class/centreonWidget/Params/Connector/Poller.class.php
+++ b/www/class/centreonWidget/Params/Connector/Poller.class.php
@@ -48,6 +48,7 @@ class CentreonWidgetParamsConnectorPoller extends CentreonWidgetParamsList
         static $tab;
 
         if (! isset($tab)) {
+            $tab = [null => null];
             $userACL = new CentreonACL($this->userId);
             $isContactAdmin = $userACL->admin;
             $request = 'SELECT SQL_CALC_FOUND_ROWS id, name FROM nagios_server ns';


### PR DESCRIPTION
## Description

retrieve possibility to not select poller in preferences

**Fixes** MON-14919

![image](https://user-images.githubusercontent.com/11978823/188581449-8feede23-1fbf-443d-9311-3d16aae69888.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Add service-monitoring widget in custom views
* Go to preferences form
* select poller filter
* check according services are properly displayed
* do not select poller filter
* check according services are properly displayed