### PR TITLE
FIX: Cannot export CSV/Images in multiple periods graphs

### DIFF
--- a/www/include/views/graphs/exportData/ExportCSVServiceData.php
+++ b/www/include/views/graphs/exportData/ExportCSVServiceData.php
@@ -33,12 +33,7 @@
  *
  */
 
-function get_error($str)
-{
-    echo $str . "<br />";
-    exit(0);
-}
-
+require_once realpath(__DIR__ . "/../../../../../bootstrap.php");
 require_once realpath(dirname(__FILE__) . "/../../../../../config/centreon.config.php");
 include_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 

--- a/www/include/views/graphs/exportData/ExportCSVServiceData.php
+++ b/www/include/views/graphs/exportData/ExportCSVServiceData.php
@@ -33,9 +33,14 @@
  *
  */
 
-require_once realpath(__DIR__ . "/../../../../../bootstrap.php");
+function get_error($str){
+    echo $str."<br />";
+    exit(0);
+}
+
 require_once realpath(dirname(__FILE__) . "/../../../../../config/centreon.config.php");
 include_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
+include_once _CENTREON_PATH_ . "www/class/HtmlAnalyzer.php";
 
 $pearDB = new CentreonDB();
 $pearDBO = new CentreonDB("centstorage");

--- a/www/include/views/graphs/exportData/ExportCSVServiceData.php
+++ b/www/include/views/graphs/exportData/ExportCSVServiceData.php
@@ -33,8 +33,9 @@
  *
  */
 
-function get_error($str){
-    echo $str."<br />";
+function get_error($str)
+{
+    echo $str . "<br />";
     exit(0);
 }
 


### PR DESCRIPTION
## Description

Due to PHP 8.1 migration, changes had to be made through out the platform and it introduced some side effects and one of them is a blank page when trying to export CSV or image in multiple period graphs

**Fixes** # MON-15169

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
