### PR TITLE
fix(UI): Add missing authentication denied page

### DIFF
--- a/www/front_src/src/FallbackPages/AuthenticationDenied/index.tsx
+++ b/www/front_src/src/FallbackPages/AuthenticationDenied/index.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from 'tss-react/mui';
+
+import { Box } from '@mui/material';
+
+import { FallbackPage } from '@centreon/ui';
+
+import {
+  labelAuthenticationDenied,
+  labelYouAreNotAbleToLogIn,
+} from './translatedLabels';
+
+const useStyles = makeStyles()({
+  pageContainer: {
+    height: '100vh',
+    width: '100vw',
+  },
+});
+
+const AuthenticationDenied: FC = () => {
+  const { classes } = useStyles();
+  const { t } = useTranslation();
+
+  return (
+    <Box className={classes.pageContainer}>
+      <FallbackPage
+        message={t(labelYouAreNotAbleToLogIn)}
+        title={t(labelAuthenticationDenied)}
+      />
+    </Box>
+  );
+};
+
+export default AuthenticationDenied;

--- a/www/front_src/src/FallbackPages/AuthenticationDenied/translatedLabels.ts
+++ b/www/front_src/src/FallbackPages/AuthenticationDenied/translatedLabels.ts
@@ -1,0 +1,2 @@
+export const labelAuthenticationDenied = 'Authentication denied';
+export const labelYouAreNotAbleToLogIn = 'You are not able to log in';

--- a/www/front_src/src/Main/index.test.tsx
+++ b/www/front_src/src/Main/index.test.tsx
@@ -17,6 +17,7 @@ import {
 import { retrievedNavigation } from '../Navigation/mocks';
 import { retrievedFederatedModule } from '../federatedModules/mocks';
 import { navigationEndpoint } from '../Navigation/useNavigation';
+import { labelAuthenticationDenied } from '../FallbackPages/AuthenticationDenied/translatedLabels';
 
 import { labelCentreonIsLoading } from './translatedLabels';
 
@@ -308,6 +309,18 @@ describe('Main', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(labelConnect)).toBeInTheDocument();
+    });
+  });
+
+  it('displays the authentication denied page', async () => {
+    window.history.pushState({}, '', '/authentication-denied');
+
+    mockDefaultGetRequests();
+
+    renderMain();
+
+    await waitFor(() => {
+      expect(screen.getByText(labelAuthenticationDenied)).toBeInTheDocument();
     });
   });
 

--- a/www/front_src/src/Main/index.tsx
+++ b/www/front_src/src/Main/index.tsx
@@ -14,12 +14,13 @@ import weekday from 'dayjs/plugin/weekday';
 import isBetween from 'dayjs/plugin/isBetween';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import duration from 'dayjs/plugin/duration';
-import { and, isNil, not } from 'ramda';
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { and, equals, isNil, not } from 'ramda';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai/utils';
 import { useAtom } from 'jotai';
 
 import reactRoutes from '../reactRoutes/routeMap';
+import AuthenticationDenied from '../FallbackPages/AuthenticationDenied';
 
 import { platformInstallationStatusAtom } from './atoms/platformInstallationStatusAtom';
 import Provider from './Provider';
@@ -44,6 +45,7 @@ const AppPage = lazy(() => import('./InitializationPage'));
 
 const Main = (): JSX.Element => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   useMain();
 
@@ -79,7 +81,10 @@ const Main = (): JSX.Element => {
       return;
     }
 
-    if (not(areUserParametersLoaded)) {
+    if (
+      not(areUserParametersLoaded) &&
+      !equals(pathname, reactRoutes.authenticationDenied)
+    ) {
       navigate(reactRoutes.login);
     }
   }, [platformInstallationStatus, areUserParametersLoaded]);
@@ -91,6 +96,10 @@ const Main = (): JSX.Element => {
   return (
     <Suspense fallback={<MainLoaderWithoutTranslation />}>
       <Routes>
+        <Route
+          element={<AuthenticationDenied />}
+          path={reactRoutes.authenticationDenied}
+        />
         <Route element={<LoginPage />} path={reactRoutes.login} />
         <Route
           element={<ResetPasswordPage />}

--- a/www/front_src/src/reactRoutes/routeMap.ts
+++ b/www/front_src/src/reactRoutes/routeMap.ts
@@ -1,5 +1,6 @@
 const routeMap = {
   authentication: '/administration/authentication',
+  authenticationDenied: '/authentication-denied',
   extensionsManagerPage: '/administration/extensions/manager',
   install: '/install/install.php',
   login: '/login',


### PR DESCRIPTION
## Description

This adds a route for authentication denied.
![Screenshot 2022-10-03 at 15 08 59](https://user-images.githubusercontent.com/12515407/193584546-0754e0e5-fa70-4e10-b502-90730d7d6000.png)

## Type of change

- x ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to `/authentication-denied` in the URL
- -> The Authentication denied is displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
