### PR TITLE
Fix: Remove obsolete code in ACL configuration listing  dev2210x

### DIFF
--- a/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+++ b/www/include/options/accessLists/actionsACL/listsActionsAccess.php
@@ -118,11 +118,6 @@ for ($i = 0; $topo = $statement->fetchRow(); $i++) {
         "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $topo['acl_action_id'] . "]' />";
     /* Contacts */
-    $ctNbr = array();
-    $rq = "SELECT COUNT(*) AS nbr FROM acl_group_actions_relations " .
-        "WHERE acl_action_id = '" . $topo['acl_action_id'] . "'";
-    $DBRESULT2 = $pearDB->query($rq);
-    $ctNbr = $DBRESULT2->fetchRow();
     $elemArr[$i] = array(
         "MenuClass" => "list_" . $style,
         "RowMenu_select" => $selectedElements->toHtml(),

--- a/www/include/options/accessLists/menusACL/listsMenusAccess.php
+++ b/www/include/options/accessLists/menusACL/listsMenusAccess.php
@@ -116,10 +116,6 @@ for ($i = 0; $topo = $dbResult->fetchRow(); $i++) {
         "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $topo['acl_topo_id'] . "]' />";
     /* Contacts */
-    $ctNbr = array();
-    $rq2 = "SELECT COUNT(*) AS nbr FROM acl_topology_relations WHERE acl_topo_id = '" . $topo['acl_topo_id'] . "'";
-    $dbResult2 = $pearDB->query($rq2);
-    $ctNbr = $dbResult2->fetchRow();
     $elemArr[$i] = array(
         "MenuClass" => "list_" . $style,
         "RowMenu_select" => $selectedElements->toHtml(),

--- a/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+++ b/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
@@ -130,13 +130,6 @@ for ($i = 0; $resources = $statement->fetchRow(); $i++) {
         . $resources['acl_res_id'] . "]'></input>";
 
     /* Contacts */
-    $ctNbr = array();
-    $rq = "SELECT COUNT(*) AS nbr
-          FROM acl_resources_host_relations
-          WHERE acl_res_id = '" . $resources['acl_res_id'] . "'";
-    $DBRESULT2 = $pearDB->query($rq);
-    $ctNbr = $DBRESULT2->fetchRow();
-
     $allHostgroups = (isset($resources["all_hostgroups"]) && $resources["all_hostgroups"] == 1 ? _("Yes") : _("No"));
     $allServicegroups = (isset($resources["all_servicegroups"]) && $resources["all_servicegroups"] == 1 ?
         _("Yes") :


### PR DESCRIPTION
## Description
$ctNbr is no more used in ACL menus/resources/actions listing
Remove following code:
```
www/include//options/accessLists/resourcesACL/listsResourcesAccess.php:    $ctNbr = array();
www/include//options/accessLists/resourcesACL/listsResourcesAccess.php:    $ctNbr = $DBRESULT2->fetchRow();
www/include//options/accessLists/menusACL/listsMenusAccess.php:    $ctNbr = array();
www/include//options/accessLists/menusACL/listsMenusAccess.php:    $ctNbr = $dbResult2->fetchRow();
www/include//options/accessLists/actionsACL/listsActionsAccess.php:    $ctNbr = array();
www/include//options/accessLists/actionsACL/listsActionsAccess.php:    $ctNbr = $DBRESULT2->fetchRow();
```

**Fixes** # MON-14971

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check if ACL Menus / Actions / Resources listing are displayed without PHP errors (/var/log/php-fpm/centreon-error.log)
## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
