### PR TITLE
Fix : Sanitize and bind centreon hostgroups class

### DIFF
--- a/www/class/centreonHostgroups.class.php
+++ b/www/class/centreonHostgroups.class.php
@@ -100,18 +100,19 @@ class CentreonHostgroups
         }
 
         $hosts = array();
-        $DBRESULT = $this->DB->query(
-            "SELECT hgr.host_host_id " .
+        $statement = $this->DB->prepare("SELECT hgr.host_host_id " .
             "FROM hostgroup_relation hgr, host h " .
-            "WHERE hgr.hostgroup_hg_id = '" . $this->DB->escape($hg_id) . "' " .
+            "WHERE hgr.hostgroup_hg_id = :hgId " .
             "AND h.host_id = hgr.host_host_id " .
-            "ORDER by h.host_name"
-        );
-        while ($elem = $DBRESULT->fetchRow()) {
+            "ORDER by h.host_name");
+        $statement->bindValue(':hgId', (int) $hg_id, \PDO::PARAM_INT);
+        $statement->execute();
+
+        while ($elem = $statement->fetchRow()) {
             $ref[$elem["host_host_id"]] = $elem["host_host_id"];
             $hosts[] = $elem["host_host_id"];
         }
-        $DBRESULT->closeCursor();
+        $statement->closeCursor();
         unset($elem);
 
         if (isset($hostgroups) && count($hostgroups)) {


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

**Fixes** # MON-14958
**Where** :  www/class/centreonHostgroups.class.php  line 103

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a hostgroup and link hosts
2. Generate configuration
3. Go to “Monitoring > Downtimes > Downtimes” menu
4. Create a downtime for hostgroup
5. Check in Centreon Engine log file that a downtime have been added for all hosts of the hostgroup

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
