### PR TITLE
Fix: Sanitize and bind menu topology listing dev-22.04.x

### DIFF
--- a/src/Centreon/Domain/Repository/TopologyRepository.php
+++ b/src/Centreon/Domain/Repository/TopologyRepository.php
@@ -105,14 +105,15 @@ class TopologyRepository extends ServiceEntityRepository
                 if ($DBRESULT->rowCount()) {
                     $topology = array();
                     $tmp_topo_page = array();
+                    $statement = $this->db->prepare("SELECT topology_topology_id, acl_topology_relations.access_right "
+                        . "FROM acl_topology_relations, acl_topology "
+                        . "WHERE acl_topology.acl_topo_activate = '1' "
+                        . "AND acl_topology.acl_topo_id = acl_topology_relations.acl_topo_id "
+                        . "AND acl_topology_relations.acl_topo_id = :acl_topo_id ");
                     while ($topo_group = $DBRESULT->fetchRow()) {
-                        $query2 = "SELECT topology_topology_id, acl_topology_relations.access_right "
-                            . "FROM acl_topology_relations, acl_topology "
-                            . "WHERE acl_topology.acl_topo_activate = '1' "
-                            . "AND acl_topology.acl_topo_id = acl_topology_relations.acl_topo_id "
-                            . "AND acl_topology_relations.acl_topo_id = '" . $topo_group["acl_topology_id"] . "' ";
-                        $DBRESULT2 = $this->db->query($query2);
-                        while ($topo_page = $DBRESULT2->fetchRow()) {
+                        $statement->bindValue(':acl_topo_id', $topo_group["acl_topology_id"], \PDO::PARAM_INT);
+                        $statement->execute();
+                        while ($topo_page = $statement->fetch(\PDO::FETCH_ASSOC)) {
                             $topology[] = (int)$topo_page["topology_topology_id"];
                             if (!isset($tmp_topo_page[$topo_page['topology_topology_id']])) {
                                 $tmp_topo_page[$topo_page["topology_topology_id"]] = $topo_page["access_right"];
@@ -127,7 +128,7 @@ class TopologyRepository extends ServiceEntityRepository
                                 }
                             }
                         }
-                        $DBRESULT2->closeCursor();
+                        $statement->closeCursor();
                     }
                     $DBRESULT->closeCursor();
 

--- a/src/Centreon/Tests/Domain/Repository/TopologyRepositoryTest.php
+++ b/src/Centreon/Tests/Domain/Repository/TopologyRepositoryTest.php
@@ -52,7 +52,7 @@ class TopologyRepositoryTest extends TestCase
                 . "FROM acl_topology_relations, acl_topology "
                 . "WHERE acl_topology.acl_topo_activate = '1' "
                 . "AND acl_topology.acl_topo_id = acl_topology_relations.acl_topo_id "
-                . "AND acl_topology_relations.acl_topo_id = '1' ",
+                . "AND acl_topology_relations.acl_topo_id = :acl_topo_id ",
                 'data' => [
                     [
                         'topology_topology_id' => 1,

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -289,7 +289,7 @@ class CentreonDB extends \PDO
     /**
      * Query
      *
-     * @return PDOStatement|null
+     * @return CentreonDBStatement|false
      * @param string $queryString
      * @param mixed $parameters
      * @param mixed $parametersArgs


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code
 **in** src/Centreon/Domain/Repository/TopologyRepository.php **on line** 114
**Fixes** # MON-14969

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a non admin user
- Give access to menu (ACL menus access)
- Connect with user
- Check if menus access are correct

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
