### PR TITLE
FIX: Sanitize and bind Centreon Notification class 22.04.x

### DIFF
--- a/www/class/centreonNotification.class.php
+++ b/www/class/centreonNotification.class.php
@@ -35,6 +35,9 @@
 
 class CentreonNotification
 {
+    /**
+     * @var CentreonDB $db
+     */
     protected $db;
     protected $svcTpl;
     protected $svcNotifType;
@@ -342,10 +345,12 @@ class CentreonNotification
         		FROM host_template_relation htr
         		LEFT JOIN contact_host_relation ctr ON htr.host_host_id = ctr.host_host_id
         		LEFT JOIN contactgroup_host_relation ctr2 ON htr.host_host_id = ctr2.host_host_id
-        		WHERE htr.host_host_id = " . $hostId . "
+        		WHERE htr.host_host_id = :host_id 
         		ORDER BY `order`";
-        $res = $this->db->query($sql);
-        while ($row = $res->fetchRow()) {
+        $statement = $this->db->prepare($sql);
+        $statement->bindValue(':host_id', (int) $hostId, \PDO::PARAM_INT);
+        $statement->execute();
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
             if ($row['contact_id']) {
                 $this->hostBreak[1] = true;
             }


### PR DESCRIPTION
## Description

Sanitizing and binding centreon notification class queries.

**Fixes** # MON-14955

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
