### PR TITLE
FIX: MBI - Impossible to see jobs and reports for Web SSO users 22.04.x

### DIFF
--- a/src/EventSubscriber/WebSSOEventSubscriber.php
+++ b/src/EventSubscriber/WebSSOEventSubscriber.php
@@ -252,7 +252,7 @@ class WebSSOEventSubscriber implements EventSubscriberInterface
             'contact_autologin_key' => '',
             'contact_admin' => $user->isAdmin() ? '1' : '0',
             'default_page' => $user->getDefaultPage(),
-            'contact_location' => $user->getLocale(),
+            'contact_location' => (string) $user->getTimezoneId(),
             'show_deprecated_pages' => $user->isUsingDeprecatedPages(),
             'reach_api' => $user->hasAccessToApiConfiguration() ? 1 : 0,
             'reach_api_rt' => $user->hasAccessToApiRealTime() ? 1 : 0,


### PR DESCRIPTION
## Description

When a user connect to Centreon via Web SSO, he can’t see these pages:

Reporting  >  Monitoring Business Intelligence  >  Report view

Reporting  >  Monitoring Business Intelligence  >  Jobs

For reference this -> [PR](https://github.com/centreon/centreon/pull/11613)

**Fixes** # MON-15124

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
