### PR TITLE
fix(oidc) add log when roles mapping is disabled (MON-14871)

### DIFF
--- a/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1146,6 +1146,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         $aclConditions = $customConfiguration->getACLConditions();
         if (!$aclConditions->isEnabled()) {
+            $this->logAuthenticationInfo("Roles mapping is disabled");
             return;
         }
 


### PR DESCRIPTION
## Description

Add log when roles mapping is disabled

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Try an OIDC authentication with roles mapping disabled 

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
