### PR TITLE
FIX: Missing translation(FR, EN, PT, etc.) in OpenId Connect configuration form

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14961,14 +14961,8 @@ msgstr ""
 # msgid "OpenID Connect only"
 # msgstr ""
 
-msgid "Trusted client addresses"
-msgstr "Direcciones de clientes de confianza"
-
 msgid "Login attribute path"
 msgstr "Ruta del atributo de inicio de sesión"
-
-msgid "Blacklist client addresses"
-msgstr "Lista negra de direcciones de clientes"
 
 msgid "Enable conditions on identity provider"
 msgstr "Habilitar las condiciones del proveedor de identidad"
@@ -15032,6 +15026,15 @@ msgstr "Definir la relación entre grupos y grupos de contacto"
 
 msgid "Group value"
 msgstr "Valor del grupo"
+
+msgid "Define your endpoint"
+msgstr "Defina su punto final"
+
+msgid "Roles mapping"
+msgstr "Asociación de roles"
+
+msgid "Groups mapping"
+msgstr "Asociación de grupos"
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14971,10 +14971,10 @@ msgid "Conditions attribute path"
 msgstr "Condiciones ruta de atributos"
 
 msgid "Which endpoint does the conditions attribute path come from?"
-msgstr "De qué punto final proviene la ruta de atributos de las condiciones?"
+msgstr "De qué endpoint proviene la ruta de atributos de las condiciones?"
 
 msgid "Introspection endpoint"
-msgstr "Punto final de introspección"
+msgstr "endpoint de introspección"
 
 msgid "User information"
 msgstr "Información para el usuario"
@@ -15004,7 +15004,7 @@ msgid "Roles attribute path"
 msgstr "Ruta del atributo Roles"
 
 msgid "Which endpoint does the roles attribute path come from?"
-msgstr "De qué punto final proviene la ruta del atributo roles?"
+msgstr "De qué endpoint proviene la ruta del atributo roles?"
 
 msgid "Define the relation between roles and ACL access groups"
 msgstr "Definir la relación entre los roles y los grupos de acceso ACL"
@@ -15019,7 +15019,7 @@ msgid "Groups attribute path"
 msgstr "Ruta de atributos de los grupos"
 
 msgid "Which endpoint does the groups attribute path come from?"
-msgstr "De qué punto final proviene la ruta de atributos de los grupos?"
+msgstr "De qué endpoint proviene la ruta de atributos de los grupos?"
 
 msgid "Define the relation between groups and contact groups"
 msgstr "Definir la relación entre grupos y grupos de contacto"
@@ -15028,13 +15028,7 @@ msgid "Group value"
 msgstr "Valor del grupo"
 
 msgid "Define your endpoint"
-msgstr "Defina su punto final"
-
-msgid "Roles mapping"
-msgstr "Asociación de roles"
-
-msgid "Groups mapping"
-msgstr "Asociación de grupos"
+msgstr "Defina su endpoint"
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14961,6 +14961,77 @@ msgstr ""
 # msgid "OpenID Connect only"
 # msgstr ""
 
+msgid "Trusted client addresses"
+msgstr "Direcciones de clientes de confianza"
+
+msgid "Login attribute path"
+msgstr "Ruta del atributo de inicio de sesión"
+
+msgid "Blacklist client addresses"
+msgstr "Lista negra de direcciones de clientes"
+
+msgid "Enable conditions on identity provider"
+msgstr "Habilitar las condiciones del proveedor de identidad"
+
+msgid "Conditions attribute path"
+msgstr "Condiciones ruta de atributos"
+
+msgid "Which endpoint does the conditions attribute path come from?"
+msgstr "De qué punto final proviene la ruta de atributos de las condiciones?"
+
+msgid "Introspection endpoint"
+msgstr "Punto final de introspección"
+
+msgid "User information"
+msgstr "Información para el usuario"
+
+msgid "Other"
+msgstr "Otros"
+
+msgid "Define authorized conditions values"
+msgstr "Definir los valores de las condiciones autorizadas"
+
+msgid "Condition value"
+msgstr "Condition value"
+
+msgid "Email attribute path"
+msgstr "Ruta de atributos del correo electrónico"
+
+msgid "Fullname attribute path"
+msgstr "Ruta del atributo nombre completo"
+
+msgid "Enable automatic management"
+msgstr "Activar la gestión automática"
+
+msgid "Apply only first role"
+msgstr "Aplicar sólo el primer papel"
+
+msgid "Roles attribute path"
+msgstr "Ruta del atributo Roles"
+
+msgid "Which endpoint does the roles attribute path come from?"
+msgstr "De qué punto final proviene la ruta del atributo roles?"
+
+msgid "Define the relation between roles and ACL access groups"
+msgstr "Definir la relación entre los roles y los grupos de acceso ACL"
+
+msgid "Role value"
+msgstr "Valor de la función"
+
+msgid "ACL access group"
+msgstr "Grupo de acceso ACL"
+
+msgid "Groups attribute path"
+msgstr "Ruta de atributos de los grupos"
+
+msgid "Which endpoint does the groups attribute path come from?"
+msgstr "De qué punto final proviene la ruta de atributos de los grupos?"
+
+msgid "Define the relation between groups and contact groups"
+msgstr "Definir la relación entre grupos y grupos de contacto"
+
+msgid "Group value"
+msgstr "Valor del grupo"
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16555,6 +16555,78 @@ msgstr "Configuration OpenID Connect sauvegardée"
 msgid "Enable OpenID Connect authentication"
 msgstr "Activer l'authentification OpenID Connect"
 
+msgid "Trusted client addresses"
+msgstr "Adresses de clients de confiance"
+
+msgid "Login attribute path"
+msgstr "Chemin de l'attribut de connexion"
+
+msgid "Blacklist client addresses"
+msgstr "Liste noire d'adresses de clients"
+
+msgid "Enable conditions on identity provider"
+msgstr "Activer les conditions sur le fournisseur d'identité"
+
+msgid "Conditions attribute path"
+msgstr "Conditions chemin des attributs"
+
+msgid "Which endpoint does the conditions attribute path come from?"
+msgstr "De quel point de terminaison provient le chemin de l'attribut des conditions ?"
+
+msgid "Introspection endpoint"
+msgstr "Point final d'introspection"
+
+msgid "User information"
+msgstr "Information de l'utilisateur"
+
+msgid "Other"
+msgstr "Autre"
+
+msgid "Define authorized conditions values"
+msgstr "Définir les valeurs des conditions autorisées"
+
+msgid "Condition value"
+msgstr "Valeur de la condition"
+
+msgid "Email attribute path"
+msgstr "Chemin de l'attribut de l'email"
+
+msgid "Fullname attribute path"
+msgstr "Chemin de l'attribut du nom complet"
+
+msgid "Enable automatic management"
+msgstr "Activer la gestion automatique"
+
+msgid "Apply only first role"
+msgstr "Ne postulez qu'au premier rôle"
+
+msgid "Roles attribute path"
+msgstr "Chemin d'accès aux attributs de rôles"
+
+msgid "Which endpoint does the roles attribute path come from?"
+msgstr "De quel point de terminaison provient le chemin d'accès de l'attribut rôles ?"
+
+msgid "Define the relation between roles and ACL access groups"
+msgstr "Définir la relation entre les rôles et les groupes d'accès ACL"
+
+msgid "Role value"
+msgstr "Valeur du rôle"
+
+msgid "ACL access group"
+msgstr "Groupe d'accès ACL"
+
+msgid "Groups attribute path"
+msgstr "Chemin des attributs de groupes"
+
+msgid "Which endpoint does the groups attribute path come from?"
+msgstr "De quel point de terminaison provient le chemin de l'attribut des groupes ?"
+
+msgid "Define the relation between groups and contact groups"
+msgstr "Définir la relation entre les groupes et les groupes de contact"
+
+msgid "Group value"
+msgstr "Valeur du groupe"
+
 msgid "Authentication mode"
 msgstr "Mode d'authentification"
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16556,25 +16556,25 @@ msgid "Enable OpenID Connect authentication"
 msgstr "Activer l'authentification OpenID Connect"
 
 msgid "Trusted client addresses"
-msgstr "Adresses de clients de confiance"
+msgstr "Adresses des clients de confiance"
 
 msgid "Login attribute path"
-msgstr "Chemin de l'attribut de connexion"
+msgstr "Chemin de l'attribut de d'identifiant"
 
 msgid "Blacklist client addresses"
-msgstr "Blacklist d'adresses de clients"
+msgstr "Liste noire d'adresses de clients"
 
 msgid "Enable conditions on identity provider"
-msgstr "Activer les conditions sur l'identity provider"
+msgstr "Activer les conditions sur le fournisseur d'identité"
 
 msgid "Conditions attribute path"
-msgstr "Conditions chemin des attributs"
+msgstr "Chemin de l'attribut des conditions"
 
 msgid "Which endpoint does the conditions attribute path come from?"
-msgstr "De quel endpoint provient le chemin de l'attribut des conditions ?"
+msgstr "De quel point d'entrée provient le chemin de l'attribut des conditions ?"
 
 msgid "Introspection endpoint"
-msgstr "endpoint d'introspection"
+msgstr "Point d'entrée d'introspection"
 
 msgid "User information"
 msgstr "Information de l'utilisateur"
@@ -16604,7 +16604,7 @@ msgid "Roles attribute path"
 msgstr "Chemin d'accès aux attributs de rôles"
 
 msgid "Which endpoint does the roles attribute path come from?"
-msgstr "De quel endpoint provient le chemin d'accès de l'attribut rôles ?"
+msgstr "De quel point d'entrée provient le chemin d'accès de l'attribut rôles ?"
 
 msgid "Define the relation between roles and ACL access groups"
 msgstr "Définir la relation entre les rôles et les groupes d'accès ACL"
@@ -16616,10 +16616,10 @@ msgid "ACL access group"
 msgstr "Groupe d'accès ACL"
 
 msgid "Groups attribute path"
-msgstr "Chemin des attributs de groupes"
+msgstr "Chemin de l'attribut de groupes"
 
 msgid "Which endpoint does the groups attribute path come from?"
-msgstr "De quel endpoint provient le chemin de l'attribut des groupes ?"
+msgstr "De quel point d'entrée provient le chemin de l'attribut des groupes ?"
 
 msgid "Define the relation between groups and contact groups"
 msgstr "Définir la relation entre les groupes et les groupes de contact"
@@ -16628,7 +16628,7 @@ msgid "Group value"
 msgstr "Valeur du groupe"
 
 msgid "Define your endpoint"
-msgstr "Définissez votre endpoint"
+msgstr "Définissez votre point d'entrée"
 
 msgid "Authentication mode"
 msgstr "Mode d'authentification"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16627,6 +16627,15 @@ msgstr "Définir la relation entre les groupes et les groupes de contact"
 msgid "Group value"
 msgstr "Valeur du groupe"
 
+msgid "Define your endpoint"
+msgstr "Définissez votre point d'accès"
+
+msgid "Roles mapping"
+msgstr "Association de rôles"
+
+msgid "Groups mapping"
+msgstr "Association de groupes"
+
 msgid "Authentication mode"
 msgstr "Mode d'authentification"
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16562,19 +16562,19 @@ msgid "Login attribute path"
 msgstr "Chemin de l'attribut de connexion"
 
 msgid "Blacklist client addresses"
-msgstr "Liste noire d'adresses de clients"
+msgstr "Blacklist d'adresses de clients"
 
 msgid "Enable conditions on identity provider"
-msgstr "Activer les conditions sur le fournisseur d'identité"
+msgstr "Activer les conditions sur l'identity provider"
 
 msgid "Conditions attribute path"
 msgstr "Conditions chemin des attributs"
 
 msgid "Which endpoint does the conditions attribute path come from?"
-msgstr "De quel point de terminaison provient le chemin de l'attribut des conditions ?"
+msgstr "De quel endpoint provient le chemin de l'attribut des conditions ?"
 
 msgid "Introspection endpoint"
-msgstr "Point final d'introspection"
+msgstr "endpoint d'introspection"
 
 msgid "User information"
 msgstr "Information de l'utilisateur"
@@ -16604,7 +16604,7 @@ msgid "Roles attribute path"
 msgstr "Chemin d'accès aux attributs de rôles"
 
 msgid "Which endpoint does the roles attribute path come from?"
-msgstr "De quel point de terminaison provient le chemin d'accès de l'attribut rôles ?"
+msgstr "De quel endpoint provient le chemin d'accès de l'attribut rôles ?"
 
 msgid "Define the relation between roles and ACL access groups"
 msgstr "Définir la relation entre les rôles et les groupes d'accès ACL"
@@ -16619,7 +16619,7 @@ msgid "Groups attribute path"
 msgstr "Chemin des attributs de groupes"
 
 msgid "Which endpoint does the groups attribute path come from?"
-msgstr "De quel point de terminaison provient le chemin de l'attribut des groupes ?"
+msgstr "De quel endpoint provient le chemin de l'attribut des groupes ?"
 
 msgid "Define the relation between groups and contact groups"
 msgstr "Définir la relation entre les groupes et les groupes de contact"
@@ -16628,13 +16628,7 @@ msgid "Group value"
 msgstr "Valeur du groupe"
 
 msgid "Define your endpoint"
-msgstr "Définissez votre point d'accès"
-
-msgid "Roles mapping"
-msgstr "Association de rôles"
-
-msgid "Groups mapping"
-msgstr "Association de groupes"
+msgstr "Définissez votre endpoint"
 
 msgid "Authentication mode"
 msgstr "Mode d'authentification"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16559,7 +16559,7 @@ msgid "Trusted client addresses"
 msgstr "Adresses des clients de confiance"
 
 msgid "Login attribute path"
-msgstr "Chemin de l'attribut de d'identifiant"
+msgstr "Chemin de l'attribut d'identifiant"
 
 msgid "Blacklist client addresses"
 msgstr "Liste noire d'adresses de clients"
@@ -16577,7 +16577,7 @@ msgid "Introspection endpoint"
 msgstr "Point d'entrée d'introspection"
 
 msgid "User information"
-msgstr "Information de l'utilisateur"
+msgstr "Informations utilisateur"
 
 msgid "Other"
 msgstr "Autre"
@@ -16598,13 +16598,13 @@ msgid "Enable automatic management"
 msgstr "Activer la gestion automatique"
 
 msgid "Apply only first role"
-msgstr "Ne postulez qu'au premier rôle"
+msgstr "Appliquer uniquement le premier rôle"
 
 msgid "Roles attribute path"
-msgstr "Chemin d'accès aux attributs de rôles"
+msgstr "Chemin d'accès à l'attribut de rôles"
 
 msgid "Which endpoint does the roles attribute path come from?"
-msgstr "De quel point d'entrée provient le chemin d'accès de l'attribut rôles ?"
+msgstr "De quel point d'entrée provient le chemin d'accès de l'attribut de rôles ?"
 
 msgid "Define the relation between roles and ACL access groups"
 msgstr "Définir la relation entre les rôles et les groupes d'accès ACL"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15422,10 +15422,10 @@ msgid "Conditions attribute path"
 msgstr "Caminho de atributos de condições"
 
 msgid "Which endpoint does the conditions attribute path come from?"
-msgstr "De que ponto final as condições atribuem o caminho?"
+msgstr "De que endpoint as condições atribuem o caminho?"
 
 msgid "Introspection endpoint"
-msgstr "Ponto final da introspecção"
+msgstr "endpoint da introspecção"
 
 msgid "User information"
 msgstr "Informações ao usuário"
@@ -15455,7 +15455,7 @@ msgid "Roles attribute path"
 msgstr "Atributos dos papéis"
 
 msgid "Which endpoint does the roles attribute path come from?"
-msgstr "De qual ponto final os papéis atribuem o caminho?"
+msgstr "De qual endpoint os papéis atribuem o caminho?"
 
 msgid "Define the relation between roles and ACL access groups"
 msgstr "Definir a relação entre as funções e os grupos de acesso ACL"
@@ -15470,7 +15470,7 @@ msgid "Groups attribute path"
 msgstr "Caminho de atributos de grupos"
 
 msgid "Which endpoint does the groups attribute path come from?"
-msgstr "De que ponto final os grupos atribuem o caminho?"
+msgstr "De que endpoint os grupos atribuem o caminho?"
 
 msgid "Define the relation between groups and contact groups"
 msgstr "Definir a relação entre grupos e grupos de contato"
@@ -15479,13 +15479,8 @@ msgid "Group value"
 msgstr "Valor do grupo"
 
 msgid "Define your endpoint"
-msgstr "Defina seu ponto final"
+msgstr "Defina seu endpoint"
 
-msgid "Roles mapping"
-msgstr "Associação de papéis"
-
-msgid "Groups mapping"
-msgstr "Associação de grupos"
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15412,6 +15412,77 @@ msgstr ""
 # msgid "OpenID Connect only"
 # msgstr ""
 
+msgid "Trusted client addresses"
+msgstr "Endereços de clientes de confiança"
+
+msgid "Login attribute path"
+msgstr "Caminho de atributo de login"
+
+msgid "Blacklist client addresses"
+msgstr "Endereços de clientes da lista negra"
+
+msgid "Enable conditions on identity provider"
+msgstr "Habilitar condições sobre o fornecedor de identidade"
+
+msgid "Conditions attribute path"
+msgstr "Caminho de atributos de condições"
+
+msgid "Which endpoint does the conditions attribute path come from?"
+msgstr "De que ponto final as condições atribuem o caminho?"
+
+msgid "Introspection endpoint"
+msgstr "Ponto final da introspecção"
+
+msgid "User information"
+msgstr "Informações ao usuário"
+
+msgid "Other"
+msgstr "Outros"
+
+msgid "Define authorized conditions values"
+msgstr "Definir valores de condições autorizadas"
+
+msgid "Condition value"
+msgstr "Valor da condição"
+
+msgid "Email attribute path"
+msgstr "Caminho de atributos de e-mail"
+
+msgid "Fullname attribute path"
+msgstr "Caminho de atributos de nome completo"
+
+msgid "Enable automatic management"
+msgstr "Habilitar o gerenciamento automático"
+
+msgid "Apply only first role"
+msgstr "Aplicar apenas o primeiro papel"
+
+msgid "Roles attribute path"
+msgstr "Atributos dos papéis"
+
+msgid "Which endpoint does the roles attribute path come from?"
+msgstr "De qual ponto final os papéis atribuem o caminho?"
+
+msgid "Define the relation between roles and ACL access groups"
+msgstr "Definir a relação entre as funções e os grupos de acesso ACL"
+
+msgid "Role value"
+msgstr "Valor do papel"
+
+msgid "ACL access group"
+msgstr "Grupo de acesso ACL"
+
+msgid "Groups attribute path"
+msgstr "Caminho de atributos de grupos"
+
+msgid "Which endpoint does the groups attribute path come from?"
+msgstr "De que ponto final os grupos atribuem o caminho?"
+
+msgid "Define the relation between groups and contact groups"
+msgstr "Definir a relação entre grupos e grupos de contato"
+
+msgid "Group value"
+msgstr "Valor do grupo"
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15412,14 +15412,8 @@ msgstr ""
 # msgid "OpenID Connect only"
 # msgstr ""
 
-msgid "Trusted client addresses"
-msgstr "Endereços de clientes de confiança"
-
 msgid "Login attribute path"
 msgstr "Caminho de atributo de login"
-
-msgid "Blacklist client addresses"
-msgstr "Endereços de clientes da lista negra"
 
 msgid "Enable conditions on identity provider"
 msgstr "Habilitar condições sobre o fornecedor de identidade"
@@ -15483,6 +15477,15 @@ msgstr "Definir a relação entre grupos e grupos de contato"
 
 msgid "Group value"
 msgstr "Valor do grupo"
+
+msgid "Define your endpoint"
+msgstr "Defina seu ponto final"
+
+msgid "Roles mapping"
+msgstr "Associação de papéis"
+
+msgid "Groups mapping"
+msgstr "Associação de grupos"
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15400,6 +15400,78 @@ msgstr ""
 # msgid "OpenID Connect only"
 # msgstr ""
 
+msgid "Trusted client addresses"
+msgstr "Endereços de clientes de confiança"
+
+msgid "Login attribute path"
+msgstr "Caminho de atributo de acesso"
+
+msgid "Blacklist client addresses"
+msgstr "Lista negra de endereços de clientes"
+
+msgid "Enable conditions on identity provider"
+msgstr "Habilitar condições sobre o fornecedor de identidade"
+
+msgid "Conditions attribute path"
+msgstr "Caminho de atributos de condições"
+
+msgid "Which endpoint does the conditions attribute path come from?"
+msgstr "De que ponto final é que as condições atribuem o caminho?"
+
+msgid "Introspection endpoint"
+msgstr "Ponto final da introspecção"
+
+msgid "User information"
+msgstr "Informação ao utilizador"
+
+msgid "Other"
+msgstr "Outros"
+
+msgid "Define authorized conditions values"
+msgstr "Definir valores de condições autorizadas"
+
+msgid "Condition value"
+msgstr "Valor da condição"
+
+msgid "Email attribute path"
+msgstr "Caminho de atributo de e-mail"
+
+msgid "Fullname attribute path"
+msgstr "Caminho do atributo do nome completo"
+
+msgid "Enable automatic management"
+msgstr "Activar a gestão automática"
+
+msgid "Apply only first role"
+msgstr "Aplicar apenas o primeiro papel"
+
+msgid "Roles attribute path"
+msgstr "Atributo de funções caminho"
+
+msgid "Which endpoint does the roles attribute path come from?"
+msgstr "De que ponto final é que os papéis atribuem o caminho?"
+
+msgid "Define the relation between roles and ACL access groups"
+msgstr "Definir a relação entre os papéis e os grupos de acesso ACL"
+
+msgid "Role value"
+msgstr "Valor do papel"
+
+msgid "ACL access group"
+msgstr "Grupo de acesso ACL"
+
+msgid "Groups attribute path"
+msgstr "Caminho de atributo de grupos"
+
+msgid "Which endpoint does the groups attribute path come from?"
+msgstr "De que ponto final é que os grupos atribuem o caminho?"
+
+msgid "Define the relation between groups and contact groups"
+msgstr "Definir a relação entre grupos e grupos de contacto"
+
+msgid "Group value"
+msgstr "Valor do grupo"
+
 # msgid "Mixed"
 # msgstr ""
 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15410,10 +15410,10 @@ msgid "Conditions attribute path"
 msgstr "Caminho de atributos de condições"
 
 msgid "Which endpoint does the conditions attribute path come from?"
-msgstr "De que ponto final é que as condições atribuem o caminho?"
+msgstr "De que endpoint é que as condições atribuem o caminho?"
 
 msgid "Introspection endpoint"
-msgstr "Ponto final da introspecção"
+msgstr "endpoint da introspecção"
 
 msgid "User information"
 msgstr "Informação ao utilizador"
@@ -15443,7 +15443,7 @@ msgid "Roles attribute path"
 msgstr "Atributo de funções caminho"
 
 msgid "Which endpoint does the roles attribute path come from?"
-msgstr "De que ponto final é que os papéis atribuem o caminho?"
+msgstr "De que endpoint é que os papéis atribuem o caminho?"
 
 msgid "Define the relation between roles and ACL access groups"
 msgstr "Definir a relação entre os papéis e os grupos de acesso ACL"
@@ -15458,7 +15458,7 @@ msgid "Groups attribute path"
 msgstr "Caminho de atributo de grupos"
 
 msgid "Which endpoint does the groups attribute path come from?"
-msgstr "De que ponto final é que os grupos atribuem o caminho?"
+msgstr "De que endpoint é que os grupos atribuem o caminho?"
 
 msgid "Define the relation between groups and contact groups"
 msgstr "Definir a relação entre grupos e grupos de contacto"
@@ -15467,13 +15467,7 @@ msgid "Group value"
 msgstr "Valor do grupo"
 
 msgid "Define your endpoint"
-msgstr "Defina o seu ponto final"
-
-msgid "Roles mapping"
-msgstr "Associação de papéis"
-
-msgid "Groups mapping"
-msgstr "Associação de grupos"
+msgstr "Defina o seu endpoint"
 
 # msgid "Mixed"
 # msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15400,14 +15400,8 @@ msgstr ""
 # msgid "OpenID Connect only"
 # msgstr ""
 
-msgid "Trusted client addresses"
-msgstr "Endereços de clientes de confiança"
-
 msgid "Login attribute path"
 msgstr "Caminho de atributo de acesso"
-
-msgid "Blacklist client addresses"
-msgstr "Lista negra de endereços de clientes"
 
 msgid "Enable conditions on identity provider"
 msgstr "Habilitar condições sobre o fornecedor de identidade"
@@ -15471,6 +15465,15 @@ msgstr "Definir a relação entre grupos e grupos de contacto"
 
 msgid "Group value"
 msgstr "Valor do grupo"
+
+msgid "Define your endpoint"
+msgstr "Defina o seu ponto final"
+
+msgid "Roles mapping"
+msgstr "Associação de papéis"
+
+msgid "Groups mapping"
+msgstr "Associação de grupos"
 
 # msgid "Mixed"
 # msgstr ""


### PR DESCRIPTION
## Description

Missing translation for new blocs:

- authentication condition

- roles mapping

- groups mapping

- “login attribute path”

![image](https://user-images.githubusercontent.com/108519266/193826481-d6620efc-1168-4225-9023-d3afeffbe96c.png)


**Fixes** # MON-15265

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
switch language from english to french and look if translation apears in  _Administration  > authentication > configuration openid connect_


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
