### PR TITLE
(fix) remove required parameters for openid

### DIFF
--- a/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
+++ b/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
@@ -154,6 +154,11 @@ class UpdateOpenIdConfiguration
     {
         $this->info('Creating Authorization Rules');
         $accessGroupIds = $this->getAccessGroupIds($authorizationRulesFromRequest);
+
+        if (empty($accessGroupIds)) {
+            return [];
+        }
+
         $foundAccessGroups = $this->accessGroupRepository->findByIds($accessGroupIds);
 
         $this->logNonExistentAccessGroupsIds($accessGroupIds, $foundAccessGroups);
@@ -241,12 +246,10 @@ class UpdateOpenIdConfiguration
             }
             $this->info('Updating OpenID Configuration');
             $this->repository->updateConfiguration($configuration);
-            if (! empty($configuration->getAuthorizationRules())) {
-                $this->info('Removing existent Authorization Rules');
-                $this->repository->deleteAuthorizationRules();
-                $this->info('Inserting new Authorization Rules');
-                $this->repository->insertAuthorizationRules($configuration->getAuthorizationRules());
-            }
+            $this->info('Removing existent Authorization Rules');
+            $this->repository->deleteAuthorizationRules();
+            $this->info('Inserting new Authorization Rules');
+            $this->repository->insertAuthorizationRules($configuration->getAuthorizationRules());
             if (! $isAlreadyInTransaction) {
                 $this->dataStorageEngine->commitTransaction();
             }


### PR DESCRIPTION
## Description

Remove required parameters regarding OpenID configuration

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Save an OpenID configuration without relation between authorization value and access group.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
