### PR TITLE
fix(oidc) groups mapping is not blocking (MON-14760)

### DIFF
--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1343,14 +1343,14 @@ class OpenIdProvider implements OpenIdProviderInterface
             $this->error(
                 "Configured attribute value not found in groups mapping endpoint",
                 [
-                    "configured_groups_mapping" => $providerGroupsMapping
+                    "provider_groups_mapping" => $providerGroupsMapping,
+                    "configured_groups_mapping" => $claimsFromProvider
                 ]
             );
             $this->logExceptionInLoginLogFile(
                 "Configured attribute value not found in groups mapping endpoint: %s, message: %s",
                 AuthenticationConditionsException::conditionsNotFound()
             );
-            throw AuthenticationConditionsException::conditionsNotFound();
         }
         $this->info("Groups found", ["group" => $groupsMatches]);
         $this->logAuthenticationInfo("Groups found", $groupsMatches);


### PR DESCRIPTION
## Description

If mapping between the provider and Centreon does not match, allow the user to reach the web app

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
