### PR TITLE
FIX: Sanitize and bind Centreon Service class 22.04.x

### DIFF
--- a/www/class/centreonService.class.php
+++ b/www/class/centreonService.class.php
@@ -1727,12 +1727,14 @@ class CentreonService
         } else {
             $alreadyProcessed[] = $svcId;
 
-            $res = $this->db->query(
-                "SELECT service_template_model_stm_id FROM service WHERE service_id = " . $this->db->escape($svcId)
+            $statement = $this->db->prepare(
+                "SELECT service_template_model_stm_id FROM service WHERE service_id = :service_id"
             );
+            $statement->bindValue(':service_id', (int) $svcId, \PDO::PARAM_INT);
+            $statement->execute();
 
-            if ($res->rowCount()) {
-                $row = $res->fetchRow();
+            if ($statement->rowCount()) {
+                $row = $statement->fetch(\PDO::FETCH_ASSOC);
                 if (!empty($row['service_template_model_stm_id']) && $row['service_template_model_stm_id'] !== null) {
                     $svcTmpl = array_merge(
                         $svcTmpl,

--- a/www/include/configuration/configKnowledge/display-hostTemplates.php
+++ b/www/include/configuration/configKnowledge/display-hostTemplates.php
@@ -167,11 +167,11 @@ try {
             foreach ($tplArr as $key1 => $value1) {
                 if ($firstTpl) {
                     $tplStr .= " <a href='" . $WikiURL .
-                        "/index.php?title=Host-Template:" . $value1 . "' target = '_blank' > " . $value1 . "</a > ";
+                        "/index.php?title=Host-Template_:_" . $value1 . "' target = '_blank' > " . $value1 . "</a > ";
                     $firstTpl = 0;
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;<a href = '" . $WikiURL .
-                        "/index.php?title=Host-Template:" . $value1 . "' target = '_blank' > " . $value1 . "</a > ";
+                        "/index.php?title=Host-Template_:_" . $value1 . "' target = '_blank' > " . $value1 . "</a > ";
                 }
             }
         }

--- a/www/include/configuration/configKnowledge/display-hosts.php
+++ b/www/include/configuration/configKnowledge/display-hosts.php
@@ -192,11 +192,11 @@ try {
             foreach ($tplArr as $key1 => $value1) {
                 if ($firstTpl) {
                     $tplStr .= "<a href='" . $WikiURL .
-                        "/index.php?title=Host:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Host-Template_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                     $firstTpl = 0;
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;<a href='" . $WikiURL .
-                        "/index.php?title=Host:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Host-Template_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                 }
             }
         }

--- a/www/include/configuration/configKnowledge/display-serviceTemplates.php
+++ b/www/include/configuration/configKnowledge/display-serviceTemplates.php
@@ -170,11 +170,11 @@ try {
             foreach ($tplArr as $key1 => $value1) {
                 if ($firstTpl) {
                     $tplStr .= "<a href='" . $WikiURL .
-                        "/index.php?title=Service-Template:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Service-Template_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                     $firstTpl = 0;
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;<a href='" . $WikiURL .
-                        "/index.php?title=Service-Template:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Service-Template_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                 }
             }
         }

--- a/www/include/configuration/configKnowledge/display-services.php
+++ b/www/include/configuration/configKnowledge/display-services.php
@@ -274,7 +274,7 @@ try {
                     $tplStr .= "&nbsp;|&nbsp;";
                 }
                 $tplStr .= "<a href='" . $WikiURL .
-                    "/index.php?title=Service_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
+                    "/index.php?title=Service-Template_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
             }
         }
         $templateHostArray[$key] = $tplStr;


### PR DESCRIPTION
## Description

Sanitizing and binding centreon service class and also fixing a bug in mediawiki template(host/service) links.

**Fixes** # MON-14962

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
