### PR TITLE
FIX: Sanitize and bind Meta Service configuration 21.10.x

### DIFF
--- a/www/class/centreonMeta.class.php
+++ b/www/class/centreonMeta.class.php
@@ -305,8 +305,11 @@ class CentreonMeta
             $row = $res->fetchRow();
             $serviceId = $row['service_id'];
             if ($row['display_name'] !== $metaName) {
-                $query = 'UPDATE service SET display_name = "' . $metaName . '" WHERE service_id = ' . $serviceId;
-                $this->db->query($query);
+                $query = 'UPDATE service SET display_name = :display_name WHERE service_id = :service_id';
+                $statement = $this->db->prepare($query);
+                $statement->bindValue(':display_name', $metaName, \PDO::PARAM_STR);
+                $statement->bindValue(':service_id', (int) $serviceId, \PDO::PARAM_INT);
+                $statement->execute();
             }
         } else {
             $query = 'INSERT INTO service (service_description, display_name, service_register) '
@@ -314,11 +317,15 @@ class CentreonMeta
                 . '("' . $composedName . '", "' . $metaName . '", "2")';
             $this->db->query($query);
             $query = 'INSERT INTO host_service_relation(host_host_id, service_service_id) '
-                . 'VALUES ('
-                . $hostId . ','
-                . '(SELECT service_id FROM service WHERE service_description = "' . $composedName . '" AND service_register = "2" LIMIT 1)'
+                . 'VALUES (:host_id,'
+                . '(SELECT service_id 
+                    FROM service 
+                    WHERE service_description = :service_description AND service_register = "2" LIMIT 1)'
                 . ')';
-            $this->db->query($query);
+            $statement = $this->db->prepare($query);
+            $statement->bindValue(':host_id', (int) $hostId, \PDO::PARAM_INT);
+            $statement->bindValue(':service_description', $composedName, \PDO::PARAM_STR);
+            $statement->execute();
             $res = $this->db->query($queryService);
             if ($res->rowCount()) {
                 $row = $res->fetchRow();


### PR DESCRIPTION
## Description

Sanitize and bind Meta service configuration queries.

**Fixes** # MON-14922

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
