### PR TITLE
FIX: Remove unused mechanism for modules to add restart/reload actions after restart of pollers

### DIFF
--- a/www/class/centreon.class.php
+++ b/www/class/centreon.class.php
@@ -168,12 +168,6 @@ class Centreon
             if (is_dir("./modules/" . $result["name"] . "/generate_files/")) {
                 $this->modules[$result["name"]]["gen"] = true;
             }
-            if (is_dir("./modules/" . $result["name"] . "/restart_pollers/")) {
-                $this->modules[$result["name"]]["restart"] = true;
-            }
-            if (file_exists("./modules/" . $result["name"] . "/license/merethis_lic.zl")) {
-                $this->modules[$result["name"]]["license"] = true;
-            }
         }
         $dbResult = null;
     }

--- a/www/class/centreon.class.php
+++ b/www/class/centreon.class.php
@@ -162,15 +162,11 @@ class Centreon
             $this->modules[$result["name"]] = array(
                 "name" => $result["name"],
                 "gen" => false,
-                "restart" => false,
                 "license" => false
             );
 
             if (is_dir("./modules/" . $result["name"] . "/generate_files/")) {
                 $this->modules[$result["name"]]["gen"] = true;
-            }
-            if (is_dir("./modules/" . $result["name"] . "/restart_pollers/")) {
-                $this->modules[$result["name"]]["restart"] = true;
             }
             if (is_dir("./modules/" . $result["name"] . "/restart_pollers/")) {
                 $this->modules[$result["name"]]["restart"] = true;

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -259,18 +259,6 @@ try {
         $msg_restart[$key] = str_replace("\n", "<br>", $str);
     }
 
-    /* Find restart / reload action from modules */
-    foreach ($centreon->modules as $key => $value) {
-        if (
-            $value["restart"]
-            && $files = glob(_CENTREON_PATH_ . "www/modules/" . $key . "/restart_pollers/*.php")
-        ) {
-            foreach ($files as $filename) {
-                include $filename;
-            }
-        }
-    }
-
     $xml->startElement("response");
     $xml->writeElement("status", $okMsg);
     $xml->writeElement("statuscode", STATUS_OK);


### PR DESCRIPTION
## Description

A mechanism was added in Centreon 2.6.2 (September 2015) to allow module to add reload/restart actions after restart of pollers, this PR will take care of removing it.

**Fixes** # MON-14952

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
