### PR TITLE
fix (service): Fix warning PHP message on array when key is not present

### DIFF
--- a/www/class/centreonService.class.php
+++ b/www/class/centreonService.class.php
@@ -821,7 +821,7 @@ class CentreonService
             }
         }
 
-        $iIdCommande = $form['command_command_id'];
+        $iIdCommande = $form['command_command_id'] ?? [];
 
         $templateName = "";
         if (empty($iIdCommande)) {


### PR DESCRIPTION
## Description

In case of the key command_command_id is not present in form, a warning PHP message appears.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
