### PR TITLE
fix(upgrade): Remove unused constant

### DIFF
--- a/www/install/php/Update-22.04.1.php
+++ b/www/install/php/Update-22.04.1.php
@@ -83,7 +83,7 @@ function updateOpenIdConfiguration(CentreonDB $pearDB): void
         $openIdCustomConfiguration["email_bind_attribute"] = null;
         $openIdCustomConfiguration["fullname_bind_attribute"] = null;
         $openIdCustomConfiguration["contact_group_id"] = $defaultContactGroupId;
-        $openIdCustomConfiguration["claim_name"] = Configuration::DEFAULT_CLAIM_NAME;
+        $openIdCustomConfiguration["claim_name"] = 'groups';
 
         $statement = $pearDB->prepare(
             "UPDATE provider_configuration SET custom_configuration = :customConfiguration


### PR DESCRIPTION
## Description

This PR intends to remove a constant that will no more exist in 22.10 and occur an error while processing the upgrade from < 22.04.1
**Fixes** # MON-211

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
