### PR TITLE
[Fix]:Sanitize and bind queries in template of service listing

### DIFF
--- a/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
@@ -82,16 +82,16 @@ if ($search) {
         "WHERE (sv.service_description LIKE :search OR sv.service_alias LIKE :search) " .
         "AND sv.service_register = '0' " .
         $lockedFilter .
-        "ORDER BY service_description LIMIT :scope, :limit");
+        "ORDER BY service_description LIMIT :offset, :limit");
     $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
 } else {
     $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sv.service_id, sv.service_description," .
         " sv.service_alias, sv.service_activate, sv.service_template_model_stm_id FROM service sv " .
         "WHERE sv.service_register = '0' " . $lockedFilter .
-        "ORDER BY service_description LIMIT :scope, :limit");
+        "ORDER BY service_description LIMIT :offset, :limit");
 }
 $statement->bindValue(':limit', (int) $limit, \PDO::PARAM_INT);
-$statement->bindValue(':scope', (int) $num * (int) $limit, \PDO::PARAM_INT);
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
 $statement->execute();
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 


### PR DESCRIPTION
## Description
Queries  sanitized and bounded using PDO statement to reduce attack surface and clean legacy code
in the file : www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
at Line: 95

**Fixes** #MON-14924

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

-  Go to “Configuration > Services > Templates”

- Search a template  with and without cheking  the box "Locked elements" 

Check listing and pagination

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
