### PR TITLE
fix table font-size for the too big content

### DIFF
--- a/www/Themes/Generic-theme/style.css
+++ b/www/Themes/Generic-theme/style.css
@@ -1847,7 +1847,7 @@ td, a.infobulle:hover td {
 #Tcontener,#Tmainpage,#tabLegend,div.tab,.Tmenu3 .center,.ListTable {width:100%;}
 
 .ListTable {
-
+font-size: 12px;
 }
 
 #Tmainpage {


### PR DESCRIPTION
## Description
Content of some widgets looks too big 
![widgeet before](https://user-images.githubusercontent.com/108519266/194044608-9000c279-0eab-4484-a21e-e4068d770f1b.PNG)


**after the fix:**
![widget after](https://user-images.githubusercontent.com/108519266/194044720-a3d2ed15-5051-4fd6-9b4b-bb55485df210.PNG)

**Fixes** # MON-15288

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x  (release-22.10.0-next)

<h2> How this pull request can be tested ? </h2>

Install widget and check if the font still looks too big 

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
