### PR TITLE
enh(enginecfg): some of engines informational messages are useful

### DIFF
--- a/src/CentreonRemote/Domain/Resources/DefaultConfig/CfgNagiosLogger.php
+++ b/src/CentreonRemote/Domain/Resources/DefaultConfig/CfgNagiosLogger.php
@@ -36,19 +36,19 @@ class CfgNagiosLogger
         return [
             'cfg_nagios_id' => 1,
             'log_v2_logger' => 'file',
-            'log_level_functions' => 'err',
+            'log_level_functions' => 'warning',
             'log_level_config' => 'info',
             'log_level_events' => 'info',
             'log_level_checks' => 'info',
-            'log_level_notifications' => 'err',
-            'log_level_eventbroker' => 'err',
+            'log_level_notifications' => 'info',
+            'log_level_eventbroker' => 'warning',
             'log_level_external_command' => 'info',
-            'log_level_commands' => 'err',
-            'log_level_downtimes' => 'err',
-            'log_level_comments' => 'err',
-            'log_level_macros' => 'err',
+            'log_level_commands' => 'warning',
+            'log_level_downtimes' => 'info',
+            'log_level_comments' => 'info',
+            'log_level_macros' => 'warning',
             'log_level_process' => 'info',
-            'log_level_runtime' => 'err',
+            'log_level_runtime' => 'warning',
         ];
     }
 }

--- a/www/install/var/baseconf/centreon-engine.sql
+++ b/www/install/var/baseconf/centreon-engine.sql
@@ -85,8 +85,9 @@ UPDATE `cfg_nagios` SET `log_file` = '@monitoring_varlog@/centengine.log',
     `cfg_file` = 'centengine.cfg',
     `logger_version` = 'log_v2_enabled';
 
-INSERT INTO `cfg_nagios_logger` (`cfg_nagios_id`, `log_v2_logger`, `log_level_functions`, `log_level_config`, `log_level_events`, `log_level_checks`, `log_level_notifications`, `log_level_eventbroker`, `log_level_external_command`, `log_level_commands`, `log_level_downtimes`, `log_level_comments`, `log_level_macros`, `log_level_process`, `log_level_runtime`) VALUES
-(1, 'file', 'err', 'info', 'info', 'info', 'err', 'err', 'info', 'err', 'err', 'err', 'err', 'info', 'err');
+INSERT INTO `cfg_nagios_logger` 
+(`cfg_nagios_id`, `log_v2_logger`, `log_level_functions`, `log_level_config`, `log_level_events`, `log_level_checks`, `log_level_notifications`, `log_level_eventbroker`, `log_level_external_command`, `log_level_commands`, `log_level_downtimes`, `log_level_comments`, `log_level_macros`, `log_level_process`, `log_level_runtime`) VALUES
+(1, 'file', 'warning', 'info', 'info', 'info', 'info', 'warning', 'info', 'warning', 'info', 'info', 'warning', 'info', 'warning');
 
 INSERT INTO `cfg_nagios_broker_module` (`cfg_nagios_id`, `broker_module`) VALUES (1, '@centreon_engine_lib@/externalcmd.so');
 


### PR DESCRIPTION
(notif, extcmd, ...)

## Description

Centengine's default log levels does not log notifications, external commands, which represent few but useful log messages. So let's log more informational messages starting 22.10 and also let's log warnings, not only errors.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software: actually what may be broker is automated tests at build time, but the changes have to be accepted

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

Cf MON

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
