### PR TITLE
fix(conf/export) broker RRDcacheD export

### DIFF
--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -220,7 +220,8 @@ class Broker extends AbstractObjectJSON
                 }
 
                 $subValuesToCastInArray = [];
-                $rrdCacheOption = 'disable';
+                $rrdCacheOption = null;
+                $rrdCached = null;
                 foreach ($value as $subvalue) {
                     if (
                         !isset($subvalue['fieldIndex'])
@@ -239,21 +240,20 @@ class Broker extends AbstractObjectJSON
                         } elseif ($subvalue['config_key'] === 'category') {
                             $object[$key][$subvalue['config_group_id']]['filters'][$subvalue['config_key']][] =
                                 $subvalue['config_value'];
-                        } else {
+                        } elseif (in_array($subvalue['config_key'], ['rrd_cached_option', 'rrd_cached'])) {
                             if ($subvalue['config_key'] === 'rrd_cached_option') {
                                 $rrdCacheOption = $subvalue['config_value'];
-                                continue;
+                            } elseif ($subvalue['config_key'] === 'rrd_cached') {
+                                $rrdCached = $subvalue['config_value'];
                             }
-
-                            if ($subvalue['config_key'] === 'rrd_cached') {
+                            if ($rrdCached && $rrdCacheOption) {
                                 if ($rrdCacheOption === 'tcp') {
-                                    $object[$key][$subvalue['config_group_id']]['port'] = $subvalue['config_value'];
+                                    $object[$key][$subvalue['config_group_id']]['port'] = $rrdCached;
                                 } elseif ($rrdCacheOption === 'unix') {
-                                    $object[$key][$subvalue['config_group_id']]['path'] = $subvalue['config_value'];
+                                    $object[$key][$subvalue['config_group_id']]['path'] = $rrdCached;
                                 }
-                                continue;
                             }
-
+                        } else {
                             $object[$key][$subvalue['config_group_id']][$subvalue['config_key']] =
                                 $subvalue['config_value'];
 


### PR DESCRIPTION
## Description
  RRDcached path was not exported depending on the database configuration as it was dependent on the rows order when retrieving data from DB.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
