### PR TITLE
enh(resources): fetch ack / dt in detail only if needed

### DIFF
--- a/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
+++ b/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
@@ -121,6 +121,14 @@ class FindHost
 
         $host->setSeverity($severity);
 
+        $acknowledgement = $host->isAcknowledged() === true
+            ? $this->acknowledgementRepository->findOnGoingAcknowledgementByHostId($hostId)
+            : null;
+
+        $downtimes = $host->isInDowntime() === true
+            ? $this->downtimeRepository->findOnGoingDowntimesByHostId($hostId)
+            : [];
+
         /**
          * Obfuscate the passwords in Host commandLine
          * @todo Re-write this code when monitoring repository will be migrated to new architecture
@@ -130,8 +138,8 @@ class FindHost
         $presenter->present(
             $this->createResponse(
                 $host,
-                $this->downtimeRepository->findOnGoingDowntimesByHostId($hostId),
-                $this->acknowledgementRepository->findOnGoingAcknowledgementByHostId($hostId)
+                $downtimes,
+                $acknowledgement
             )
         );
     }

--- a/src/Core/Application/RealTime/UseCase/FindMetaService/FindMetaService.php
+++ b/src/Core/Application/RealTime/UseCase/FindMetaService/FindMetaService.php
@@ -120,12 +120,20 @@ class FindMetaService
         $hostId = $metaService->getHostId();
         $serviceId = $metaService->getServiceId();
 
+        $acknowledgement = $metaService->isAcknowledged() === true
+            ? $this->acknowledgementRepository->findOnGoingAcknowledgementByHostIdAndServiceId($hostId, $serviceId)
+            : null;
+
+        $downtimes = $metaService->isInDowntime() === true
+            ? $this->downtimeRepository->findOnGoingDowntimesByHostIdAndServiceId($hostId, $serviceId)
+            : [];
+
         $presenter->present(
             $this->createResponse(
                 $metaService,
                 $metaServiceConfiguration,
-                $this->downtimeRepository->findOnGoingDowntimesByHostIdAndServiceId($hostId, $serviceId),
-                $this->acknowledgementRepository->findOnGoingAcknowledgementByHostIdAndServiceId($hostId, $serviceId)
+                $downtimes,
+                $acknowledgement,
             )
         );
     }

--- a/src/Core/Application/RealTime/UseCase/FindService/FindService.php
+++ b/src/Core/Application/RealTime/UseCase/FindService/FindService.php
@@ -159,6 +159,14 @@ class FindService
 
         $service->setSeverity($severity);
 
+        $acknowledgement = $service->isAcknowledged() === true
+            ? $this->acknowledgementRepository->findOnGoingAcknowledgementByHostIdAndServiceId($hostId, $serviceId)
+            : null;
+
+        $downtimes = $service->isInDowntime() === true
+            ? $this->downtimeRepository->findOnGoingDowntimesByHostIdAndServiceId($hostId, $serviceId)
+            : [];
+
         /**
          * Obfuscate the passwords in Service commandLine
          */
@@ -167,8 +175,8 @@ class FindService
         $presenter->present(
             $this->createResponse(
                 $service,
-                $this->downtimeRepository->findOnGoingDowntimesByHostIdAndServiceId($hostId, $serviceId),
-                $this->acknowledgementRepository->findOnGoingAcknowledgementByHostIdAndServiceId($hostId, $serviceId),
+                $downtimes,
+                $acknowledgement,
                 $host
             )
         );

--- a/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
@@ -57,7 +57,10 @@ beforeEach(function () {
     $this->severityRepository = $this->createMock(ReadSeverityRepositoryInterface::class);
 
     $this->acknowledgement = new Acknowledgement(1, 1, 10, new \DateTime('1991-09-10'));
-    $this->host = HostTest::createHostModel();
+    $this->host = (HostTest::createHostModel())
+        ->setIsInDowntime(true)
+        ->setIsAcknowledged(true);
+
     $this->contact = $this->createMock(ContactInterface::class);
 
     $this->hostgroup = new Hostgroup(10, 'ALL');

--- a/tests/php/Core/Application/RealTime/UseCase/FindMetaService/FindMetaServiceTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindMetaService/FindMetaServiceTest.php
@@ -181,7 +181,9 @@ it('should present a NotFoundResponse if metaservice requested is not found as n
 
 it('should find the metaservice as non-admin', function () {
     $metaServiceConfiguration = MetaServiceConfigurationTest::createMetaServiceModel();
-    $metaService = MetaServiceTest::createMetaServiceModel();
+    $metaService = (MetaServiceTest::createMetaServiceModel())
+        ->setIsInDowntime(true)
+        ->setIsAcknowledged(true);
 
     $downtimes[] = (new Downtime(1, 1, 10))
         ->setCancelled(false);

--- a/tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
+++ b/tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
@@ -67,8 +67,14 @@ beforeEach(function () {
 
     $this->contact = $this->createMock(ContactInterface::class);
 
-    $this->host = HostTest::createHostModel();
-    $this->service = ServiceTest::createServiceModel();
+    $this->host = (HostTest::createHostModel())
+        ->setIsInDowntime(true)
+        ->setIsAcknowledged(true);
+
+    $this->service = (ServiceTest::createServiceModel())
+        ->setIsInDowntime(true)
+        ->setIsAcknowledged(true);
+
     $this->servicegroup = new Servicegroup(1, 'ALL');
     $this->category = new Tag(1, 'service-category-name', Tag::SERVICE_CATEGORY_TYPE_ID);
     $icon = (new Icon())->setId(1)->setName('centreon')->setUrl('ppm/centreon.png');


### PR DESCRIPTION
This PR intends to do several things
- Workaround an issue when an Acknowledgement is considered as on-going even if resource has returned to a OK / UP status
- Optimization - don't do the request of ACK / DT if the resource if not acknowledged or in downtime

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for this

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
