### PR TITLE
fix(websso): Correctly check Is Active and Is Forced properties

### DIFF
--- a/src/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Repository/DbWebSSOConfigurationFactory.php
+++ b/src/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Repository/DbWebSSOConfigurationFactory.php
@@ -37,8 +37,8 @@ class DbWebSSOConfigurationFactory
     public static function createFromRecord(array $customConfiguration, array $configuration): WebSSOConfiguration
     {
         $webSSOConfiguration = new WebSSOConfiguration(
-            $configuration['is_active'] === '1',
-            $configuration['is_forced'] === '1',
+            $configuration['is_active'] === 1,
+            $configuration['is_forced'] === 1,
             $customConfiguration['trusted_client_addresses'],
             $customConfiguration['blacklist_client_addresses'],
             $customConfiguration['login_header_attribute'],


### PR DESCRIPTION
## Description
This PR intends to correctly check Is Active and Is Forced properties. Since PHP has been upgraded to 8.1, the record returned are no longer string of '0' or '1' but directly an integer

**Fixes** # MON-15154

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create a WebSSO configuration, try to enable it or set it to forced. save the form, while refreshing the page, the radio button for isActive or isForced should still be activate.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
