### PR TITLE
Fix: Sanitize and bind SNMP Traps listing  dev-21.10.x

### DIFF
--- a/www/include/configuration/configObject/traps/listTraps.php
+++ b/www/include/configuration/configObject/traps/listTraps.php
@@ -200,9 +200,11 @@ for ($i = 0; $trap = $stmt->fetch(); $i++) {
         "event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;" .
         "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $trap['traps_id'] . "]' />";
-    $dbResult2 = $pearDB->query("select alias from traps_vendor where id='" . $trap['manufacturer_id'] . "' LIMIT 1");
-    $mnftr = $dbResult2->fetch();
-    $dbResult2->closeCursor();
+    $statement = $pearDB->prepare("select alias from traps_vendor where id= :trap LIMIT 1");
+    $statement->bindValue(':trap', (int) $trap['manufacturer_id'], \PDO::PARAM_INT);
+    $statement->execute();
+    $mnftr = $statement->fetch();
+    $statement->closeCursor();
     $elemArr[$i] = array(
         "MenuClass" => "list_" . $style,
         "RowMenu_select" => $selectedElements->toHtml(),


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

**in**

www/include/configuration/configObject/traps/listTraps.php

**Line: 203**

**Fixes** # MON-14967

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check that vendor column is displayed in SNMP Traps configuration listing

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
