### PR TITLE
fix(clapi)CLAPI doesn't support & (and maybe other) special char in password (develop)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6570,12 +6570,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "fbf6f542e40d9178d882e40a6b25a52622d2c3bc"
+                "reference": "d3ded3c12fc4f70788f43452b057bc6a505f41ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/fbf6f542e40d9178d882e40a6b25a52622d2c3bc",
-                "reference": "fbf6f542e40d9178d882e40a6b25a52622d2c3bc",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/d3ded3c12fc4f70788f43452b057bc6a505f41ee",
+                "reference": "d3ded3c12fc4f70788f43452b057bc6a505f41ee",
                 "shasum": ""
             },
             "require": {
@@ -6590,6 +6590,9 @@
                 "symfony/http-client": "^5.4.0",
                 "symfony/property-access": "^5.4.0",
                 "webmozart/assert": "^1.9"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.21"
             },
             "suggest": {
                 "behat/mink": "Browser controller/emulator abstraction for PHP",
@@ -6622,7 +6625,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/master"
             },
-            "time": "2022-09-16T14:39:36+00:00"
+            "time": "2022-09-26T11:56:45+00:00"
         },
         {
             "name": "composer/pcre",

--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -107,7 +107,7 @@ class CentreonAPI
             $this->login = htmlentities($user, ENT_QUOTES);
         }
         if (isset($password)) {
-            $this->password = htmlentities($password, ENT_QUOTES);
+            $this->password = \HtmlAnalyzer::sanitizeAndRemoveTags($password);
         }
         if (isset($action)) {
             $this->action = htmlentities(strtoupper($action), ENT_QUOTES);


### PR DESCRIPTION
## Description

Fixed special character (i.e. '&') encoding in CLAPI.

**Fixes** MON-15158

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create `test` user with password `t3$t#&Ot3$t#&O`
- Execute CLAPI command `centreon -u test -p 't3$t#&Ot3$t#&O' -o HOST -a SHOW`
- Check command line output

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
