### PR TITLE
fix(upgrade) migration to unifiedsql ouput in broker conf

### DIFF
--- a/www/install/php/Update-22.04.0-beta.1.php
+++ b/www/install/php/Update-22.04.0-beta.1.php
@@ -539,7 +539,7 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
             AND config_value IN ($blockIdBinds)");
         $grpIdStatement->bindValue(':configId', (int) $configId, PDO::PARAM_INT);
         foreach ($blockIdsQueryBinds as $key => $value) {
-            $grpIdStatement->bindValue($key, (int) $value, PDO::PARAM_INT);
+            $grpIdStatement->bindValue($key, $value, PDO::PARAM_STR);
         }
         $grpIdStatement->execute();
         $configGroupIds = $grpIdStatement->fetchAll(\PDO::FETCH_COLUMN, 0);


### PR DESCRIPTION
## Description

During Centreon update to version >= 22.04.0, all broker config outputs where deleted

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
