### PR TITLE
Fix: Remove obsolete code in legacy service detail page dev-2110

### DIFF
--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -621,18 +621,17 @@ if (!is_null($host_id)) {
             $status .= "&value[" . $key . "]=" . $value;
         }
 
-        $optionsURL = "host_name=" . urlencode($host_name) . "&service_description=" . urlencode($svc_description);
-
-        $query = "SELECT id FROM `index_data`, `metrics` WHERE host_name = '" . $pearDBO->escape($host_name) .
-            "' AND service_description = '" . $pearDBO->escape($svc_description) . "' AND id = index_id LIMIT 1";
-        $DBRES = $pearDBO->query($query);
+        $query = "SELECT id FROM `index_data`, `metrics` WHERE host_name = :host_name" .
+            " AND service_description = :svc_description AND id = index_id LIMIT 1";
+        $statement = $pearDBO->prepare($query);
+        $statement->bindValue(':host_name', $host_name, \PDO::PARAM_STR);
+        $statement->bindValue(':svc_description', $svc_description, \PDO::PARAM_STR);
+        $statement->execute();
         $index_data = 0;
-        if ($DBRES->rowCount()) {
-            $row = $DBRES->fetchRow();
+        if ($statement->rowCount()) {
+            $row = $statement->fetchRow();
             $index_data = $row['id'];
         }
-        $optionsURL2 = "index=" . $index_data;
-
         /*
          * Assign translations
          */
@@ -875,9 +874,7 @@ if (!is_null($host_id)) {
         $tpl->assign("sv_ext_action_url_lang", _("Action URL"));
         $tpl->assign("sv_ext_action_url", CentreonUtils::escapeSecure($actionurl));
         $tpl->assign("sv_ext_icon_image_alt", getMyServiceExtendedInfoField($service_id, "esi_icon_image_alt"));
-        $tpl->assign("options", $optionsURL);
         $tpl->assign("index_data", $index_data);
-        $tpl->assign("options2", CentreonUtils::escapeSecure($optionsURL2));
 
         /**
          * Build the service detail URI that will be used in the


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code
 **in** www/include/monitoring/objectDetails/serviceDetails.php

**Line:** 626
**Fixes** # MON-14928

**Remove following block:**

```
$optionsURL = "host_name=" . urlencode($host_name) . "&service_description=" . urlencode($svc_description);

$optionsURL2 = "index=" . $index_data;
```
**As well as:**
```

$tpl->assign("options", $optionsURL);
$tpl->assign("options2", CentreonUtils::escapeSecure($optionsURL2));
```
 

$optionsURL (options) & $optionsURL2 (options2) are no used in /www/include/monitoring/objectDetails/template/serviceDetails.ihtml

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to “Monitoring > Status Details” and select a service
- Check if no errors appear on page

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
