### PR TITLE
fix(websso): Correctly set contact theme while authenticating with WebSSO

### DIFF
--- a/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
+++ b/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
@@ -207,4 +207,9 @@ interface ContactInterface
      * @return static
      */
     public function setAccessToApiRealTime(bool $hasAccessToApiRealTime): static;
+
+    /**
+     * @return string|null
+     */
+    public function getTheme(): ?string;
 }

--- a/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
+++ b/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
@@ -171,7 +171,8 @@ class OpenId implements ProviderAuthenticationInterface
             'contact_location' => $user->getLocale(),
             'show_deprecated_pages' => $user->isUsingDeprecatedPages(),
             'reach_api' => $user->hasAccessToApiConfiguration() ? 1 : 0,
-            'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0
+            'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0,
+            'contact_theme' => $user->getTheme() ?? 'light'
         ];
 
         $this->provider->setLegacySession(new \Centreon($sessionUserInfos));

--- a/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
+++ b/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
@@ -88,7 +88,8 @@ class WebSSO implements ProviderAuthenticationInterface
             'contact_location' => $user->getLocale(),
             'show_deprecated_pages' => $user->isUsingDeprecatedPages(),
             'reach_api' => $user->hasAccessToApiConfiguration() ? 1 : 0,
-            'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0
+            'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0,
+            'contact_theme' => $user->getTheme() ?? 'light'
         ];
 
         $this->provider->setLegacySession(new \Centreon($sessionUserInfos));


### PR DESCRIPTION
## Description

This PR Intends to fix an issue where contact_theme wasn't set when users tried to authenticate using Web SSO

**Fixes** # MON-14822

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
