### PR TITLE
fix(Resources/details):white page shown when clicking host resource status

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -184,7 +184,7 @@ const getDetailCardLines = ({
       title: labelCalculationType,
     },
     {
-      line: <DetailsLine line={details.parent.uuid} />,
+      line: <DetailsLine line={details.parent?.uuid} />,
       shouldBeDisplayed: !isNil(details.calculation_type),
       title: labelCalculationType,
     },


### PR DESCRIPTION
resource of type host has no parent ,  his the parent