### PR TITLE
FIX: Sanitize and bind default configuration queries 21.10.x

### DIFF
--- a/www/install/steps/process/insertBaseConf.php
+++ b/www/install/steps/process/insertBaseConf.php
@@ -123,18 +123,21 @@ if ($row = $centralServerQuery->fetch()) {
 
 // Manage timezone
 $timezone = date_default_timezone_get();
-$resTimezone = $link->query("SELECT timezone_id FROM timezone WHERE timezone_name= '" . $timezone . "'");
-if (!$resTimezone) {
+$statement = $link->prepare("SELECT timezone_id FROM timezone WHERE timezone_name= :timezone_name");
+$statement->bindValue(':timezone_name', $timezone, \PDO::PARAM_STR);
+if (!$statement->execute()) {
     $return['msg'] = _('Cannot get timezone information');
     echo json_encode($return);
     exit;
 }
-if ($row = $resTimezone->fetch()) {
+if ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
     $timezoneId = $row['timezone_id'];
 } else {
     $timezoneId = '334'; # Europe/London timezone
 }
-$link->exec("INSERT INTO `options` (`key`, `value`) VALUES ('gmt','" . $timezoneId . "')");
+$statement = $link->prepare("INSERT INTO `options` (`key`, `value`) VALUES ('gmt', :value)");
+$statement->bindValue(':value', $timezoneId, \PDO::PARAM_STR);
+$statement->execute();
 
 # Generate random key for this instance and set it to be not central and not remote
 $uniqueKey = md5(uniqid(rand(), true));


### PR DESCRIPTION
## Description

Sanitizing and binding default conf queries.

**Fixes** # MON-14954

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
