### PR TITLE
Fix: Remove obsolete code in database partitioning functions dev-21.10.x

### DIFF
--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -426,44 +426,6 @@ class PartEngine
         }
     }
 
-    /**
-     * optimize all partitions for a table
-     *
-     * @param MysqlTable $table
-     */
-    public function optimizeTablePartitions($table, $db)
-    {
-        $tableName = "`" . $table->getSchema() . "`." . $table->getName();
-        if (!$table->exists()) {
-            throw new Exception("Optimize error: Table " . $tableName . " does not exists\n");
-        }
-
-        $request = "SELECT PARTITION_NAME FROM information_schema.`PARTITIONS` ";
-        $request .= "WHERE `TABLE_NAME`='" . $table->getName() . "' ";
-        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
-        try {
-            $dbResult = $db->query($request);
-        } catch (\PDOException $e) {
-            throw new Exception(
-                "Error : Cannot get table schema information  for "
-                . $tableName . ", " . $e->getMessage() . "\n"
-            );
-        }
-
-        while ($row = $dbResult->fetch()) {
-            $request = "ALTER TABLE " . $tableName . " OPTIMIZE PARTITION `" . $row["PARTITION_NAME"] . "`;";
-            try {
-                $dbResult2 = $db->query($request);
-            } catch (\PDOException $e) {
-                throw new Exception(
-                    "Optimize error : Cannot optimize partition " . $row["PARTITION_NAME"]
-                    . " of table " . $tableName . ", " . $e->getMessage() . "\n"
-                );
-            }
-        }
-
-        $dbResult->closeCursor();
-    }
 
     /**
      * list all partitions for a table


### PR DESCRIPTION
## Description
Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

www/class/centreon-partition/partEngine.class.php

Remove optimizeTablePartitions function

**Fixes** # MON-14974

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Get number of current partition for “data_bin”:

`ls /var/lib/mysql/centreon_storage/ | egrep data_bin#P#* | wc -l`
38
Increase “Forward provisioning” from “Administration > Parameters > Options” menu (+10)

Run script manually

`/usr/bin/php /usr/share/centreon/cron/centreon-partitioning.php`
Check that partitions have been created using:

`ls /var/lib/mysql/centreon_storage/ | egrep data_bin#P#* | wc -l`
48
Reduce “Retention duration for performance data in MySQL database” from “Administration > Parameters > Options” menu

Run script manually

`/usr/bin/php /usr/share/centreon/cron/centstorage_purge.php`
Check that partitions have been deleted

`ls /var/lib/mysql/centreon_storage/ | egrep data_bin#P#* | wc -l`
35
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
