### PR TITLE
fix(clapi)CLAPI doesn't support & (and maybe other) special char in password

### DIFF
--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -107,7 +107,7 @@ class CentreonAPI
             $this->login = htmlentities($user, ENT_QUOTES);
         }
         if (isset($password)) {
-            $this->password = htmlentities($password, ENT_QUOTES);
+            $this->password = filter_var($password, FILTER_SANITIZE_STRING);
         }
         if (isset($action)) {
             $this->action = htmlentities(strtoupper($action), ENT_QUOTES);


### PR DESCRIPTION
## Description

Fixed special character (i.e. '&') encoding in CLAPI.

**Fixes** # MON-15158

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create `test` user with password `t3$t#&Ot3$t#&O`
- Execute CLAPI command `centreon -u test -p 't3$t#&Ot3$t#&O' -o HOST -a SHOW`
- Check command line output

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
