### PR TITLE
enh(auth): Add Authentication Conditions to OpenID Connect Authentication

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17045,7 +17045,7 @@ msgid "Invalid endpoint URL specified"
 msgstr "URL d'endpoint spécifié invalide"
 
 msgid "Request for authentication conditions custom endpoint has failed"
-msgtr "La demande de conditions d'authentification de l'endpoint personnalisé a échoué"
+msgstr "La demande de conditions d'authentification de l'endpoint personnalisé a échoué"
 
 msgid "Authorized conditions not found in provider conditions"
 msgstr "Les conditions autorisées ne figurent pas dans les conditions du provider"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17043,3 +17043,9 @@ msgstr "Type d'endpoint spécifié invalide"
 
 msgid "Invalid endpoint URL specified"
 msgstr "URL d'endpoint spécifié invalide"
+
+msgid "Request for authentication conditions custom endpoint has failed"
+msgtr "La demande de conditions d'authentification de l'endpoint personnalisé a échoué"
+
+msgid "Authorized conditions not found in provider conditions"
+msgstr "Les conditions autorisées ne figurent pas dans les conditions du provider"

--- a/src/Core/Application/Common/UseCase/ErrorAuthenticationConditionsResponse.php
+++ b/src/Core/Application/Common/UseCase/ErrorAuthenticationConditionsResponse.php
@@ -20,22 +20,10 @@
  */
 declare(strict_types=1);
 
-namespace Core\Security\Authentication\Infrastructure\Api\Login\Local;
+namespace Core\Application\Common\UseCase;
 
-use Core\Application\Common\UseCase\AbstractPresenter;
-use Core\Security\Authentication\Application\UseCase\Login\LoginPresenterInterface;
+use Core\Application\Common\UseCase\ForbiddenResponse;
 
-class LoginPresenter extends AbstractPresenter implements LoginPresenterInterface
+class ErrorAuthenticationConditionsResponse extends ForbiddenResponse
 {
-    /**
-     * @param mixed $response
-     */
-    public function present(mixed $response): void
-    {
-        $presenterResponse = [
-            'redirect_uri' => $this->responseStatus->getMessage()
-        ];
-
-        parent::present($presenterResponse);
-    }
 }

--- a/src/Core/Security/Authentication/Application/UseCase/Login/LoginResponse.php
+++ b/src/Core/Security/Authentication/Application/UseCase/Login/LoginResponse.php
@@ -52,6 +52,9 @@ final class LoginResponse implements ResponseStatusInterface
         return $this->exception;
     }
 
+    /**
+     * @return string
+     */
     public function getMessage(): string
     {
         return $this->redirectUri;

--- a/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
+++ b/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
@@ -21,39 +21,17 @@
 
 declare(strict_types=1);
 
-namespace Core\Security\Authentication\Application\UseCase\Login;
+namespace Core\Security\Authentication\Domain\Exception;
 
-use Core\Application\Common\UseCase\ResponseStatusInterface;
-use Exception;
-
-final class LoginResponse implements ResponseStatusInterface
+class AuthenticationConditionsException extends \Exception
 {
-    /**
-     * @param string $redirectUri
-     * @param Exception|null $exception
-     */
-    public function __construct(private string $redirectUri, private ?Exception $exception = null)
+    public static function invalidAuthenticationConditions(): self
     {
+        return new self(_("Invalid Provider authentication conditions"));
     }
 
-    /**
-     * @return string
-     */
-    public function getRedirectUri(): string
+    public static function conditionsNotFound(): self
     {
-        return $this->redirectUri;
-    }
-
-    /**
-     * @return Exception|null
-     */
-    public function getException(): ?Exception
-    {
-        return $this->exception;
-    }
-
-    public function getMessage(): string
-    {
-        return $this->redirectUri;
+        return new self(_("Authorized conditions not found in provider conditions"));
     }
 }

--- a/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
+++ b/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
@@ -25,11 +25,21 @@ namespace Core\Security\Authentication\Domain\Exception;
 
 class AuthenticationConditionsException extends \Exception
 {
+    /**
+     * Exceptions thrown when authentication conditions are invalid.
+     *
+     * @return self
+     */
     public static function invalidAuthenticationConditions(): self
     {
         return new self(_("Invalid Provider authentication conditions"));
     }
 
+    /**
+     * Exceptions thrown when authentication are not found.
+     *
+     * @return self
+     */
     public static function conditionsNotFound(): self
     {
         return new self(_("Authorized conditions not found in provider conditions"));

--- a/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+++ b/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
@@ -177,4 +177,9 @@ class SSOAuthenticationException extends \Exception
     {
         return new self(_("An error occured while decoding Identity Provider ID Token"));
     }
+
+    public static function requestForCustomAuthenticationConditionsEndpointFail(): self
+    {
+        return new self(_('Request for authentication conditions custom endpoint has failed'));
+    }
 }

--- a/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+++ b/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
@@ -178,6 +178,11 @@ class SSOAuthenticationException extends \Exception
         return new self(_("An error occured while decoding Identity Provider ID Token"));
     }
 
+    /**
+     * Exception thrown when the request to authentication condition fail
+     *
+     * @return self
+     */
     public static function requestForCustomAuthenticationConditionsEndpointFail(): self
     {
         return new self(_('Request for authentication conditions custom endpoint has failed'));

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -890,7 +890,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         AuthenticationConditions $authenticationConditions
     ): array {
         $conditionsEndpoint = $authenticationConditions->getEndpoint();
-        switch($conditionsEndpoint->getType()) {
+        switch ($conditionsEndpoint->getType()) {
             case Endpoint::INTROSPECTION:
                 $conditions = $this->sendRequestForIntrospectionEndpoint();
                 break;
@@ -959,7 +959,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     /**
      * Validate Authentication conditions or throw an exception.
      *
-     * @param array $conditions
+     * @param array<string,mixed> $conditions
      * @param AuthenticationConditions $authenticationConditions
      */
     private function validateAuthenticationConditions(
@@ -969,7 +969,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         $authenticationAttributePath = explode(".", $authenticationConditions->getAttributePath());
         $this->logAuthenticationInfo("Configured Attribute path found", $authenticationAttributePath);
         $this->logAuthenticationInfo("Configured Authorized values", $authenticationConditions->getAuthorizedValues());
-        foreach($authenticationAttributePath as $attribute) {
+        foreach ($authenticationAttributePath as $attribute) {
             $providerAuthenticationConditions = [];
             if (array_key_exists($attribute, $conditions)) {
                 $providerAuthenticationConditions = $conditions[$attribute];
@@ -995,8 +995,10 @@ class OpenIdProvider implements OpenIdProviderInterface
      * @param string[] $configuredAuthorizedValues
      * @throws AuthenticationConditionsException
      */
-    private function validateAttributeOrFail(array $providerAuthenticationConditions, array $configuredAuthorizedValues): void
-    {
+    private function validateAttributeOrFail(
+        array $providerAuthenticationConditions,
+        array $configuredAuthorizedValues
+    ): void {
         //@TODO: Remove this polyfill when php 8.1 is supported
         if (!function_exists("array_is_list")) {
             /**
@@ -1020,7 +1022,8 @@ class OpenIdProvider implements OpenIdProviderInterface
         }
         if (array_is_list($providerAuthenticationConditions) === false) {
             $errorMessage = "Invalid Authentication conditions format, array of string expected";
-            $this->error($errorMessage,
+            $this->error(
+                $errorMessage,
                 [
                 "authentication_condition_from_provider" => $providerAuthenticationConditions
                 ]
@@ -1033,9 +1036,10 @@ class OpenIdProvider implements OpenIdProviderInterface
         }
 
         $conditionMatches = array_intersect($providerAuthenticationConditions, $configuredAuthorizedValues);
-        if (empty ($conditionMatches)) {
+        if (empty($conditionMatches)) {
             $errorMessage = "Configured attribute path not found in conditions endpoint";
-            $this->error("Configured attribute path not found in conditions endpoint",
+            $this->error(
+                "Configured attribute path not found in conditions endpoint",
                 [
                     "configured_authorized_values" => $configuredAuthorizedValues
                 ]

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -619,6 +619,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      *
      * @param string $clientIp
      * @throws SSOAuthenticationException
+     * @throws AuthenticationConditionsException
      */
     private function verifyThatClientIsAllowedToConnectOrFail(string $clientIp): void
     {
@@ -910,6 +911,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      *
      * @param string $customEndpoint
      * @return array<string,mixed>
+     * @throws SSOAuthenticationException
      */
     private function sendRequestForCustomAuthenticationConditionEndpoint(string $customEndpoint): array
     {
@@ -961,6 +963,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      *
      * @param array<string,mixed> $conditions
      * @param AuthenticationConditions $authenticationConditions
+     * @throws AuthenticationConditionsException
      */
     private function validateAuthenticationConditions(
         array $conditions,

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -951,7 +951,7 @@ class OpenIdProvider implements OpenIdProviderInterface
             $this->logErrorFromExternalProvider($content);
             throw SSOAuthenticationException::errorFromExternalProvider($this->configuration->getName());
         }
-        $this->logAuthenticationDebug('Authentication conditions: ', $content);
+        $this->logAuthenticationInfo('Authentication conditions', $content);
 
         return $content;
     }
@@ -967,6 +967,8 @@ class OpenIdProvider implements OpenIdProviderInterface
         AuthenticationConditions $authenticationConditions
     ): void {
         $authenticationAttributePath = explode(".", $authenticationConditions->getAttributePath());
+        $this->logAuthenticationInfo("Configured Attribute path found", $authenticationAttributePath);
+        $this->logAuthenticationInfo("Configured Authorized values", $authenticationConditions->getAuthorizedValues());
         foreach($authenticationAttributePath as $attribute) {
             $providerAuthenticationConditions = [];
             if (array_key_exists($attribute, $conditions)) {
@@ -1018,9 +1020,11 @@ class OpenIdProvider implements OpenIdProviderInterface
         }
         if (array_is_list($providerAuthenticationConditions) === false) {
             $errorMessage = "Invalid Authentication conditions format, array of string expected";
-            $this->error($errorMessage, [
+            $this->error($errorMessage,
+                [
                 "authentication_condition_from_provider" => $providerAuthenticationConditions
-            ]);
+                ]
+            );
             $this->logExceptionInLoginLogFile(
                 $errorMessage,
                 AuthenticationConditionsException::invalidAuthenticationConditions()
@@ -1031,10 +1035,15 @@ class OpenIdProvider implements OpenIdProviderInterface
         $conditionMatches = array_intersect($providerAuthenticationConditions, $configuredAuthorizedValues);
         if (empty ($conditionMatches)) {
             $errorMessage = "Configured attribute path not found in conditions endpoint";
-            $this->error($errorMessage, [
-                "configured_authorized_values" => $configuredAuthorizedValues
-            ]);
-            $this->logExceptionInLoginLogFile($errorMessage, AuthenticationConditionsException::conditionsNotFound());
+            $this->error("Configured attribute path not found in conditions endpoint",
+                [
+                    "configured_authorized_values" => $configuredAuthorizedValues
+                ]
+            );
+            $this->logExceptionInLoginLogFile(
+                "Configured attribute path not found in conditions endpoint: %s, message: %s",
+                AuthenticationConditionsException::conditionsNotFound()
+            );
             throw AuthenticationConditionsException::conditionsNotFound();
         }
         $this->info("Conditions found", ["conditions" => $conditionMatches]);

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -801,7 +801,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     }
 
     /**
-     * Log Authentication informations
+     * Log Authentication debug
      *
      * @param string $message
      * @param array<string,string> $content
@@ -830,6 +830,12 @@ class OpenIdProvider implements OpenIdProviderInterface
         $this->debug('Authentication informations : ', $content);
     }
 
+    /**
+     * Log Authentication information
+     *
+     * @param string $message
+     * @param array<string,string> $content
+     */
     private function logAuthenticationInfo(string $message, array $content): void
     {
         $this->centreonLog->insertLog(
@@ -953,8 +959,8 @@ class OpenIdProvider implements OpenIdProviderInterface
     /**
      * Validate Authentication conditions or throw an exception.
      *
-     * @param array<string,mixed> $conditions
-     * @param string $attributePath
+     * @param array $conditions
+     * @param AuthenticationConditions $authenticationConditions
      */
     private function validateAuthenticationConditions(
         array $conditions,
@@ -991,6 +997,14 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         //@TODO: Remove this polyfill when php 8.1 is supported
         if (!function_exists("array_is_list")) {
+            /**
+             * Polyfill for array_is_list
+             *
+             * https://www.php.net/manual/en/function.array-is-list.php
+             *
+             * @param mixed[] $array
+             * @return bool
+             */
             function array_is_list(array $array): bool
             {
                 $i = 0;

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -571,7 +571,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function sendRequestForUserInformationEndpoint(): array
     {
-        $this->info('Send Request for User Information...');
+        $this->info('Sending Request for User Information...');
 
         $headers = [
             'Authorization' => "Bearer " . trim($this->providerToken->getToken())
@@ -623,7 +623,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function verifyThatClientIsAllowedToConnectOrFail(string $clientIp): void
     {
-        $this->info('Check Client IP from blacklist/whitelist addresses');
+        $this->info('Check Client IP against blacklist/whitelist addresses');
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
         $authenticationConditions = $customConfiguration->getAuthenticationConditions();
@@ -828,7 +828,7 @@ class OpenIdProvider implements OpenIdProviderInterface
             CentreonUserLog::TYPE_LOGIN,
             "[Openid] [Debug] $message " . json_encode($content)
         );
-        $this->debug('Authentication informations : ', $content);
+        $this->debug('Authentication information : ', $content);
     }
 
     /**
@@ -915,7 +915,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function sendRequestForCustomAuthenticationConditionEndpoint(string $customEndpoint): array
     {
-        $this->info('Send Request for authentication conditions...');
+        $this->info('Sending Request for authentication conditions...');
 
         $headers = [
             'Authorization' => "Bearer " . trim($this->providerToken->getToken())

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1054,6 +1054,6 @@ class OpenIdProvider implements OpenIdProviderInterface
             throw AuthenticationConditionsException::conditionsNotFound();
         }
         $this->info("Conditions found", ["conditions" => $conditionMatches]);
-        $this->logAuthenticationInfo("Conditions found", $*);
+        $this->logAuthenticationInfo("Conditions found", $$conditionMatches);
     }
 }

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -835,7 +835,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      * Log Authentication information
      *
      * @param string $message
-     * @param array<string,string> $content
+     * @param array<string|int,string> $content
      */
     private function logAuthenticationInfo(string $message, array $content): void
     {
@@ -1054,6 +1054,6 @@ class OpenIdProvider implements OpenIdProviderInterface
             throw AuthenticationConditionsException::conditionsNotFound();
         }
         $this->info("Conditions found", ["conditions" => $conditionMatches]);
-        $this->logAuthenticationInfo("Conditions found", $conditionMatches);
+        $this->logAuthenticationInfo("Conditions found", $*);
     }
 }

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1040,7 +1040,6 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $conditionMatches = array_intersect($providerAuthenticationConditions, $configuredAuthorizedValues);
         if (empty($conditionMatches)) {
-            $errorMessage = "Configured attribute path not found in conditions endpoint";
             $this->error(
                 "Configured attribute path not found in conditions endpoint",
                 [
@@ -1054,6 +1053,6 @@ class OpenIdProvider implements OpenIdProviderInterface
             throw AuthenticationConditionsException::conditionsNotFound();
         }
         $this->info("Conditions found", ["conditions" => $conditionMatches]);
-        $this->logAuthenticationInfo("Conditions found", $$conditionMatches);
+        $this->logAuthenticationInfo("Conditions found", $conditionMatches);
     }
 }

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -992,7 +992,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     }
 
     /**
-     * Undocumented function
+     * Validate Authentication Condition Attribute
      *
      * @param array<mixed> $providerAuthenticationConditions
      * @param string[] $configuredAuthorizedValues

--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1024,7 +1024,7 @@ class OpenIdProvider implements OpenIdProviderInterface
             }
         }
         if (array_is_list($providerAuthenticationConditions) === false) {
-            $errorMessage = "Invalid Authentication conditions format, array of string expected";
+            $errorMessage = "Invalid Authentication conditions format, array of strings expected";
             $this->error(
                 $errorMessage,
                 [

--- a/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
+++ b/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
@@ -28,12 +28,14 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Centreon\Application\Controller\AbstractController;
+use Core\Application\Common\UseCase\UnauthorizedResponse;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Core\Security\Authentication\Application\UseCase\Login\Login;
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
 use Core\Security\Authentication\Application\UseCase\Login\LoginResponse;
 use Core\Application\Common\UseCase\ErrorAuthenticationConditionsResponse;
 use Core\Security\Authentication\Domain\Exception\AuthenticationException;
+use Core\Security\Authentication\Application\UseCase\Login\PasswordExpiredResponse;
 
 class LoginController extends AbstractController
 {
@@ -61,7 +63,8 @@ class LoginController extends AbstractController
         $useCase($request, $presenter);
 
         switch(true) {
-            case is_a($presenter->getResponseStatus(), PasswordExpiredResponse::class):
+            case is_a($presenter->getResponseStatus(), PasswordExpiredResponse::class)
+                || is_a($presenter->getResponseStatus(), UnauthorizedResponse::class):
                 return View::createRedirect(
                     $this->getBaseUrl() . '/login?authenticationError=' . $presenter->getResponseStatus()->getMessage()
                 );

--- a/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
+++ b/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
@@ -62,7 +62,7 @@ class LoginController extends AbstractController
 
         $useCase($request, $presenter);
 
-        switch(true) {
+        switch (true) {
             case is_a($presenter->getResponseStatus(), PasswordExpiredResponse::class)
                 || is_a($presenter->getResponseStatus(), UnauthorizedResponse::class):
                 return View::createRedirect(
@@ -72,7 +72,7 @@ class LoginController extends AbstractController
                 return View::createRedirect(
                     $this->getBaseUrl() . '/authentication-denied'
                 );
-            case is_a($presenter->getResponseStatus(), LoginResponse::class):
+            default:
                 /**
                  * @var LoginResponse
                  */

--- a/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
+++ b/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
@@ -23,17 +23,17 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Infrastructure\Api\Login\OpenId;
 
-use Centreon\Application\Controller\AbstractController;
-use Core\Infrastructure\Common\Api\HttpUrlTrait;
-use Core\Security\Authentication\Application\UseCase\Login\Login;
-use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
-use Core\Security\Authentication\Domain\Exception\AuthenticationException;
-use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
-use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use FOS\RestBundle\View\View;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Core\Infrastructure\Common\Api\HttpUrlTrait;
+use Centreon\Application\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Core\Security\Authentication\Application\UseCase\Login\Login;
+use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
+use Core\Security\Authentication\Application\UseCase\Login\LoginResponse;
+use Core\Application\Common\UseCase\ErrorAuthenticationConditionsResponse;
+use Core\Security\Authentication\Domain\Exception\AuthenticationException;
 
 class LoginController extends AbstractController
 {
@@ -60,17 +60,25 @@ class LoginController extends AbstractController
 
         $useCase($request, $presenter);
 
-        $response = $presenter->getPresentedData();
-        if ($response->getException() !== null) {
-            return View::createRedirect(
-                $this->getBaseUrl() . '/login?authenticationError=' . $response->getError()->getMessage()
-            );
+        switch(true) {
+            case is_a($presenter->getResponseStatus(), PasswordExpiredResponse::class):
+                return View::createRedirect(
+                    $this->getBaseUrl() . '/login?authenticationError=' . $presenter->getResponseStatus()->getMessage()
+                );
+            case is_a($presenter->getResponseStatus(), ErrorAuthenticationConditionsResponse::class):
+                return View::createRedirect(
+                    $this->getBaseUrl() . '/authentication-denied'
+                );
+            case is_a($presenter->getResponseStatus(), LoginResponse::class):
+                /**
+                 * @var LoginResponse
+                 */
+                $response = $presenter->getResponseStatus();
+                return View::createRedirect(
+                    $this->getBaseUrl() . $response->getRedirectUri(),
+                    Response::HTTP_FOUND,
+                    ['Set-Cookie' => 'PHPSESSID=' . $session->getId()]
+                );
         }
-
-        return View::createRedirect(
-            $this->getBaseUrl() . $response->getRedirectUri(),
-            Response::HTTP_FOUND,
-            ['Set-Cookie' => 'PHPSESSID=' . $session->getId()]
-        );
     }
 }

--- a/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
+++ b/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
@@ -112,7 +112,7 @@ class OpenIdConfigurationException extends \Exception
         return new self(_(sprintf(
             'The authentication conditions endpoint should match your introspection or user information endpoints:'
                 . '%s given',
-            git $endpoint
+            $endpoint
         )));
     }
 }

--- a/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
+++ b/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
@@ -100,4 +100,19 @@ class OpenIdConfigurationException extends \Exception
             implode(', ', $missingParameters)
         )));
     }
+
+    /**
+     * Exception thrown when the Authentication Endpoints is not valid.
+     *
+     * @param string $endpoint
+     * @return self
+     */
+    public static function invalidAuthenticationConditionsEndpoint(string $endpoint): self
+    {
+        return new self(_(sprintf(
+            'The authentication conditions endpoint should match your introspection or user information endpoints:'
+                . '%s given',
+                $endpoint
+        )));
+    }
 }

--- a/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
+++ b/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
@@ -111,7 +111,7 @@ class OpenIdConfigurationException extends \Exception
     {
         return new self(_(sprintf(
             'The authentication conditions endpoint should match your introspection or user information endpoints:'
-                . '%s given',
+                . ' %s given',
             $endpoint
         )));
     }

--- a/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
+++ b/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
@@ -112,7 +112,7 @@ class OpenIdConfigurationException extends \Exception
         return new self(_(sprintf(
             'The authentication conditions endpoint should match your introspection or user information endpoints:'
                 . '%s given',
-                $endpoint
+            git $endpoint
         )));
     }
 }

--- a/tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -58,8 +58,6 @@ it('should present a NoContentResponse when the use case is executed correctly',
     $request = new UpdateOpenIdConfigurationRequest();
     $request->isActive = true;
     $request->isForced = true;
-    $request->trustedClientAddresses = [];
-    $request->blacklistClientAddresses = [];
     $request->baseUrl = 'http://127.0.0.1/auth/openid-connect';
     $request->authorizationEndpoint = '/authorization';
     $request->tokenEndpoint = '/token';
@@ -169,8 +167,6 @@ it('should present an Error Response when auto import is enable and mandatory pa
     $request = new UpdateOpenIdConfigurationRequest();
     $request->isActive = true;
     $request->isForced = true;
-    $request->trustedClientAddresses = [];
-    $request->blacklistClientAddresses = [];
     $request->baseUrl = 'http://127.0.0.1/auth/openid-connect2';
     $request->authorizationEndpoint = '/authorization';
     $request->tokenEndpoint = '/token';
@@ -224,8 +220,6 @@ it('should present an Error Response when auto import is enable and the contact 
     $request = new UpdateOpenIdConfigurationRequest();
     $request->isActive = true;
     $request->isForced = true;
-    $request->trustedClientAddresses = [];
-    $request->blacklistClientAddresses = [];
     $request->baseUrl = 'http://127.0.0.1/auth/openid-connect';
     $request->authorizationEndpoint = '/authorization';
     $request->tokenEndpoint = '/token';


### PR DESCRIPTION
## Description

This PR add the possibility to use Authentication Conditions on OpenID.

While the authentication condition mode is enable, we request the provider to get authentications conditions.
The response is parsed using the configured attribute path in Centreon openid configuration.
If the parsing matching and an authorized values is found, so the user is connected. Else he is redirected to a new page `/authentication-denied`

**Fixes** # MON-15005

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Configure an OpenID Provider in Centreon and enable authentication conditions
- Configure your attribute path
- Configure your authorized values
- Configure the endpoint to call to get the provider authentication conditions
- Try to authenticate yourself using OpenID

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
