### PR TITLE
fix(ui): SVG icons in status views compatible with Firefox (#11527)

### DIFF
--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -458,7 +458,7 @@ while ($data = $dbResult->fetch()) {
     } else {
         $obj->XML->writeElement("hau", "none");
     }
-    $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
+    $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
     $obj->XML->endElement();
 }
 $dbResult->closeCursor();

--- a/www/include/monitoring/status/Hosts/xsl/host.xsl
+++ b/www/include/monitoring/status/Hosts/xsl/host.xsl
@@ -181,7 +181,7 @@
 				<xsl:attribute name="href">./main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
 				<xsl:element name="span">
 					<xsl:attribute name="class">svgs</xsl:attribute>
-					<xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+					<xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
 				</xsl:element>
 			</xsl:element>
 			

--- a/www/include/monitoring/status/Services/xml/serviceGridXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceGridXML.php
@@ -235,8 +235,8 @@ if (isset($tab_svc)) {
                     ]),
                 ])
         );
-        $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
-        $obj->XML->writeElement("viewIcon", returnSvg("www/img/icons/view.svg", "var(--icons-fill-color)", 18, 18));
+        $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
+        $obj->XML->writeElement("viewIcon", "./img/icons/view.svg");
         $obj->XML->endElement();
     }
 }

--- a/www/include/monitoring/status/Services/xml/serviceSummaryXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceSummaryXML.php
@@ -288,8 +288,8 @@ foreach ($tabFinal as $host_name => $tab) {
             ? $serviceListingDeprecatedUri . '&statusFilter=pending'
             : $buildServicesUri($host_name, [$pendingStatus])
     );
-    $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
-    $obj->XML->writeElement("viewIcon", returnSvg("www/img/icons/view.svg", "var(--icons-fill-color)", 18, 18));
+    $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
+    $obj->XML->writeElement("viewIcon", "./img/icons/view.svg");
     $obj->XML->endElement();
 }
 

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -660,7 +660,7 @@ if (!$sqlError) {
             "svc_index",
             (isset($graphs[$data["host_id"]][$data["service_id"]]) ? $graphs[$data["host_id"]][$data["service_id"]] : 0)
         );
-        $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
+        $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
         $obj->XML->endElement();
     }
     $dbResult->closeCursor();

--- a/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/www/include/monitoring/status/Services/xsl/service.xsl
@@ -299,7 +299,7 @@
                     <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>
                     <xsl:element name="span">
                         <xsl:attribute name="class">svgs</xsl:attribute>
-                        <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                        <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
                     </xsl:element>
                 </xsl:element>
             </xsl:if>

--- a/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
@@ -40,14 +40,14 @@
                             <xsl:attribute name="isreact">true</xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">svgs</xsl:attribute>
-                                <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="viewIcon"/></xsl:attribute></xsl:element>
                             </xsl:element>
                         </xsl:element>
                         <xsl:element name="a">
                             <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">svgs</xsl:attribute>
-                                <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
                             </xsl:element>
                         </xsl:element>
                     </td>

--- a/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
@@ -34,14 +34,14 @@
                 <xsl:attribute name="isreact">true</xsl:attribute>
                 <xsl:element name="span">
                     <xsl:attribute name="class">svgs</xsl:attribute>
-                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                    <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="viewIcon"/></xsl:attribute></xsl:element>
                 </xsl:element>
 			</xsl:element>
 			<xsl:element name="a">
 			  	<xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
                 <xsl:element name="span">
                     <xsl:attribute name="class">svgs</xsl:attribute>
-                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                    <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
                 </xsl:element>
 			</xsl:element>
 		</td>

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
@@ -321,11 +321,11 @@ if (isset($tab_finalH)) {
                 );
                 $obj->XML->writeElement(
                     "chartIcon",
-                    returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18)
+                    "./img/icons/chart.svg"
                 );
                 $obj->XML->writeElement(
                     "viewIcon",
-                    returnSvg("www/img/icons/view.svg", "var(--icons-fill-color)", 18, 18)
+                    "./img/icons/view.svg"
                 );
                 $obj->XML->endElement();
                 $count++;

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
@@ -315,8 +315,8 @@ if (isset($tab_final)) {
                     ? $serviceListingDeprecatedUri . '&statusFilter=pending'
                     : $buildServicesUri($host_name, [$pendingStatus])
             );
-            $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
-            $obj->XML->writeElement("viewIcon", returnSvg("www/img/icons/view.svg", "var(--icons-fill-color)", 18, 18));
+            $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
+            $obj->XML->writeElement("viewIcon", "./img/icons/view.svg");
             $obj->XML->endElement();
             $count++;
         }

--- a/www/include/monitoring/status/ServicesHostGroups/xsl/serviceGridByHG.xsl
+++ b/www/include/monitoring/status/ServicesHostGroups/xsl/serviceGridByHG.xsl
@@ -89,14 +89,14 @@
 						<xsl:attribute name="isreact">true</xsl:attribute>
 						<xsl:element name="span">
                             <xsl:attribute name="class">svgs</xsl:attribute>
-                            <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                            <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="viewIcon"/></xsl:attribute></xsl:element>
 						</xsl:element>
 					</xsl:element>
 					<xsl:element name="a">
 					  	<xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
 						<xsl:element name="span">
                             <xsl:attribute name="class">svgs</xsl:attribute>
-                            <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                            <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
 						</xsl:element>
 					</xsl:element>
 				</td>

--- a/www/include/monitoring/status/ServicesHostGroups/xsl/serviceSummaryByHG.xsl
+++ b/www/include/monitoring/status/ServicesHostGroups/xsl/serviceSummaryByHG.xsl
@@ -99,14 +99,14 @@
                                 <xsl:attribute name="isreact">true</xsl:attribute>
                                 <xsl:element name="span">
                                     <xsl:attribute name="class">svgs</xsl:attribute>
-                                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                    <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="viewIcon"/></xsl:attribute></xsl:element>
                                 </xsl:element>
                             </xsl:element>
                             <xsl:element name="a">
                                 <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
                                 <xsl:element name="span">
                                     <xsl:attribute name="class">svgs</xsl:attribute>
-                                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                    <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
                                 </xsl:element>
                             </xsl:element>
                         </td>

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
@@ -349,8 +349,8 @@ foreach ($aTab as $key => $element) {
             );
             $obj->XML->endElement();
         }
-        $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
-        $obj->XML->writeElement("viewIcon", returnSvg("www/img/icons/view.svg", "var(--icons-fill-color)", 18, 18));
+        $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
+        $obj->XML->writeElement("viewIcon", "./img/icons/view.svg");
         $obj->XML->endElement();
         $count++;
     }

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
@@ -362,8 +362,8 @@ if ($numRows > 0) {
             foreach ($hostInfos['states'] as $state => $count) {
                 $obj->XML->writeElement($state, $count);
             }
-            $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
-            $obj->XML->writeElement("viewIcon", returnSvg("www/img/icons/view.svg", "var(--icons-fill-color)", 18, 18));
+            $obj->XML->writeElement("chartIcon", "./img/icons/chart.svg");
+            $obj->XML->writeElement("viewIcon", "./img/icons/view.svg");
             $obj->XML->endElement();
         }
         $obj->XML->endElement();

--- a/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceGridBySG.xsl
+++ b/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceGridBySG.xsl
@@ -51,14 +51,14 @@
                                 <xsl:attribute name="isreact">true</xsl:attribute>
                                 <xsl:element name="span">
                                     <xsl:attribute name="class">svgs</xsl:attribute>
-                                    <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                                    <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="viewIcon"/></xsl:attribute></xsl:element>
                                 </xsl:element>
                             </xsl:element>
                             <xsl:element name="a">
                                 <xsl:attribute name="href">main.php?p=20401&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
                                 <xsl:element name="span">
                                     <xsl:attribute name="class">svgs</xsl:attribute>
-                                    <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                                    <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
                                 </xsl:element>
                             </xsl:element>
                         </td>

--- a/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceSummaryBySG.xsl
+++ b/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceSummaryBySG.xsl
@@ -44,14 +44,14 @@
 				  	<xsl:attribute name="href"><xsl:value-of select="s_listing_uri"/></xsl:attribute>
                     <xsl:element name="span">
                         <xsl:attribute name="class">svgs</xsl:attribute>
-                        <xsl:value-of select="viewIcon" disable-output-escaping="yes"/>
+                        <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="viewIcon"/></xsl:attribute></xsl:element>
                     </xsl:element>
 				</xsl:element>
 				<xsl:element name="a">
 				  	<xsl:attribute name="href">main.php?p=20401&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/></xsl:attribute>
                     <xsl:element name="span">
                         <xsl:attribute name="class">svgs</xsl:attribute>
-                        <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
+                        <xsl:element name="img"><xsl:attribute name="src"><xsl:value-of select="chartIcon"/></xsl:attribute></xsl:element>
                     </xsl:element>
 				</xsl:element>
 			</td>


### PR DESCRIPTION
- Replace in XML responses SVG data by SVG url
- Replace in XSL transformations SVG code by IMG tag
- Avoid the XSL attribute disable-output-escaping

Refs: #11527
Signed-off-by: Grégory Marigot <gmarigot@teicee.com>

## Description

Some pages in "Monitoring / Status Details" are generated with XML/XSL and contains SVG icons (the SVG code is included as data in the page). But Firefox don't support the "disable-output-escaping" attribute in XSL transformations, so the SVG code is escaped instead of displaying the image.

For a better compatibility, this patch replace the SVG data by IMG tags with the SVG url.

**Fixes** #11527

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Log in Centreon with Firefox
- Go to the "Services by Hostgroup" page ("Monitoring > Status details > Services by HostGroup" )
- On each line, the SVG icons (chart & view) are well displayed by an IMG tag


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
