### PR TITLE
Fix: Sanitize and bind host category listing

### DIFF
--- a/www/include/configuration/configObject/host_categories/listHostCategories.php
+++ b/www/include/configuration/configObject/host_categories/listHostCategories.php
@@ -141,16 +141,16 @@ for ($i = 0; $hc = $DBRESULT->fetch(); $i++) {
         $aclFrom = ", $aclDbName.centreon_acl acl ";
         $aclCond = " AND h.host_id = acl.host_id AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";
     }
-    $DBRESULT2 = $pearDB->query(
-        "SELECT h.host_id, h.host_activate " .
+    $hcStatement = $pearDB->prepare("SELECT h.host_id, h.host_activate " .
         "FROM hostcategories_relation hcr, host h " . $aclFrom .
-        " WHERE hostcategories_hc_id = '" . $hc['hc_id'] . "'" .
+        " WHERE hostcategories_hc_id = :hcId" .
         " AND h.host_id = hcr.host_host_id " . $aclCond .
-        " AND h.host_register = '1' "
-    );
+        " AND h.host_register = '1' ");
+    $hcStatement->bindValue(':hcId', (int) $hc['hc_id'], \PDO::PARAM_INT);
+    $hcStatement->execute();
     $nbrhostActArr = array();
     $nbrhostDeactArr = array();
-    while ($row = $DBRESULT2->fetch()) {
+    while ($row = $hcStatement->fetch()) {
         if ($row['host_activate']) {
             $nbrhostActArr[$row['host_id']] = true;
         } else {


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code
### Where
www/include/configuration/configObject/host_categories/listHostCategories.php
### Line: 144

**Fixes** # MON-14970

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create an host category and link it to host(s) (enabled and disabled) from “[Configuration](https://pendo-22-04.centreon.io/centreon/main.php?p=6)  >  [Hosts](https://pendo-22-04.centreon.io/centreon/main.php?p=601)  >  [Categories](https://pendo-22-04.centreon.io/centreon/main.php?p=60104)”

Check if host category listing is OK: “ Enabled Hosts” and “ Disabled Hosts” columns display correct numbers of hosts
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
