### PR TITLE
fix(UI): Get Platform versions synchronously with installation status

### DIFF
--- a/www/front_src/src/Main/index.test.tsx
+++ b/www/front_src/src/Main/index.test.tsx
@@ -117,9 +117,6 @@ const renderMain = (): RenderResult =>
 const mockDefaultGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedWeb,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: true,
@@ -127,6 +124,9 @@ const mockDefaultGetRequests = (): void => {
     })
     .mockResolvedValueOnce({
       data: retrievedUser,
+    })
+    .mockResolvedValueOnce({
+      data: retrievedWeb,
     })
     .mockResolvedValueOnce({
       data: retrievedTranslations,
@@ -151,9 +151,6 @@ const mockDefaultGetRequests = (): void => {
 const mockRedirectFromLoginPageGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedWeb,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: true,
@@ -161,6 +158,9 @@ const mockRedirectFromLoginPageGetRequests = (): void => {
     })
     .mockResolvedValueOnce({
       data: retrievedUser,
+    })
+    .mockResolvedValueOnce({
+      data: retrievedWeb,
     })
     .mockResolvedValueOnce({
       data: retrievedTranslations,
@@ -188,9 +188,6 @@ const mockRedirectFromLoginPageGetRequests = (): void => {
 const mockNotConnectedGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedWeb,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: true,
@@ -198,6 +195,9 @@ const mockNotConnectedGetRequests = (): void => {
     })
     .mockRejectedValueOnce({
       response: { status: 403 },
+    })
+    .mockResolvedValueOnce({
+      data: retrievedWeb,
     })
     .mockResolvedValueOnce({
       data: retrievedTranslations,
@@ -210,9 +210,6 @@ const mockNotConnectedGetRequests = (): void => {
 const mockInstallGetRequests = (): void => {
   mockedAxios.get
     .mockResolvedValueOnce({
-      data: retrievedWeb,
-    })
-    .mockResolvedValueOnce({
       data: {
         has_upgrade_available: false,
         is_installed: false,
@@ -220,14 +217,14 @@ const mockInstallGetRequests = (): void => {
     })
     .mockRejectedValueOnce({
       response: { status: 403 },
+    })
+    .mockResolvedValueOnce({
+      data: retrievedWeb,
     });
 };
 
 const mockUpgradeAndUserDisconnectedGetRequests = (): void => {
   mockedAxios.get
-    .mockResolvedValueOnce({
-      data: retrievedWeb,
-    })
     .mockResolvedValueOnce({
       data: {
         has_upgrade_available: true,
@@ -236,14 +233,14 @@ const mockUpgradeAndUserDisconnectedGetRequests = (): void => {
     })
     .mockRejectedValueOnce({
       response: { status: 403 },
+    })
+    .mockResolvedValueOnce({
+      data: retrievedWeb,
     });
 };
 
 const mockUpgradeAndUserConnectedGetRequests = (): void => {
   mockedAxios.get
-    .mockResolvedValueOnce({
-      data: retrievedWeb,
-    })
     .mockResolvedValueOnce({
       data: {
         has_upgrade_available: true,
@@ -252,6 +249,9 @@ const mockUpgradeAndUserConnectedGetRequests = (): void => {
     })
     .mockResolvedValueOnce({
       data: retrievedUser,
+    })
+    .mockResolvedValueOnce({
+      data: retrievedWeb,
     })
     .mockResolvedValueOnce({
       data: retrievedTranslations,

--- a/www/front_src/src/Main/useMain.ts
+++ b/www/front_src/src/Main/useMain.ts
@@ -56,12 +56,11 @@ const useMain = (): void => {
   useEffect(() => {
     displayAuthenticationError();
 
-    getPlatformVersions();
-
     getPlatformInstallationStatus({
       endpoint: platformInstallationStatusEndpoint,
     }).then((retrievedPlatformInstallationStatus) => {
       setPlatformInstallationStatus(retrievedPlatformInstallationStatus);
+      getPlatformVersions();
     });
   }, []);
 


### PR DESCRIPTION
## Description

This gets Platform versions synchronously with installation status.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- -> The Platform versions APi request is called once the platform installation status is done

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
