### PR TITLE
Fix: Remove obsolete code in Criticality class   dev.21.10.x

### DIFF
--- a/www/class/centreonCriticality.class.php
+++ b/www/class/centreonCriticality.class.php
@@ -358,29 +358,4 @@ class CentreonCriticality
         }
         return 0;
     }
-
-    public function getHostTplCriticities($host_id, $cache)
-    {
-        global $pearDB;
-        
-        if (!$host_id) {
-            return null;
-        }
-        
-        $rq = "SELECT host_tpl_id " .
-            "FROM host_template_relation " .
-            "WHERE host_host_id = '".$host_id."' " .
-            "ORDER BY `order`";
-        $DBRESULT = $pearDB->query($rq);
-        while ($row = $DBRESULT->fetchRow()) {
-            if (isset($cache[$row['host_tpl_id']])) {
-                return $this->getData($cache[$row['host_tpl_id']], false);
-            } else {
-                if ($result_field = $this->getHostTplCriticities($row['host_tpl_id'], $cache)) {
-                    return $result_field;
-                }
-            }
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
## Description

The getHostTplCriticities called itself but is not called by Centreon or modules.

File: www/class/centreonCriticality.class.php

Remove function getHostTplCriticities

**Fixes** # MON-14972

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
no tests fo this PR
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
