### PR TITLE
Fix: Sanitize and bind Media import 

### DIFF
--- a/www/class/centreonMedia.class.php
+++ b/www/class/centreonMedia.class.php
@@ -413,14 +413,12 @@ class CentreonMedia
             $imageId = $row['img_id'];
 
             // Insert relation between directory and image
-            $query = 'INSERT INTO view_img_dir_relation '
-                . '(dir_dir_parent_id, img_img_id) '
-                . 'VALUES ('
-                . $directoryId . ', '
-                . $imageId . ' '
-                . ') ';
+            $statement = $this->db->prepare("INSERT INTO view_img_dir_relation (dir_dir_parent_id, img_img_id) " .
+                "VALUES (:dirId, :imgId) ");
+            $statement->bindValue(':dirId', (int) $directoryId, \PDO::PARAM_INT);
+            $statement->bindValue(':imgId', (int) $imageId, \PDO::PARAM_INT);
             try {
-                $this->db->query($query);
+                $statement->execute();
             } catch (\PDOException $e) {
                 throw new \Exception('Error while inserting relation between' . $imageName . ' and ' . $directoryName);
             }


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where:

[www/class/centreonMedia.class.php](https://github.com/centreon/centreon/tree/a3c5e11fc0f5923b2711fad0b5eb7884d6dbdaa0/www/class/centreonMedia.class.php#L423)

Line: 423

**Fixes** # MON-14973

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add a new image in Centreon from “[Administration](https://pendo-22-04.centreon.io/centreon/main.php?p=5&o=c)  >  [Parameters](https://pendo-22-04.centreon.io/centreon/main.php?p=501&o=c)  >  [Images](https://pendo-22-04.centreon.io/centreon/main.php?p=50102)”

Valide that image have been imported
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
