### PR TITLE
FIX: Sanitize and bind SNMP Traps groups configuration 21.10.x

### DIFF
--- a/www/include/configuration/configObject/traps-groups/DB-Func.php
+++ b/www/include/configuration/configObject/traps-groups/DB-Func.php
@@ -172,10 +172,12 @@ function insertTrapGroup($ret = array())
 
     $fields = array();
     if (isset($ret['traps'])) {
+        $query = "INSERT INTO traps_group_relation (traps_group_id, traps_id) VALUES (:traps_group_id, :traps_id)";
+        $statement = $pearDB->prepare($query);
         foreach ($ret['traps'] as $trap_id) {
-            $query = "INSERT INTO traps_group_relation (traps_group_id, traps_id) VALUES (" .
-                $pearDB->escape($trap_group_id['max_id']) . ",'" . $pearDB->escape($trap_id) . "')";
-            $pearDB->query($query);
+            $statement->bindValue(':traps_group_id', $trap_group_id['max_id'], \PDO::PARAM_INT);
+            $statement->bindValue(':traps_id', (int) $trap_id, \PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 


### PR DESCRIPTION
## Description

Sanitizing and binding SNPM traps group configuration queries.

**Fixes** # MON-14963

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
