### PR TITLE
Fix: Sanitize and bind CLAPI Centreon Hostgroup class dev-22.04.x

### DIFF
--- a/www/class/centreon-clapi/centreonHostGroup.class.php
+++ b/www/class/centreon-clapi/centreonHostGroup.class.php
@@ -174,6 +174,7 @@ class CentreonHostGroup extends CentreonObject
             $listParam = explode('|', $params[1]);
             $exportedFields = [];
             $resultString = "";
+            $paramString = "";
             foreach ($listParam as $paramSearch) {
                 if (!$paramString) {
                     $paramString = $paramSearch;
@@ -257,20 +258,24 @@ class CentreonHostGroup extends CentreonObject
     public function getIdIcon($path)
     {
         $iconData = explode('/', $path);
-        $query = 'SELECT dir_id FROM view_img_dir WHERE dir_name = "' . $iconData[0] . '"';
-        $res = $this->db->query($query);
-        $row = $res->fetch();
+        $dirStatement = $this->db->prepare("SELECT dir_id FROM view_img_dir WHERE dir_name = :IconData");
+        $dirStatement->bindValue(':IconData', $iconData[0], \PDO::PARAM_STR);
+        $dirStatement->execute();
+        $row = $dirStatement->fetch();
         $dirId = $row['dir_id'];
 
-        $query = 'SELECT img_id FROM view_img WHERE img_path = "' . $iconData[1] . '"';
-        $res = $this->db->query($query);
-        $row = $res->fetch();
+        $imgStatement = $this->db->prepare("SELECT img_id FROM view_img WHERE img_path = :iconData");
+        $imgStatement->bindValue(':iconData', $iconData[1], \PDO::PARAM_STR);
+        $imgStatement->execute();
+        $row = $imgStatement->fetch();
         $iconId = $row['img_id'];
 
-        $query = 'SELECT vidr_id FROM view_img_dir_relation ' .
-            'WHERE dir_dir_parent_id = ' . $dirId . ' AND img_img_id = ' . $iconId;
-        $res = $this->db->query($query);
-        $row = $res->fetch();
+        $vidrStatement = $this->db->prepare("SELECT vidr_id FROM view_img_dir_relation " .
+            "WHERE dir_dir_parent_id = :dirId AND img_img_id = :iconId");
+        $vidrStatement->bindValue(':dirId', (int) $dirId, \PDO::PARAM_INT);
+        $vidrStatement->bindValue(':iconId', (int) $iconId, \PDO::PARAM_INT);
+        $vidrStatement->execute();
+        $row = $vidrStatement->fetch();
         return $row['vidr_id'];
     }
 


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code
in
www/class/centreon-clapi/centreonHostGroup.class.php
Lines: 

- 350
- 355
- 361

**Fixes** # MON-14968

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add map icon to an hostgroup

Get map icon image using CLAPI:

`centreon -u admin -p 'centreon' -o HG -a getparam -v "test;map_icon_image"`
Result should be like (image ID from “[Administration](https://pendo-22-04.centreon.io/centreon/main.php?p=5&o=c)  >  [Parameters](https://pendo-22-04.centreon.io/centreon/main.php?p=501&o=c)  >  [Images](https://pendo-22-04.centreon.io/centreon/main.php?p=50102)”):

```
map_icon_image
5
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
