### PR TITLE
fix(web): display the contact notifications 22.04.x

### DIFF
--- a/www/include/configuration/configObject/contact/displayNotification.ihtml
+++ b/www/include/configuration/configObject/contact/displayNotification.ihtml
@@ -14,13 +14,9 @@
 	<a href='#simple_host'>[{$labels.host_notifications}]</a>&nbsp;
 	<a href='#simple_service'>[{$labels.service_notifications}]</a>
 	<br/><br/>
-	{if $i == 0}
-		{if $contact != 0}
-			<div class="updateSecu" style='text-align:center;'>{$msg}</div>
-		{else}
-			<div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
-		{/if}
-	{else}
+    {if $contact == 0}
+        <div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
+    {else}
 	<a name='host_escalation'>
 	<table class="ListTable">
 		<tr class="ListHeader">
@@ -95,6 +91,5 @@
 		{/section}
 	</table>	
 	<br/>
-	{/if}
 {$form.hidden}
 </form>

--- a/www/include/configuration/configObject/contact/displayNotification.ihtml
+++ b/www/include/configuration/configObject/contact/displayNotification.ihtml
@@ -14,9 +14,9 @@
 	<a href='#simple_host'>[{$labels.host_notifications}]</a>&nbsp;
 	<a href='#simple_service'>[{$labels.service_notifications}]</a>
 	<br/><br/>
-    {if $contact == 0}
-        <div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
-    {else}
+	{if $contact == 0}
+		<div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
+	{else}
 	<a name='host_escalation'>
 	<table class="ListTable">
 		<tr class="ListHeader">
@@ -91,5 +91,6 @@
 		{/section}
 	</table>	
 	<br/>
+	{/if}
 {$form.hidden}
 </form>

--- a/www/include/configuration/configObject/contact/displayNotification.php
+++ b/www/include/configuration/configObject/contact/displayNotification.php
@@ -193,11 +193,8 @@ $labels = array(
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-$tpl->assign('msg', _("The selected user didn't see any resources"));
 $tpl->assign('msgSelect', _("Please select a user in order to view his notifications"));
-$tpl->assign('msgdisable', _("The selected user is not enable."));
 $tpl->assign('p', $p);
-$tpl->assign('i', $i);
 $tpl->assign('contact', $contactId);
 $tpl->assign('labels', $labels);
 $tpl->display("displayNotification.ihtml");

--- a/www/include/configuration/configObject/contactgroup/displayNotification.ihtml
+++ b/www/include/configuration/configObject/contactgroup/displayNotification.ihtml
@@ -14,13 +14,9 @@
 	<a href='#simple_host'>[{$labels.host_notifications}]</a>&nbsp;
 	<a href='#simple_service'>[{$labels.service_notifications}]</a>
 	<br/><br/>
-	{if $i == 0}
-		{if $contact != 0}
-			<div class="updateSecu" style='text-align:center;'>{$msg}</div>
-		{else}
-			<div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
-		{/if}
-	{else}
+    {if $contact == 0}
+        <div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
+    {else}
 	<a name='host_escalation'>
 	<table class="ListTable">
 		<tr class="ListHeader">

--- a/www/include/configuration/configObject/contactgroup/displayNotification.ihtml
+++ b/www/include/configuration/configObject/contactgroup/displayNotification.ihtml
@@ -14,9 +14,9 @@
 	<a href='#simple_host'>[{$labels.host_notifications}]</a>&nbsp;
 	<a href='#simple_service'>[{$labels.service_notifications}]</a>
 	<br/><br/>
-    {if $contact == 0}
-        <div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
-    {else}
+	{if $contact == 0}
+		<div class="uptodate" style='text-align:center;'>{$msgSelect}</div>
+	{else}
 	<a name='host_escalation'>
 	<table class="ListTable">
 		<tr class="ListHeader">

--- a/www/include/configuration/configObject/contactgroup/displayNotification.php
+++ b/www/include/configuration/configObject/contactgroup/displayNotification.php
@@ -189,11 +189,8 @@ $labels = array(
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-$tpl->assign('msg', _("The selected user didn't see any resources"));
 $tpl->assign('msgSelect', _("Please select a user in order to view his notifications"));
-$tpl->assign('msgdisable', _("The selected user is not enable."));
 $tpl->assign('p', $p);
-$tpl->assign('i', $i);
 $tpl->assign('contact', $contactgroup_id);
 $tpl->assign('labels', $labels);
 $tpl->display("displayNotification.ihtml");


### PR DESCRIPTION
## Description

Fix an issue related to the button **View contact notifications** into the page _Configuration  >  Users  >  Contacts / Users_.
With the 22.04 we deleted a code block that defined the variable $i into the file **www/include/core/header/header.php** .
It was an issue to define it here.

**Fixes** MON-15250

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)