### PR TITLE
fix text field height in the mui theme 23 04 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@visx/threshold": "^2.12.2",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
-        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -8185,7 +8185,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.10.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#9c83111511f857c2a03fab5650905472640d426f",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#96f901aee141209968805e9caa13160ac9457c95",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.3",
@@ -27079,6 +27079,58 @@
         "reduce-css-calc": "^1.3.0"
       }
     },
+    "@visx/threshold": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@visx/threshold/-/threshold-2.12.2.tgz",
+      "integrity": "sha512-Wg33MK8t8m12SRO4W3U6pKmVK7mnIcA8EshmlS8vL/VvKBcyOyw1/7FHmBAdSvyfh4zXAmj5WtG0G8lp5TwkYw==",
+      "requires": {
+        "@types/react": "*",
+        "@visx/clip-path": "2.10.0",
+        "@visx/shape": "2.12.2",
+        "classnames": "^2.3.1",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@visx/clip-path": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/clip-path/-/clip-path-2.10.0.tgz",
+          "integrity": "sha512-YIUQstsHKGysyDISOV5p+fMymkUdHCs89nSY/w6TG9EIl8x2jRhrQdojwtCYvjLkPZiZiKa8MBT6fFzsSfGImg==",
+          "requires": {
+            "@types/react": "*",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@visx/group": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/group/-/group-2.10.0.tgz",
+          "integrity": "sha512-DNJDX71f65Et1+UgQvYlZbE66owYUAfcxTkC96Db6TnxV221VKI3T5l23UWbnMzwFBP9dR3PWUjjqhhF12N5pA==",
+          "requires": {
+            "@types/react": "*",
+            "classnames": "^2.3.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "@visx/shape": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-2.12.2.tgz",
+          "integrity": "sha512-4gN0fyHWYXiJ+Ck8VAazXX0i8TOnLJvOc5jZBnaJDVxgnSIfCjJn0+Nsy96l9Dy/bCMTh4DBYUBv9k+YICBUOA==",
+          "requires": {
+            "@types/d3-path": "^1.0.8",
+            "@types/d3-shape": "^1.3.1",
+            "@types/lodash": "^4.14.172",
+            "@types/react": "*",
+            "@visx/curve": "2.1.0",
+            "@visx/group": "2.10.0",
+            "@visx/scale": "2.2.2",
+            "classnames": "^2.3.1",
+            "d3-path": "^1.0.5",
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.5.10"
+          }
+        }
+      }
+    },
     "@visx/tooltip": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@visx/tooltip/-/tooltip-2.8.0.tgz",
@@ -28322,8 +28374,8 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#9c83111511f857c2a03fab5650905472640d426f",
-      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#96f901aee141209968805e9caa13160ac9457c95",
+      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
       "requires": {
         "@dnd-kit/core": "^5.0.3",
         "@dnd-kit/modifiers": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8185,7 +8185,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.10.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#96f901aee141209968805e9caa13160ac9457c95",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#9b1a50a92b6bead1d10b4abe624e6f6905c34812",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.3",
@@ -28374,7 +28374,7 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#96f901aee141209968805e9caa13160ac9457c95",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#9b1a50a92b6bead1d10b4abe624e6f6905c34812",
       "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
       "requires": {
         "@dnd-kit/core": "^5.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@visx/threshold": "^2.12.2",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
-        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
+        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -8185,7 +8185,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.10.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#9b1a50a92b6bead1d10b4abe624e6f6905c34812",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#c2fab0ce87578dff54c80a5b32c35e46518eb7ee",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.3",
@@ -28374,8 +28374,8 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#9b1a50a92b6bead1d10b4abe624e6f6905c34812",
-      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#c2fab0ce87578dff54c80a5b32c35e46518eb7ee",
+      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
       "requires": {
         "@dnd-kit/core": "^5.0.3",
         "@dnd-kit/modifiers": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@visx/threshold": "^2.12.2",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
-    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@visx/threshold": "^2.12.2",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
-    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15038-fix-text-field-height-in-the-mui-theme-23-04",
+    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -423,7 +423,7 @@ describe('Password expiration policy', () => {
       ),
     ).toHaveTextContent('1');
 
-    expect(screen.getByText(labelExcludedUsers)).toBeInTheDocument();
+    expect(screen.getByLabelText(labelExcludedUsers)).toBeInTheDocument();
   });
 
   it('does not display any error message when the password expiration time is cleared', async () => {


### PR DESCRIPTION
## Description

Standardization of Buttons and text fields size by adding them to the global theme

https://user-images.githubusercontent.com/109956462/193564559-aab8d1b2-fc1f-45fd-928f-031053decfb3.mp4



## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>


#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
