### PR TITLE
fix(db): change type of notification_number column 21.10

### DIFF
--- a/www/install/php/Update-21.10.11.php
+++ b/www/install/php/Update-21.10.11.php
@@ -29,14 +29,22 @@ $errorMessage = '';
 try {
     $errorMessage = "Impossible to update 'hosts' table";
     if (! str_contains(strtolower($pearDBO->getColumnType('hosts', 'notification_number')), 'bigint')) {
+        $pearDBO->beginTransaction();
+        $pearDBO->query("UPDATE `hosts` SET `notification_number`= 0 WHERE `notification_number`< 0");
         $pearDBO->query("ALTER TABLE `hosts` MODIFY `notification_number` BIGINT(20) UNSIGNED DEFAULT NULL");
     }
 
     $errorMessage = "Impossible to update 'services' table";
     if (! str_contains(strtolower($pearDBO->getColumnType('services', 'notification_number')), 'bigint')) {
+        $pearDBO->beginTransaction();
+        $pearDBO->query("UPDATE `services` SET `notification_number`= 0 WHERE `notification_number`< 0");
         $pearDBO->query("ALTER TABLE `services` MODIFY `notification_number` BIGINT(20) UNSIGNED DEFAULT NULL");
     }
 } catch (\Exception $e) {
+    if ($pearDBO->inTransaction()) {
+        $pearDBO->rollBack();
+    }
+
     $centreonLog->insertLog(
         4,
         $versionOfTheUpgrade . $errorMessage .


### PR DESCRIPTION
## Description

This is a fix on PR https://github.com/centreon/centreon/pull/11863 hadling the case when notification_number is inferior to 0 during update to 21.10.11

**Fixes** # MON-14223

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
