### PR TITLE
Fix: Sanitize and bind CALPI Centreon service class dev-22.04.x

### DIFF
--- a/www/class/centreon-clapi/centreonService.class.php
+++ b/www/class/centreon-clapi/centreonService.class.php
@@ -1584,12 +1584,12 @@ class CentreonService extends CentreonObject
         $arr = array();
         $i = 0;
         if ($serviceId) {
-            $res = $this->db->query("SELECT svc_macro_name, svc_macro_value, is_password, description
-                                FROM on_demand_macro_service
-                                WHERE svc_svc_id = " .
-                $serviceId . "
-                                ORDER BY macro_order ASC");
-            while ($row = $res->fetch()) {
+            $statement = $this->db->prepare("SELECT svc_macro_name, svc_macro_value, is_password, description " .
+                "FROM on_demand_macro_service " .
+                "WHERE svc_svc_id = :serviceId ORDER BY macro_order ASC");
+            $statement->bindValue(':serviceId', (int) $serviceId, \PDO::PARAM_INT);
+            $statement->execute();
+            while ($row = $statement->fetch()) {
                 if (preg_match('/\$_SERVICE(.*)\$$/', $row['svc_macro_name'], $matches)) {
                     $arr[$i]['svc_macro_name'] = $matches[1];
                     $arr[$i]['svc_macro_value'] = $row['svc_macro_value'];


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

in : www/class/centreon-clapi/centreonService.class.php
Line: 1672

**Fixes** # MON-14961

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Configure custom macros on a service using UI
2. [Export configuration using CLAPI](https://docs.centreon.com/docs/api/clapi/#export)
3. `centreon -u admin -p 'Centreon!2021' -o SERVICE -e`
4. check if custom macros have been exported, you must have lines like:

`SERVICE;setmacro;centreon-central;Broker-Stats;filtername;toto;0;`

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).