### PR TITLE
feat: MON-15009 create authentication denied route

### DIFF
--- a/www/front_src/src/Main/index.tsx
+++ b/www/front_src/src/Main/index.tsx
@@ -20,6 +20,7 @@ import { useAtomValue } from 'jotai/utils';
 import { useAtom } from 'jotai';
 
 import reactRoutes from '../reactRoutes/routeMap';
+import NotAllowedPage from '../FallbackPages/NotAllowedPage';
 
 import { platformInstallationStatusAtom } from './atoms/platformInstallationStatusAtom';
 import Provider from './Provider';
@@ -79,6 +80,7 @@ const Main = (): JSX.Element => {
       return;
     }
 
+    // TODO: if isCloud from API and license expired redirect to authentication-denied route
     if (not(areUserParametersLoaded)) {
       navigate(reactRoutes.login);
     }
@@ -95,6 +97,10 @@ const Main = (): JSX.Element => {
         <Route
           element={<ResetPasswordPage />}
           path={reactRoutes.resetPassword}
+        />
+        <Route
+          element={<NotAllowedPage />}
+          path={reactRoutes.authenticationDenied}
         />
         <Route element={<AppPage />} path="*" />
       </Routes>

--- a/www/front_src/src/reactRoutes/routeMap.ts
+++ b/www/front_src/src/reactRoutes/routeMap.ts
@@ -1,5 +1,6 @@
 const routeMap = {
   authentication: '/administration/authentication',
+  authenticationDenied: '/authentication-denied',
   extensionsManagerPage: '/administration/extensions/manager',
   install: '/install/install.php',
   login: '/login',


### PR DESCRIPTION
## Description

This PR introduces a new condition when trying to reach the Centreon cloud. If your license is invalid, you should see the rescue page instead of login page.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Load centreon page in cloud context with an expired license,
- You should be redirected to fallback page instead of login  

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
