### PR TITLE
fix missing alma8 web bundle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -371,7 +371,7 @@ try {
   stage('Docker packaging') {
     def parallelSteps = [:]
     def osBuilds = isStableBuild() ? ['centos7', 'alma8'] : ['centos7']
-    for (x in osBuilds) {
+    for (x in ['centos7', 'alma8']) {
       def osBuild = x
       parallelSteps[osBuild] = {
         node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -370,7 +370,6 @@ try {
 
   stage('Docker packaging') {
     def parallelSteps = [:]
-    def osBuilds = isStableBuild() ? ['centos7', 'alma8'] : ['centos7']
     for (x in ['centos7', 'alma8']) {
       def osBuild = x
       parallelSteps[osBuild] = {


### PR DESCRIPTION
## Description

fix missing alma8 bundle to create alma8 containers, to have it available for other jobs that uses the alma8 container

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
