### PR TITLE
[Fix]: Sanitize and bind service by hostgroups listing

### DIFF
--- a/www/include/configuration/configObject/service/listServiceByHostGroup.php
+++ b/www/include/configuration/configObject/service/listServiceByHostGroup.php
@@ -221,7 +221,8 @@ if ($searchS || $searchHG) {
         "WHERE service_service_id = sv.service_id GROUP BY sv.service_id ) AS nbr, sv.service_id, " .
         "sv.service_description, sv.service_activate, sv.service_template_model_stm_id, hg.hg_id, hg.hg_name " .
         "FROM service sv, hostgroup hg, host_service_relation hsr $aclFrom " .
-        "WHERE sv.service_register = '1' $sqlFilterCase AND sv.service_id IN ($tmpBinds) AND hsr.hostgroup_hg_id IN ($tmp2Binds) " .
+        "WHERE sv.service_register = '1' $sqlFilterCase AND sv.service_id " .
+        "IN ($tmpBinds) AND hsr.hostgroup_hg_id IN ($tmp2Binds) " .
         ((isset($template) && $template) ? " AND service_template_model_stm_id = :template " : "") .
         " AND hsr.service_service_id = sv.service_id AND hg.hg_id = hsr.hostgroup_hg_id " . $aclCond .
         "ORDER BY hg.hg_name, sv.service_description LIMIT :offset_, :limit";


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code
**Fixes** MON-14964

## Type of change

- [] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a service by hostgroup
2. Duplicate it (at least 20 time)
3. In listing of service by host group, search service, modify number of rows 
4. Check if the display is correct for a user with ACL and admin

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
