### PR TITLE
Fix(UI): Centreon logo issue with safari

### DIFF
--- a/www/front_src/src/Login/Logo.tsx
+++ b/www/front_src/src/Login/Logo.tsx
@@ -16,6 +16,7 @@ import { labelCentreonLogo } from './translatedLabels';
 const useStyles = makeStyles({
   centreonLogo: {
     height: '100%',
+    objectFit: 'contain',
     width: '100%',
   },
   centreonLogoWhite: {


### PR DESCRIPTION
## Description

This fixes a logo display issue with safari
![Screenshot 2022-09-28 at 15 54 14](https://user-images.githubusercontent.com/12515407/192797540-da86a511-922b-4a5c-9bef-e32f8a4b9a87.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Open a Safari browser
- Go to the Centreon login page
- -> The logo is correctly displayed (does not appear as not stretched)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
