### PR TITLE
add missing centreon-poller package

### DIFF
--- a/ci/debian/centreon-poller.postinst
+++ b/ci/debian/centreon-poller.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ "$1" = "configure" ]; then
+
+    if [ "$(getent passwd centreon-engine)" ]; then
+        chmod -v -R 0775 \
+            /var/lib/centreon/centplugins
+        chown -v -R centreon-engine:centreon-engine \
+            /var/lib/centreon/centplugins
+    fi
+
+fi
+exit 0

--- a/ci/debian/control
+++ b/ci/debian/control
@@ -60,6 +60,39 @@ Description: The package contains base configuration for Centreon Engine and Cen
  two Centreon Broker instances to store real-time information in database and
  performance data in RRD files.
 
+Package: centreon-poller
+Architecture: all
+Depends: 
+    centreon-common (>= ${centreon:version}~),
+    centreon-poller-centreon-engine (>= ${centreon:version}~),
+    centreon-trap (>= ${centreon:version}~),
+    centreon-engine (>= ${centreon:version}~),
+    centreon-broker (>= ${centreon:version}~),
+    centreon-broker-cbmod (>= ${centreon:version}~),
+    centreon-broker-storage (>= ${centreon:version}~),
+    centreon-connector (>= ${centreon:version}~),
+    centreon-gorgone (>= ${centreon:version}~),
+    libdbd-mysql-perl,
+    libdbd-sqlite3-perl,
+    centreon-plugin-applications-databases-mysql,
+    centreon-plugin-applications-monitoring-centreon-central,
+    centreon-plugin-applications-monitoring-centreon-database,
+    centreon-plugin-applications-monitoring-centreon-map4-jmx,
+    centreon-plugin-applications-monitoring-centreon-poller,
+    centreon-plugin-applications-protocol-dns,
+    centreon-plugin-applications-protocol-ftp,
+    centreon-plugin-applications-protocol-http,
+    centreon-plugin-applications-protocol-ldap,
+    centreon-plugin-applications-databases-mysql,
+    centreon-plugin-hardware-printers-generic-snmp,
+    centreon-plugin-hardware-ups-standard-rfc1628-snmp,
+    centreon-plugin-network-cisco-standard-snmp,
+    centreon-plugin-operatingsystems-linux-snmp,
+    centreon-plugin-operatingsystems-windows-snmp,
+    monitoring-plugins-basic
+Description: This package add rights and default directories for a poller
+ managed by Centreon. This includes the default central poller.
+ 
 Package: centreon-web-common
 Architecture: all
 Depends:


### PR DESCRIPTION
## Description

Add missing centreon-poller package so that it can be built and delivered to 22.10 apt repo.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
