### PR TITLE
fix(centreontrapd): check if conf file is not empty before to load it

### DIFF
--- a/lib/perl/centreon/script.pm
+++ b/lib/perl/centreon/script.pm
@@ -142,7 +142,7 @@ sub parse_options {
     die "Command line error" if !GetOptions(%{$self->{options}});
     pod2usage(-exitval => 1, -input => $FindBin::Bin . "/" . $FindBin::Script) if $self->{help};
     if ($self->{noconfig} == 0) {
-        if (-e "$self->{config_file}") {
+        if (-e "$self->{config_file}" && -s "$self->{config_file}") {
             require $self->{config_file};
             $self->{centreon_config} = $centreon_config;
         }


### PR DESCRIPTION
## Description

Check if the file exists and is not empty

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
