### PR TITLE
[Fix]: Sanitize and bind service by hostgroups listing dev-22.10.x

### DIFF
--- a/www/include/configuration/configObject/service/listServiceByHostGroup.php
+++ b/www/include/configuration/configObject/service/listServiceByHostGroup.php
@@ -202,27 +202,56 @@ $tpl->assign("headerMenu_options", _("Options"));
  * HostGroup/service list
  */
 if ($searchS || $searchHG) {
+    //preparing tmp binds
+    $tmpIds = explode(',', $tmp);
+    $tmpQueryBinds = [];
+    foreach ($tmpIds as $key => $value) {
+        $tmpQueryBinds[':tmp_id_' . $key] = $value;
+    }
+    $tmpBinds = implode(',', array_keys($tmpQueryBinds));
+    //preparing tmp2 binds
+    $tmp2Ids = explode(',', $tmp2);
+    $tmp2QueryBinds = [];
+    foreach ($tmp2Ids as $key => $value) {
+        $tmp2QueryBinds[':tmp2_id_' . $key] = $value;
+    }
+    $tmp2Binds = implode(',', array_keys($tmp2QueryBinds));
+
     $query = "SELECT $distinct @nbr:=(SELECT COUNT(*) FROM host_service_relation " .
         "WHERE service_service_id = sv.service_id GROUP BY sv.service_id ) AS nbr, sv.service_id, " .
         "sv.service_description, sv.service_activate, sv.service_template_model_stm_id, hg.hg_id, hg.hg_name " .
         "FROM service sv, hostgroup hg, host_service_relation hsr $aclFrom " .
-        "WHERE sv.service_register = '1' $sqlFilterCase AND sv.service_id IN (" . ($tmp ? $tmp : 'NULL') .
-        ") AND hsr.hostgroup_hg_id IN (" . ($tmp2 ? $tmp2 : 'NULL') . ") " .
-        ((isset($template) && $template) ? " AND service_template_model_stm_id = '$template' " : "") .
+        "WHERE sv.service_register = '1' $sqlFilterCase AND sv.service_id " .
+        "IN ($tmpBinds) AND hsr.hostgroup_hg_id IN ($tmp2Binds) " .
+        ((isset($template) && $template) ? " AND service_template_model_stm_id = :template " : "") .
         " AND hsr.service_service_id = sv.service_id AND hg.hg_id = hsr.hostgroup_hg_id " . $aclCond .
-        "ORDER BY hg.hg_name, sv.service_description LIMIT " . $num * $limit . ", " . $limit;
+        "ORDER BY hg.hg_name, sv.service_description LIMIT :offset_, :limit";
+    $statement = $pearDB->prepare($query);
+    //tmp bind values
+    foreach ($tmpQueryBinds as $key => $value) {
+        $statement->bindValue($key, (int) $value, PDO::PARAM_INT);
+    }
+    //tmp bind values
+    foreach ($tmp2QueryBinds as $key => $value) {
+        $statement->bindValue($key, (int) $value, PDO::PARAM_INT);
+    }
 } else {
     $query = "SELECT $distinct @nbr:=(SELECT COUNT(*) FROM host_service_relation " .
         "WHERE service_service_id = sv.service_id GROUP BY sv.service_id ) AS nbr, sv.service_id, " .
         "sv.service_description, sv.service_activate, sv.service_template_model_stm_id, hg.hg_id, hg.hg_name " .
         "FROM service sv, hostgroup hg, host_service_relation hsr $aclFrom " .
         "WHERE sv.service_register = '1' $sqlFilterCase " .
-        ((isset($template) && $template) ? " AND service_template_model_stm_id = '$template' " : "") .
+        ((isset($template) && $template) ? " AND service_template_model_stm_id = :template " : "") .
         " AND hsr.service_service_id = sv.service_id AND hg.hg_id = hsr.hostgroup_hg_id " . $aclCond .
-        "ORDER BY hg.hg_name, sv.service_description LIMIT " . $num * $limit . ", " . $limit;
+        "ORDER BY hg.hg_name, sv.service_description LIMIT :offset_, :limit";
+    $statement = $pearDB->prepare($query);
 }
-$dbResult = $pearDB->query($query);
-
+$statement->bindValue(':offset_', (int) $num * (int) $limit, \PDO::PARAM_INT);
+$statement->bindValue(':limit', (int) $limit, \PDO::PARAM_INT);
+if ((isset($template) && $template)) {
+    $statement->bindValue(':template', (int) $template, \PDO::PARAM_INT);
+}
+$statement->execute();
 $form = new HTML_QuickFormCustom('select_form', 'POST', "?p=" . $p);
 
 // Different style between each lines
@@ -263,7 +292,7 @@ $fgHostgroup = array("value" => null, "print" => null);
 
 $centreonToken = createCSRFToken();
 
-for ($i = 0; $service = $dbResult->fetch(); $i++) {
+for ($i = 0; $service = $statement->fetch(); $i++) {
     $moptions = "";
     $fgHostgroup["value"] != $service["hg_name"]
         ? ($fgHostgroup["print"] = true && $fgHostgroup["value"] = $service["hg_name"])


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code
**Fixes** MON-14964

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a service by hostgroup
2. Duplicate it (at least 20 time)
3. In listing of service by host group, search service, modify number of rows 
4. Check if the display is correct for a user with ACL and admin

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
