### PR TITLE
fix(conf) broken translations in acl access page

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -4306,9 +4306,6 @@ msgstr "Ejecuta el comando definido en la configuración del recopilador (Config
 #~ msgid "Additional Remote Server to which this server will be attached"
 #~ msgstr ""
 
-#  msgid "Poller Configuration Actions / Poller Management"
-#  msgstr ""
-
 #  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 #  msgstr ""
 

--- a/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -4306,15 +4306,6 @@ msgstr "Ejecuta el comando definido en la configuración del recopilador (Config
 #~ msgid "Additional Remote Server to which this server will be attached"
 #~ msgstr ""
 
-#  msgid "Create and edit pollers"
-#  msgstr ""
-
-#  msgid "Delete pollers"
-#  msgstr ""
-
-#  msgid "Deploy configuration"
-#  msgstr ""
-
 #  msgid "Poller Configuration Actions / Poller Management"
 #  msgstr ""
 

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15227,3 +15227,12 @@ msgstr "Nivel de criticidad del host"
 
 # msgid "CSV"
 # msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15228,6 +15228,9 @@ msgstr "Nivel de criticidad del host"
 # msgid "CSV"
 # msgstr ""
 
+#  msgid "Poller Configuration Actions / Poller Management"
+#  msgstr ""
+
 #  msgid "Create and edit pollers"
 #  msgstr ""
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7215,9 +7215,6 @@ msgstr ""
 msgid "Expected TLS certificate common name (CN) - leave blank if unsure."
 msgstr "Champ common name (CN) attendu dans le certificat TLS - laisser vide en cas de doute"
 
-msgid "Poller Configuration Actions / Poller Management"
-msgstr "Actions de configuration du collecteur / Gestion du collecteur"
-
 msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 msgstr "Permet à l'utilisateur de créer des collecteurs (boutons Ajouter, Ajouter (avancé) et Dupliquer)."
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -7218,15 +7218,6 @@ msgstr "Champ common name (CN) attendu dans le certificat TLS - laisser vide en 
 msgid "Poller Configuration Actions / Poller Management"
 msgstr "Actions de configuration du collecteur / Gestion du collecteur"
 
-msgid "Create and edit pollers"
-msgstr "Créer et modifier des collecteurs"
-
-msgid "Delete pollers"
-msgstr "Supprimer des collecteurs"
-
-msgid "Deploy configuration"
-msgstr "Déployer la configuration"
-
 msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 msgstr "Permet à l'utilisateur de créer des collecteurs (boutons Ajouter, Ajouter (avancé) et Dupliquer)."
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17023,6 +17023,9 @@ msgstr "Petite taille"
 msgid "CSV"
 msgstr "CSV"
 
+msgid "Poller Configuration Actions / Poller Management"
+msgstr "Actions de configuration des collecteurs / Gestion des collecteurs"
+
 msgid "Create and edit pollers"
 msgstr "Créer et modifier des collecteurs"
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17022,3 +17022,12 @@ msgstr "Petite taille"
 
 msgid "CSV"
 msgstr "CSV"
+
+msgid "Create and edit pollers"
+msgstr "Créer et modifier des collecteurs"
+
+msgid "Delete pollers"
+msgstr "Supprimer des collecteurs"
+
+msgid "Deploy configuration"
+msgstr "Déployer la configuration"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -6656,10 +6656,6 @@ msgstr ""
 #~ msgid "Additional Remote Server to which this server will be attached"
 #~ msgstr ""
 
-
-#  msgid "Poller Configuration Actions / Poller Management"
-#  msgstr ""
-
 #  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 #  msgstr ""
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -6660,15 +6660,6 @@ msgstr ""
 #  msgid "Poller Configuration Actions / Poller Management"
 #  msgstr ""
 
-#  msgid "Create and edit pollers"
-#  msgstr ""
-
-#  msgid "Delete pollers"
-#  msgstr ""
-
-#  msgid "Deploy configuration"
-#  msgstr ""
-
 #  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 #  msgstr ""
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15688,6 +15688,9 @@ msgstr "Nível de Severidade de host"
 # msgid "CSV"
 # msgstr ""
 
+#  msgid "Poller Configuration Actions / Poller Management"
+#  msgstr ""
+
 #  msgid "Create and edit pollers"
 #  msgstr ""
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15687,3 +15687,12 @@ msgstr "Nível de Severidade de host"
 
 # msgid "CSV"
 # msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -4776,9 +4776,6 @@ msgstr ""
 #  msgid "Disacknowledgement command sent"
 #  msgid ""
 
-#  msgid "Poller Configuration Actions / Poller Management"
-#  msgstr ""
-
 #  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 #  msgstr ""
 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -4779,15 +4779,6 @@ msgstr ""
 #  msgid "Poller Configuration Actions / Poller Management"
 #  msgstr ""
 
-#  msgid "Create and edit pollers"
-#  msgstr ""
-
-#  msgid "Delete pollers"
-#  msgstr ""
-
-#  msgid "Deploy configuration"
-#  msgstr ""
-
 #  msgid "Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on pollers."
 #  msgstr ""
 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15676,6 +15676,9 @@ msgstr "Nível de Severidade de host"
 # msgid "CSV"
 # msgstr ""
 
+#  msgid "Poller Configuration Actions / Poller Management"
+#  msgstr ""
+
 #  msgid "Create and edit pollers"
 #  msgstr ""
 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15675,3 +15675,12 @@ msgstr "Nível de Severidade de host"
 
 # msgid "CSV"
 # msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""

--- a/www/include/options/accessLists/actionsACL/formActionsAccess.php
+++ b/www/include/options/accessLists/actionsACL/formActionsAccess.php
@@ -175,7 +175,7 @@ $form->addElement('checkbox', 'poller_listing', _("Display Poller Listing"));
 // Configuration Actions
 $form->addElement('checkbox', 'create_edit_poller_cfg', _("Create and edit pollers"));
 $form->addElement('checkbox', 'delete_poller_cfg', _("Delete pollers"));
-$form->addElement('checkbox', 'generate_cfg', _("Deploy configuration Files"));
+$form->addElement('checkbox', 'generate_cfg', _("Deploy configuration"));
 $form->addElement('checkbox', 'generate_trap', _("Generate SNMP Trap configuration"));
 
 $form->addElement('checkbox', 'all_service', "");


### PR DESCRIPTION
## Description

fix broken translations
<img width="517" alt="eninfr" src="https://user-images.githubusercontent.com/88387848/189165461-3f821454-1502-4c75-b613-1fbb381dcbb3.png">

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
