### PR TITLE
fix(resources): rework the resource details redirection

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -309,6 +309,32 @@ class MonitoringResourceController extends AbstractController
     }
 
     /**
+     * Generates a resource details redirection link
+     *
+     * @param string $resourceType
+     * @param integer $resourceId
+     * @param array<string, integer> $parameters
+     * @return string
+     */
+    private function buildResourceDetailsUri(string $resourceType, int $resourceId, array $parameters): string
+    {
+        $resourceDetailsEndpoint = null;
+        foreach ($this->hyperMediaProviders as $hyperMediaProvider) {
+            if ($hyperMediaProvider->isValidFor($resourceType)) {
+                $resourceDetailsEndpoint = $hyperMediaProvider->generateResourceDetailsUri($parameters);
+            }
+        }
+
+        return $this->buildListingUri([
+            'details' => json_encode([
+                'id' => $resourceId,
+                'tab' => self::TAB_DETAILS_NAME,
+                'resourcesDetailsEndpoint' => $this->getBaseUri() . $resourceDetailsEndpoint
+            ])
+        ]);
+    }
+
+    /**
      * Build uri to access host panel with details tab
      *
      * @param integer $hostId
@@ -316,7 +342,11 @@ class MonitoringResourceController extends AbstractController
      */
     public function buildHostDetailsUri(int $hostId): string
     {
-        return $this->buildHostUri($hostId, self::TAB_DETAILS_NAME);
+        return $this->buildResourceDetailsUri(
+            ResourceEntity::TYPE_HOST,
+            $hostId,
+            ['hostId' => $hostId]
+        );
     }
 
     /**
@@ -351,7 +381,15 @@ class MonitoringResourceController extends AbstractController
      */
     public function buildServiceDetailsUri(int $hostId, int $serviceId): string
     {
-        return $this->buildServiceUri($hostId, $serviceId, self::TAB_DETAILS_NAME);
+        return $this->buildResourceDetailsUri(
+            ResourceEntity::TYPE_SERVICE,
+            $serviceId,
+            [
+                'hostId' => $hostId,
+                'serviceId' => $serviceId
+            ],
+            self::TAB_DETAILS_NAME
+        );
     }
 
     /**
@@ -384,25 +422,18 @@ class MonitoringResourceController extends AbstractController
      * Build uri to access meta service panel
      *
      * @param integer $metaId
-     * @param string $tab tab name
      * @return string
      */
-    public function buildMetaServiceDetailsUri(int $metaId, string $tab = self::TAB_DETAILS_NAME): string
+    public function buildMetaServiceDetailsUri(int $metaId): string
     {
-        if (!in_array($tab, self::ALLOWED_TABS)) {
-            throw new ResourceException(sprintf(_('Cannot build uri to unknown tab : %s'), $tab));
-        }
-
-        return $this->buildListingUri([
-            'details' => json_encode([
-                'parentType' => null,
-                'parentId' => null,
-                'type' => ResourceEntity::TYPE_META,
-                'id' => $metaId,
-                'tab' => $tab,
-                'uuid' => 'm' . $metaId
-            ]),
-        ]);
+        return $this->buildResourceDetailsUri(
+            ResourceEntity::TYPE_META,
+            $metaId,
+            [
+                'metaId' => $metaId
+            ],
+            self::TAB_DETAILS_NAME
+        );
     }
 
     /**

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -387,8 +387,7 @@ class MonitoringResourceController extends AbstractController
             [
                 'hostId' => $hostId,
                 'serviceId' => $serviceId
-            ],
-            self::TAB_DETAILS_NAME
+            ]
         );
     }
 
@@ -431,8 +430,7 @@ class MonitoringResourceController extends AbstractController
             $metaId,
             [
                 'metaId' => $metaId
-            ],
-            self::TAB_DETAILS_NAME
+            ]
         );
     }
 

--- a/src/Core/Infrastructure/RealTime/Hypermedia/AbstractHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/AbstractHypermediaProvider.php
@@ -177,7 +177,7 @@ abstract class AbstractHypermediaProvider
     /**
      * @param array<string, int> $parameters
      */
-    protected function generateResourceDetailsUri(array $parameters): string
+    public function generateResourceDetailsUri(array $parameters): string
     {
         return $this->generateEndpoint(static::ENDPOINT_DETAILS, $parameters);
     }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/AbstractHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/AbstractHypermediaProvider.php
@@ -31,6 +31,7 @@ abstract class AbstractHypermediaProvider
 {
     public const URI_EVENT_LOGS = '/main.php?p=20301&svc={hostId}_{serviceId}';
     public const ENDPOINT_SERVICE_DOWNTIME = '';
+    public const ENDPOINT_DETAILS = '';
 
     /**
      * @param ContactInterface $contact
@@ -171,5 +172,13 @@ abstract class AbstractHypermediaProvider
         }
 
         return $this->generateUri(static::URI_EVENT_LOGS, $urlParams);
+    }
+
+    /**
+     * @param array<string, int> $parameters
+     */
+    protected function generateResourceDetailsUri(array $parameters): string
+    {
+        return $this->generateEndpoint(static::ENDPOINT_DETAILS, $parameters);
     }
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/HostHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/HostHypermediaProvider.php
@@ -197,12 +197,4 @@ class HostHypermediaProvider extends AbstractHypermediaProvider implements Hyper
             $categories
         );
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function generateResourceDetailsUri(array $parameters): string
-    {
-        return parent::generateResourceDetailsUri($parameters);
-    }
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/HostHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/HostHypermediaProvider.php
@@ -25,6 +25,7 @@ namespace Core\Infrastructure\RealTime\Hypermedia;
 
 use Centreon\Domain\Contact\Contact;
 use Core\Domain\RealTime\Model\ResourceTypes\HostResourceType;
+use Core\Infrastructure\Common\Api\HttpUrlTrait;
 
 class HostHypermediaProvider extends AbstractHypermediaProvider implements HypermediaProviderInterface
 {
@@ -34,7 +35,7 @@ class HostHypermediaProvider extends AbstractHypermediaProvider implements Hyper
                  URI_HOSTGROUP_CONFIGURATION = '/main.php?p=60102&o=c&hg_id={hostgroupId}',
                  URI_HOST_CATEGORY_CONFIGURATION = '/main.php?p=60104&o=c&hc_id={hostCategoryId}',
                  ENDPOINT_HOST_ACKNOWLEDGEMENT = 'centreon_application_acknowledgement_addhostacknowledgement',
-                 ENDPOINT_HOST_DETAILS = 'centreon_application_monitoring_resource_details_host',
+                 ENDPOINT_DETAILS = 'centreon_application_monitoring_resource_details_host',
                  ENDPOINT_SERVICE_DOWNTIME = 'monitoring.downtime.addHostDowntime',
                  ENDPOINT_HOST_NOTIFICATION_POLICY = 'configuration.host.notification-policy',
                  ENDPOINT_HOST_TIMELINE = 'centreon_application_monitoring_gettimelinebyhost',
@@ -76,7 +77,7 @@ class HostHypermediaProvider extends AbstractHypermediaProvider implements Hyper
                 self::ENDPOINT_HOST_NOTIFICATION_POLICY,
                 $urlParams
             ),
-            'details' => $this->generateEndpoint(self::ENDPOINT_HOST_DETAILS, $urlParams),
+            'details' => $this->generateEndpoint(self::ENDPOINT_DETAILS, $urlParams),
             'downtime' => $this->generateDowntimeEndpoint($urlParams),
             'acknowledgement' => $this->generateAcknowledgementEndpoint($urlParams)
         ];
@@ -195,5 +196,13 @@ class HostHypermediaProvider extends AbstractHypermediaProvider implements Hyper
             ],
             $categories
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateResourceDetailsUri(array $parameters): string
+    {
+        return parent::generateResourceDetailsUri($parameters);
     }
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/HypermediaProviderInterface.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/HypermediaProviderInterface.php
@@ -61,4 +61,10 @@ interface HypermediaProviderInterface
      * @return array<int, array<string, string|int|null>>
      */
     public function convertCategoriesForPresenter(array $categories): array;
+
+    /**
+     * @param array<string, int> $parameters
+     * @return string
+     */
+    public function generateResourceDetailsUri(array $parameters): string;
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/MetaServiceHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/MetaServiceHypermediaProvider.php
@@ -135,12 +135,4 @@ class MetaServiceHypermediaProvider extends AbstractHypermediaProvider implement
     {
         return [];
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function generateResourceDetailsUri(array $parameters): string
-    {
-        return parent::generateResourceDetailsUri($parameters);
-    }
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/MetaServiceHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/MetaServiceHypermediaProvider.php
@@ -29,8 +29,6 @@ use Core\Domain\RealTime\Model\ResourceTypes\MetaServiceResourceType;
 
 class MetaServiceHypermediaProvider extends AbstractHypermediaProvider implements HypermediaProviderInterface
 {
-    use HttpUrlTrait;
-
     public const ENDPOINT_TIMELINE = 'centreon_application_monitoring_gettimelinebymetaservices',
                  ENDPOINT_TIMELINE_DOWNLOAD = 'centreon_application_monitoring_download_timeline_by_metaservice',
                  ENDPOINT_PERFORMANCE_GRAPH = 'monitoring.metric.getMetaServicePerformanceMetrics',
@@ -136,5 +134,13 @@ class MetaServiceHypermediaProvider extends AbstractHypermediaProvider implement
     public function convertCategoriesForPresenter(array $categories): array
     {
         return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateResourceDetailsUri(array $parameters): string
+    {
+        return parent::generateResourceDetailsUri($parameters);
     }
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/ServiceHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/ServiceHypermediaProvider.php
@@ -209,12 +209,4 @@ class ServiceHypermediaProvider extends AbstractHypermediaProvider implements Hy
             $categories
         );
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function generateResourceDetailsUri(array $parameters): string
-    {
-        return parent::generateResourceDetailsUri($parameters);
-    }
 }

--- a/src/Core/Infrastructure/RealTime/Hypermedia/ServiceHypermediaProvider.php
+++ b/src/Core/Infrastructure/RealTime/Hypermedia/ServiceHypermediaProvider.php
@@ -25,11 +25,12 @@ namespace Core\Infrastructure\RealTime\Hypermedia;
 
 use Centreon\Domain\Contact\Contact;
 use Core\Domain\RealTime\Model\ResourceTypes\ServiceResourceType;
+use Core\Infrastructure\Common\Api\HttpUrlTrait;
 
 class ServiceHypermediaProvider extends AbstractHypermediaProvider implements HypermediaProviderInterface
 {
     public const ENDPOINT_SERVICE_ACKNOWLEDGEMENT = 'centreon_application_acknowledgement_addserviceacknowledgement',
-                 ENDPOINT_SERVICE_DETAILS = 'centreon_application_monitoring_resource_details_service',
+                 ENDPOINT_DETAILS = 'centreon_application_monitoring_resource_details_service',
                  ENDPOINT_SERVICE_DOWNTIME = 'monitoring.downtime.addServiceDowntime',
                  ENDPOINT_SERVICE_NOTIFICATION_POLICY = 'configuration.service.notification-policy',
                  ENDPOINT_SERVICE_PERFORMANCE_GRAPH = 'monitoring.metric.getServicePerformanceMetrics',
@@ -117,7 +118,7 @@ class ServiceHypermediaProvider extends AbstractHypermediaProvider implements Hy
         $urlParams = ['serviceId' => $parameters['serviceId'], 'hostId' => $parameters['hostId'],];
 
         return [
-            'details' => $this->generateEndpoint(self::ENDPOINT_SERVICE_DETAILS, $urlParams),
+            'details' => $this->generateEndpoint(self::ENDPOINT_DETAILS, $urlParams),
             'timeline' => $this->generateEndpoint(self::ENDPOINT_SERVICE_TIMELINE, $urlParams),
             'timeline_download' => $this->generateEndpoint(self::TIMELINE_DOWNLOAD, $urlParams),
             'status_graph' => $this->generateEndpoint(self::ENDPOINT_SERVICE_STATUS_GRAPH, $urlParams),
@@ -207,5 +208,13 @@ class ServiceHypermediaProvider extends AbstractHypermediaProvider implements Hy
             ],
             $categories
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateResourceDetailsUri(array $parameters): string
+    {
+        return parent::generateResourceDetailsUri($parameters);
     }
 }


### PR DESCRIPTION
This PR intends to unbrake the redirections to resource details in Resource status when coming from legacy pages.


https://user-images.githubusercontent.com/31647811/193276115-1a2cf7fe-dbd5-43ce-a9aa-18f10badd9d9.mov



**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
