### PR TITLE
FIX: Sanitize and bind command configuration queries 21.10.x

### DIFF
--- a/www/include/common/javascript/commandGetArgs/cmdGetExample.php
+++ b/www/include/common/javascript/commandGetArgs/cmdGetExample.php
@@ -58,13 +58,14 @@ if (isset($_POST["index"])) {
         exit();
     }
 
-    $DBRESULT = $pearDB->query(
-        "SELECT `command_example` FROM `command` WHERE `command_id` = '". $pearDB->escape($_POST["index"]) ."'"
+    $statement = $pearDB->prepare(
+        "SELECT `command_example` FROM `command` WHERE `command_id` = :command_id"
     );
-    while ($arg = $DBRESULT->fetchRow()) {
+    $statement->bindValue(':command_id', (int) $_POST["index"], \PDO::PARAM_INT);
+    $statement->execute();
+    while ($arg = $statement->fetch(\PDO::FETCH_ASSOC)) {
         echo myDecodeService($arg["command_example"]);
     }
-    unset($arg);
-    unset($DBRESULT);
+    unset($arg, $statement);
     $pearDB = null;
 }


### PR DESCRIPTION
## Description

Sanitize and bind command configuration queries.

**Fixes** # MON-14926

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
