### PR TITLE
fix(api): Fix warning message when calling the "platform/versions" API

### DIFF
--- a/src/Centreon/Application/Controller/PlatformController.php
+++ b/src/Centreon/Application/Controller/PlatformController.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Centreon\Application\Controller;
 
+use Centreon\Domain\VersionHelper;
 use FOS\RestBundle\View\View;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -90,12 +91,16 @@ class PlatformController extends AbstractController
      */
     private function extractVersion(string $version): array
     {
-        list($major, $minor, $fix) = explode('.', $version, 3);
+        list($major, $minor, $fix) = explode(
+            '.',
+            VersionHelper::regularizeDepthVersion($version),
+            3
+        );
         return [
             'version' => $version,
             'major' => $major,
             'minor' => $minor,
-            'fix' => !empty($fix) ? $fix : '0'
+            'fix' => $fix
         ];
     }
 


### PR DESCRIPTION
## Description

A warning message appears when calling the "platform/versions" API and when one of the retrieved versions does not contain the fix version number.
This warning appears only with PHP 8.1

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
