### PR TITLE
[Style]: MBI Widgets are not readable in dark mode

### DIFF
--- a/www/Themes/Centreon-Dark/variables.css
+++ b/www/Themes/Centreon-Dark/variables.css
@@ -232,4 +232,5 @@
     --bt-success-hover-font-color: var(--color-white);
     --bt-danger-hover-font-color: var(--color-white);
     --view-body-portlet-border-color: var(--color-divider-dark);
+    --chart-legend-color: var(--color-white);
 }

--- a/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/www/Themes/Generic-theme/Variables-css/variables.css
@@ -351,6 +351,7 @@
     --date-font-color: var(--color-ghost);
     --detail-chart-title-background-color:var(--color-periwinkle-gray);
     --header-text-font-color: var(--body-color);
+    --chart-legend-color: var(--color-black);
 
     /* ------ START : info box variables -----*/
     --info-box-border-color: var(--color-iron);


### PR DESCRIPTION
## Description

When I use the dark mode and MBI widgets, legends are written in black (except Business Activities MTBF and MTRS)

**Fixes**  MON-14007

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Click on the button at the top right to switch to the dark mode
2. Go to Home > Custom Views
3. Create a custom view
4. Add all affected widgets
you must see a result similar to view in screen bellow:
![mbi widgets pr](https://user-images.githubusercontent.com/108519266/189628239-00ec166c-81d3-499f-8592-d9f524a029e5.PNG)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
