### PR TITLE
(fix) remove required parameter regarding openid configuration

### DIFF
--- a/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
+++ b/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
@@ -161,6 +161,11 @@ class UpdateOpenIdConfiguration
     {
         $this->info('Creating Authorization Rules');
         $accessGroupIds = $this->getAccessGroupIds($authorizationRulesFromRequest);
+
+        if (empty($accessGroupIds)) {
+            return [];
+        }
+
         $foundAccessGroups = $this->accessGroupRepository->findByIds($accessGroupIds);
 
         $this->logNonExistentAccessGroupsIds($accessGroupIds, $foundAccessGroups);

--- a/src/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Repository/DbWriteOpenIdConfigurationRepository.php
+++ b/src/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Repository/DbWriteOpenIdConfigurationRepository.php
@@ -70,12 +70,10 @@ class DbWriteOpenIdConfigurationRepository extends AbstractRepositoryDRB impleme
         $customConfiguration = $configuration->getCustomConfiguration();
         $authorizationRules = $customConfiguration->getAuthorizationRules();
 
-        if (!empty($authorizationRules)) {
-            $this->info('Removing existing Authorization Rules');
-            $this->deleteAuthorizationRules();
-            $this->info('Inserting new Authorization Rules');
-            $this->insertAuthorizationRules($authorizationRules);
-        }
+        $this->info('Removing existing Authorization Rules');
+        $this->deleteAuthorizationRules();
+        $this->info('Inserting new Authorization Rules');
+        $this->insertAuthorizationRules($authorizationRules);
     }
 
     /**


### PR DESCRIPTION
## Description

Remove required parameters regarding OpenID configuration

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Save an OpenID configuration without relation between authorization value and access group.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
