### PR TITLE
fix(Resources/AnomalyDetection/): fixes

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15356,7 +15356,7 @@ msgstr "Editar datos de detección de anomalías"
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
 
-msgid "you have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changed, do you want to proceed?"
 msgstr "no ha guardado los cambios, ¿quiere continuar?"
 
 #  msgid "Confirm"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15287,3 +15287,9 @@ msgstr "Editar datos de detección de anomalías"
 
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
+
+msgid "you have unsaved changed, do you want to proceed?"
+msgstr "no ha guardado los cambios, ¿quiere continuar?"
+
+#  msgid "Confirm"
+#  msgstr "Confirmar"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15249,8 +15249,8 @@ msgstr "Los cambios en el tamaño del sobre se aplicarán inmediatamente."
 msgid "Manage envelope size"
 msgstr "Administrar el tamaño del sobre"
 
-msgid "use default value"
-msgstr "usar el valor predeterminado"
+msgid "Set to default value"
+msgstr "Establecer en el valor predeterminado"
 
 msgid "points out of envelope"
 msgstr "puntos fuera del sobre"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15308,10 +15308,10 @@ msgstr "Nivel de criticidad del host"
 #  msgid "Deploy configuration"
 #  msgstr ""
 
-msgid "Are you sure you want to change the size of the envelope? The new envelope size will be applied immediately."
+msgid "Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same."
 msgstr "¿Está seguro de que desea cambiar el tamaño del sobre? El nuevo tamaño de sobre se aplicará inmediatamente."
 
-msgid "Changes to the envelope size will be applied immediately"
+msgid "Changes to the envelope size will be applied only from now on."
 msgstr "Los cambios en el tamaño del sobre se aplicarán inmediatamente."
 
 msgid "Manage envelope size"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15357,7 +15357,7 @@ msgstr "Editar datos de detección de anomalías"
 #  msgstr ""
 
 msgid "You have unsaved changed, do you want to proceed?"
-msgstr "no ha guardado los cambios, ¿quiere continuar?"
+msgstr "No ha guardado los cambios, ¿quiere continuar?"
 
 #  msgid "Confirm"
 #  msgstr "Confirmar"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15317,7 +15317,7 @@ msgstr "Los cambios en el tamaño del sobre se aplicarán inmediatamente."
 msgid "Manage envelope size"
 msgstr "Administrar el tamaño del sobre"
 
-msgid "Set to default value"
+msgid "Reset to default value"
 msgstr "Establecer en el valor predeterminado"
 
 msgid "points out of envelope"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15320,7 +15320,7 @@ msgstr "Administrar el tamaño del sobre"
 msgid "Reset to default value"
 msgstr "Establecer en el valor predeterminado"
 
-msgid "points out of envelope"
+msgid "points outside of the envelope"
 msgstr "puntos fuera del sobre"
 
 msgid "Edit anomaly detection data"

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15356,7 +15356,7 @@ msgstr "Editar datos de detección de anomalías"
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
 
-msgid "You have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changes, do you want to proceed?"
 msgstr "No ha guardado los cambios, ¿quiere continuar?"
 
 #  msgid "Confirm"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17185,7 +17185,7 @@ msgstr "Groupes d'hôtes (simplifiés)"
 msgid "Services (simplified)"
 msgstr "Services (simplifiés)"
 
-msgid "You have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changes, do you want to proceed?"
 msgstr "Vous avez des modifications non enregistrées, voulez-vous continuer?"
 
 #  msgid "Confirm"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17134,11 +17134,11 @@ msgstr "Les roles récupérés depuis le serveur d'identité sont incorrects"
 msgid "Role mapping conditions do not match"
 msgstr "Aucune correspondance trouvée pour le couple rôles/groupe d'accès"
 
-msgid "Are you sure you want to change the size of the envelope? The new envelope size will be applied immediately."
-msgstr "Voulez-vous vraiment modifier la taille de l'enveloppe ? Le nouveau format d'enveloppe sera appliqué immédiatement."
+msgid "Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same."
+msgstr "Souhaitez-vous vraiment modifier la taille de l'enveloppe? Notez que la nouvelle taille d'enveloppe s’appliquera seulement à partir de maintenant. L’ancienne enveloppe restera inchangée."
 
-msgid "Changes to the envelope size will be applied immediately"
-msgstr "Les modifications apportées à la taille de l'enveloppe seront appliquées immédiatement"
+msgid "Changes to the envelope size will be applied only from now on."
+msgstr "La nouvelle taille d'enveloppe s’appliquera seulement à partir de maintenant."
 
 msgid "Manage envelope size"
 msgstr "Gérer la taille de l'enveloppe"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17109,3 +17109,9 @@ msgstr "Groupes d'hôtes (simplifiés)"
 
 msgid "Services (simplified)"
 msgstr "Services (simplifiés)"
+
+msgid "you have unsaved changed, do you want to proceed?"
+msgstr "vous avez des modifications non enregistrées, voulez-vous continuer?"
+
+#  msgid "Confirm"
+#  msgstr "Confirmer"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17146,7 +17146,7 @@ msgstr "Gérer la taille de l'enveloppe"
 msgid "Reset to default value"
 msgstr "Rétablir la valeur par défaut"
 
-msgid "points out of envelope"
+msgid "points outside of the envelope"
 msgstr "points hors enveloppe"
 
 msgid "Edit anomaly detection data"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17185,7 +17185,7 @@ msgstr "Groupes d'hôtes (simplifiés)"
 msgid "Services (simplified)"
 msgstr "Services (simplifiés)"
 
-msgid "you have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changed, do you want to proceed?"
 msgstr "vous avez des modifications non enregistrées, voulez-vous continuer?"
 
 #  msgid "Confirm"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17144,7 +17144,7 @@ msgid "Manage envelope size"
 msgstr "Gérer la taille de l'enveloppe"
 
 msgid "Set to default value"
-msgstr "Définir sur la valeur par défaut"
+msgstr "Rétablir la valeur par défaut"
 
 msgid "points out of envelope"
 msgstr "points hors enveloppe"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17068,8 +17068,8 @@ msgstr "Les modifications apportées à la taille de l'enveloppe seront appliqu�
 msgid "Manage envelope size"
 msgstr "Gérer la taille de l'enveloppe"
 
-msgid "use default value"
-msgstr "utiliser la valeur par défaut"
+msgid "Set to default value"
+msgstr "Définir sur la valeur par défaut"
 
 msgid "points out of envelope"
 msgstr "points hors enveloppe"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17186,7 +17186,7 @@ msgid "Services (simplified)"
 msgstr "Services (simplifiés)"
 
 msgid "You have unsaved changed, do you want to proceed?"
-msgstr "vous avez des modifications non enregistrées, voulez-vous continuer?"
+msgstr "Vous avez des modifications non enregistrées, voulez-vous continuer?"
 
 #  msgid "Confirm"
 #  msgstr "Confirmer"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17143,7 +17143,7 @@ msgstr "Les modifications apportées à la taille de l'enveloppe seront appliqu�
 msgid "Manage envelope size"
 msgstr "Gérer la taille de l'enveloppe"
 
-msgid "Set to default value"
+msgid "Reset to default value"
 msgstr "Rétablir la valeur par défaut"
 
 msgid "points out of envelope"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15709,8 +15709,8 @@ msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
 msgid "Manage envelope size"
 msgstr "Gerenciar o tamanho do envelope"
 
-msgid "use default value"
-msgstr "usar valor padrão"
+msgid "Set to default value"
+msgstr "Definir para o valor padrão"
 
 msgid "points out of envelope"
 msgstr "pontos fora do envelope"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15747,3 +15747,9 @@ msgstr "Editar dados de detecção de anomalias"
 
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
+
+msgid "you have unsaved changed, do you want to proceed?"
+msgstr "você não salvou as alterações, deseja continuar?"
+
+#  msgid "Confirm"
+#  msgstr "confirme"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15821,4 +15821,4 @@ msgid "you have unsaved changed, do you want to proceed?"
 msgstr "você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"
-#  msgstr "confirme"
+#  msgstr "Confirme"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15769,10 +15769,10 @@ msgstr "Nível de Severidade de host"
 #  msgid "Deploy configuration"
 #  msgstr ""
 
-msgid "Are you sure you want to change the size of the envelope? The new envelope size will be applied immediately."
+msgid "Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same."
 msgstr "Tem certeza de que deseja alterar o tamanho do envelope? O novo tamanho de envelope será aplicado imediatamente."
 
-msgid "Changes to the envelope size will be applied immediately"
+msgid "Changes to the envelope size will be applied only from now on."
 msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
 
 msgid "Manage envelope size"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15781,7 +15781,7 @@ msgstr "Gerenciar o tamanho do envelope"
 msgid "Reset to default value"
 msgstr "Definir para o valor padrão"
 
-msgid "points out of envelope"
+msgid "points outside of the envelope"
 msgstr "pontos fora do envelope"
 
 msgid "Edit anomaly detection data"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15778,7 +15778,7 @@ msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
 msgid "Manage envelope size"
 msgstr "Gerenciar o tamanho do envelope"
 
-msgid "Set to default value"
+msgid "Reset to default value"
 msgstr "Definir para o valor padrão"
 
 msgid "points out of envelope"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15817,7 +15817,7 @@ msgstr "Editar dados de detecção de anomalias"
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
 
-msgid "You have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changes, do you want to proceed?"
 msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15818,7 +15818,7 @@ msgstr "Editar dados de detecção de anomalias"
 #  msgstr ""
 
 msgid "you have unsaved changed, do you want to proceed?"
-msgstr "você não salvou as alterações, deseja continuar?"
+msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"
 #  msgstr "Confirme"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15817,7 +15817,7 @@ msgstr "Editar dados de detecção de anomalias"
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
 
-msgid "you have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changed, do you want to proceed?"
 msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15806,7 +15806,7 @@ msgstr "Editar dados de detecção de anomalias"
 #  msgstr ""
 
 msgid "you have unsaved changed, do you want to proceed?"
-msgstr "você não salvou as alterações, deseja continuar?"
+msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"
 #  msgstr "confirme"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15805,7 +15805,7 @@ msgstr "Editar dados de detecção de anomalias"
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
 
-msgid "You have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changes, do you want to proceed?"
 msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15757,10 +15757,10 @@ msgstr "Nível de Severidade de host"
 #  msgid "Deploy configuration"
 #  msgstr ""
 
-msgid "Are you sure you want to change the size of the envelope? The new envelope size will be applied immediately."
+msgid "Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same."
 msgstr "Tem certeza de que deseja alterar o tamanho do envelope? O novo tamanho de envelope será aplicado imediatamente."
 
-msgid "Changes to the envelope size will be applied immediately"
+msgid "Changes to the envelope size will be applied only from now on."
 msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
 
 msgid "Manage envelope size"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15805,7 +15805,7 @@ msgstr "Editar dados de detecção de anomalias"
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
 
-msgid "you have unsaved changed, do you want to proceed?"
+msgid "You have unsaved changed, do you want to proceed?"
 msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15735,3 +15735,9 @@ msgstr "Editar dados de detecção de anomalias"
 
 #  msgid "Host Groups (simplified)"
 #  msgstr ""
+
+msgid "you have unsaved changed, do you want to proceed?"
+msgstr "você não salvou as alterações, deseja continuar?"
+
+#  msgid "Confirm"
+#  msgstr "confirme"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15809,4 +15809,4 @@ msgid "you have unsaved changed, do you want to proceed?"
 msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Confirm"
-#  msgstr "confirme"
+#  msgstr "Confirme"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15767,7 +15767,7 @@ msgid "Manage envelope size"
 msgstr "Gerenciar o tamanho do envelope"
 
 msgid "Set to default value"
-msgstr "Definir para o valor padrão
+msgstr "Definir para o valor padrão"
 
 msgid "points out of envelope"
 msgstr "pontos fora do envelope"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15769,7 +15769,7 @@ msgstr "Gerenciar o tamanho do envelope"
 msgid "Set to default value"
 msgstr "Definir para o valor padrão"
 
-msgid "points out of envelope"
+msgid "points outside of the envelope"
 msgstr "pontos fora do envelope"
 
 msgid "Edit anomaly detection data"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15697,8 +15697,8 @@ msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
 msgid "Manage envelope size"
 msgstr "Gerenciar o tamanho do envelope"
 
-msgid "use default value"
-msgstr "usar valor padrão"
+msgid "Set to default value"
+msgstr "Definir para o valor padrão
 
 msgid "points out of envelope"
 msgstr "pontos fora do envelope"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15766,7 +15766,7 @@ msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
 msgid "Manage envelope size"
 msgstr "Gerenciar o tamanho do envelope"
 
-msgid "Set to default value"
+msgid "Reset to default value"
 msgstr "Definir para o valor padrão"
 
 msgid "points outside of the envelope"

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionModalConfirmation.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionModalConfirmation.tsx
@@ -1,17 +1,14 @@
-import { useTranslation } from 'react-i18next';
+import { ReactNode } from 'react';
 
-import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 
 import { Dialog } from '@centreon/ui';
 
-import {
-  labelEditAnomalyDetectionConfirmation,
-  labelMenageEnvelope,
-  labelSave,
-  labelCancel,
-} from '../../../translatedLabels';
+import { labelCancel, labelMenageEnvelope } from '../../../translatedLabels';
 
 interface Props {
+  children: ReactNode;
+  labelConfirm: string;
   open: boolean;
   sendCancel: (value: boolean) => void;
   sendConfirm: (value: boolean) => void;
@@ -23,6 +20,8 @@ const AnomalyDetectionModalConfirmation = ({
   setOpen,
   sendCancel,
   sendConfirm,
+  children,
+  labelConfirm,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
@@ -34,14 +33,13 @@ const AnomalyDetectionModalConfirmation = ({
   return (
     <Dialog
       labelCancel={t(labelCancel)}
-      labelConfirm={t(labelSave)}
+      labelConfirm={t(labelConfirm)}
       labelTitle={t(labelMenageEnvelope)}
       open={open}
       onCancel={cancel}
-      onClose={(): void => setOpen(false)}
       onConfirm={(): void => sendConfirm(true)}
     >
-      <Typography>{t(labelEditAnomalyDetectionConfirmation)}</Typography>
+      {children}
     </Dialog>
   );
 };

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -294,6 +294,7 @@ const AnomalyDetectionSlider = ({
           control={
             <Checkbox
               checked={isDefaultValue}
+              disabled={isDefaultValue}
               onChange={handleChangeCheckBox}
             />
           }

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -36,11 +36,6 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(2),
     marginTop: theme.spacing(5),
   },
-  buttonSetDefault: {
-    color: theme.palette.text.primary,
-    justifyContent: 'flex-start',
-    textTransform: 'none',
-  },
   confirmButton: {
     marginLeft: theme.spacing(2),
   },
@@ -49,6 +44,9 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'space-evenly',
     padding: theme.spacing(2),
+  },
+  defaultValue: {
+    color: theme.palette.text.primary,
   },
   divider: {
     margin: theme.spacing(0.5, 0, 2, 0),
@@ -296,16 +294,14 @@ const AnomalyDetectionSlider = ({
             </div>
           </IconButton>
         </div>
-        <Button
-          className={classes.buttonSetDefault}
+        <IconButton
           disabled={isDefaultValue}
           size="small"
-          variant="text"
           onClick={setToDefaultValue}
         >
-          <ResetIcon color={isDefaultValue ? 'disabled' : 'primary'} />
-          {t(labelUseDefaultValue)}
-        </Button>
+          <ResetIcon />
+          <Typography>{t(labelUseDefaultValue)}</Typography>
+        </IconButton>
       </div>
 
       <Divider className={classes.divider} />

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -19,7 +19,7 @@ import {
   labelMenageEnvelopeSubTitle,
   labelPointsOutsideOfEnvelopeCount,
   labelSave,
-  labelSetToDefaultValue,
+  labelResetToDefaultValue,
 } from '../../../translatedLabels';
 
 import { countedRedCirclesAtom } from './anomalyDetectionAtom';
@@ -301,7 +301,7 @@ const AnomalyDetectionSlider = ({
           startIcon={<ResetIcon />}
           onClick={setToDefaultValue}
         >
-          {t(labelSetToDefaultValue)}
+          {t(labelResetToDefaultValue)}
         </Button>
       </div>
 

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -1,30 +1,26 @@
-import { useState, useEffect, Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
-import { useTranslation } from 'react-i18next';
-import { equals, path } from 'ramda';
 import { useAtom } from 'jotai';
+import { equals, path } from 'ramda';
+import { useTranslation } from 'react-i18next';
 
-import { Tooltip } from '@mui/material';
-import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
-import Slider from '@mui/material/Slider';
+import ResetIcon from '@mui/icons-material/SettingsBackupRestore';
+import { Button, Divider, Slider, Tooltip, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
-import Button from '@mui/material/Button';
 
-import { IconButton, useRequest, putData } from '@centreon/ui';
+import { IconButton, putData, useRequest } from '@centreon/ui';
 
+import { ResourceDetails, Sensitivity } from '../../../Details/models';
 import {
+  labelCancel,
   labelMenageEnvelope,
   labelMenageEnvelopeSubTitle,
-  labelCancel,
+  labelPointsOutsideOfEnvelopeCount,
   labelSave,
   labelUseDefaultValue,
-  labelPointsOutsideOfEnvelopeCount,
 } from '../../../translatedLabels';
-import { ResourceDetails, Sensitivity } from '../../../Details/models';
 
 import { countedRedCirclesAtom } from './anomalyDetectionAtom';
 import { CustomFactorsData } from './models';
@@ -40,6 +36,11 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(2),
     marginTop: theme.spacing(5),
   },
+  buttonSetDefault: {
+    color: theme.palette.text.primary,
+    justifyContent: 'flex-start',
+    textTransform: 'none',
+  },
   confirmButton: {
     marginLeft: theme.spacing(2),
   },
@@ -49,9 +50,12 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-evenly',
     padding: theme.spacing(2),
   },
+  divider: {
+    margin: theme.spacing(0.5, 0, 2, 0),
+  },
   footer: {
     display: 'flex',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
   },
   header: {
     display: 'flex',
@@ -74,6 +78,8 @@ const useStyles = makeStyles((theme) => ({
     '& .MuiSlider-valueLabel': {
       backgroundColor: theme.palette.primary.main,
       borderRadius: '50%',
+      height: theme.spacing(2.25),
+      width: theme.spacing(1.25),
     },
     '& .MuiSlider-valueLabel:before': {
       width: 0,
@@ -164,12 +170,12 @@ const AnomalyDetectionSlider = ({
     setOpenTooltip(true);
   };
 
-  const handleChangeCheckBox = (event): void => {
+  const setToDefaultValue = (): void => {
     setIsResizingConfirmed(true);
     if (isDefaultValue) {
       return;
     }
-    setIsDefaultValue(event.target.checked);
+    setIsDefaultValue(true);
     setOpenTooltip(true);
   };
 
@@ -290,20 +296,26 @@ const AnomalyDetectionSlider = ({
             </div>
           </IconButton>
         </div>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={isDefaultValue}
-              disabled={isDefaultValue}
-              onChange={handleChangeCheckBox}
-            />
-          }
-          label={t(labelUseDefaultValue)}
-        />
+        <Button
+          className={classes.buttonSetDefault}
+          disabled={isDefaultValue}
+          size="small"
+          variant="text"
+          onClick={setToDefaultValue}
+        >
+          <ResetIcon color={isDefaultValue ? 'disabled' : 'primary'} />
+          {t(labelUseDefaultValue)}
+        </Button>
       </div>
 
+      <Divider className={classes.divider} />
+
       <div className={classes.footer}>
-        <Button size="small" variant="text" onClick={cancelResizingEnvelope}>
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={cancelResizingEnvelope}
+        >
           {t(labelCancel)}
         </Button>
         <Button

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -48,9 +48,6 @@ const useStyles = makeStyles((theme) => ({
   defaultButton: {
     justifyContent: 'flex-start',
   },
-  defaultValue: {
-    color: theme.palette.text.primary,
-  },
   divider: {
     margin: theme.spacing(0.5, 0, 2, 0),
   },

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -19,7 +19,7 @@ import {
   labelMenageEnvelopeSubTitle,
   labelPointsOutsideOfEnvelopeCount,
   labelSave,
-  labelUseDefaultValue,
+  labelSetToDefaultValue,
 } from '../../../translatedLabels';
 
 import { countedRedCirclesAtom } from './anomalyDetectionAtom';
@@ -301,7 +301,7 @@ const AnomalyDetectionSlider = ({
           startIcon={<ResetIcon />}
           onClick={setToDefaultValue}
         >
-          {t(labelUseDefaultValue)}
+          {t(labelSetToDefaultValue)}
         </Button>
       </div>
 

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -47,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
   },
   defaultButton: {
     justifyContent: 'flex-start',
+    textTransform: 'none',
   },
   divider: {
     margin: theme.spacing(0.5, 0, 2, 0),
@@ -294,15 +295,14 @@ const AnomalyDetectionSlider = ({
             </div>
           </IconButton>
         </div>
-        <div className={classes.defaultButton}>
-          <Button
-            disabled={isDefaultValue}
-            startIcon={<ResetIcon />}
-            onClick={setToDefaultValue}
-          >
-            {t(labelUseDefaultValue)}
-          </Button>
-        </div>
+        <Button
+          className={classes.defaultButton}
+          disabled={isDefaultValue}
+          startIcon={<ResetIcon />}
+          onClick={setToDefaultValue}
+        >
+          {t(labelUseDefaultValue)}
+        </Button>
       </div>
 
       <Divider className={classes.divider} />

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/AnomalyDetectionSlider.tsx
@@ -45,6 +45,9 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-evenly',
     padding: theme.spacing(2),
   },
+  defaultButton: {
+    justifyContent: 'flex-start',
+  },
   defaultValue: {
     color: theme.palette.text.primary,
   },
@@ -294,14 +297,15 @@ const AnomalyDetectionSlider = ({
             </div>
           </IconButton>
         </div>
-        <IconButton
-          disabled={isDefaultValue}
-          size="small"
-          onClick={setToDefaultValue}
-        >
-          <ResetIcon />
-          <Typography>{t(labelUseDefaultValue)}</Typography>
-        </IconButton>
+        <div className={classes.defaultButton}>
+          <Button
+            disabled={isDefaultValue}
+            startIcon={<ResetIcon />}
+            onClick={setToDefaultValue}
+          >
+            {t(labelUseDefaultValue)}
+          </Button>
+        </div>
       </div>
 
       <Divider className={classes.divider} />

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/EditAnomalyDetectionDataDialog.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/EditAnomalyDetectionDataDialog.tsx
@@ -3,10 +3,16 @@ import { Dispatch, ReactNode, SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUpdateAtom } from 'jotai/utils';
 
-import { Button, Dialog, Paper } from '@mui/material';
+import { Button, Dialog, Paper, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 
-import { labelClose } from '../../../translatedLabels';
+import {
+  labelClose,
+  labelEditAnomalyDetectionConfirmation,
+  labelEditAnomalyDetectionClosing,
+  labelSave,
+  labelConfirm,
+} from '../../../translatedLabels';
 import TimePeriodButtonGroup from '../TimePeriods';
 
 import AnomalyDetectionExclusionPeriod from './AnomalyDetectionExclusionPeriod';
@@ -80,11 +86,20 @@ const EditAnomalyDetectionDataDialog = ({
     useState(false);
 
   const [isResizeEnvelope, setIsResizeEnvelope] = useState(false);
+  const [
+    isModalEditAnomalyDetectionConfirmationOpened,
+    setIsModalEditAnomalyDetectionConfirmationOpened,
+  ] = useState(false);
   const setCountedRedCircles = useUpdateAtom(countedRedCirclesAtom);
 
   const handleClose = (): void => {
-    setIsOpen(false);
-    setCountedRedCircles(null);
+    if (!factorsData?.isResizing) {
+      setIsOpen(false);
+      setCountedRedCircles(null);
+
+      return;
+    }
+    setIsModalEditAnomalyDetectionConfirmationOpened(true);
   };
 
   const getFactors = (data: CustomFactorsData): void => {
@@ -105,7 +120,7 @@ const EditAnomalyDetectionDataDialog = ({
   };
 
   return (
-    <Dialog className={classes.container} open={isOpen}>
+    <Dialog className={classes.container} open={isOpen} onClose={handleClose}>
       <div>
         <div className={classes.spacing}>
           <TimePeriodButtonGroup />
@@ -123,11 +138,26 @@ const EditAnomalyDetectionDataDialog = ({
           </Paper>
         </div>
         <EditAnomalyDetectionDataDialog.ModalConfirmation
+          labelConfirm={labelSave}
           open={isModalConfirmationOpened}
           sendCancel={cancelResizeEnvelope}
           sendConfirm={resizeEnvelope}
           setOpen={setIsModalConfirmationOpened}
-        />
+        >
+          <Typography> {t(labelEditAnomalyDetectionConfirmation)} </Typography>
+        </EditAnomalyDetectionDataDialog.ModalConfirmation>
+
+        <EditAnomalyDetectionDataDialog.ModalClosing
+          labelConfirm={labelConfirm}
+          open={isModalEditAnomalyDetectionConfirmationOpened}
+          sendCancel={(): void =>
+            setIsModalEditAnomalyDetectionConfirmationOpened(true)
+          }
+          sendConfirm={(): void => setIsOpen(false)}
+          setOpen={setIsModalEditAnomalyDetectionConfirmationOpened}
+        >
+          {t(labelEditAnomalyDetectionClosing)}
+        </EditAnomalyDetectionDataDialog.ModalClosing>
         <div className={classes.close}>
           <Button onClick={handleClose}>{t(labelClose)}</Button>
         </div>
@@ -141,5 +171,6 @@ EditAnomalyDetectionDataDialog.ExclusionPeriod =
   AnomalyDetectionExclusionPeriod;
 EditAnomalyDetectionDataDialog.ModalConfirmation =
   AnomalyDetectionModalConfirmation;
+EditAnomalyDetectionDataDialog.ModalClosing = AnomalyDetectionModalConfirmation;
 
 export default EditAnomalyDetectionDataDialog;

--- a/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/EditAnomalyDetectionDataDialog.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/AnomalyDetection/EditAnomalyDetectionDataDialog.tsx
@@ -119,6 +119,11 @@ const EditAnomalyDetectionDataDialog = ({
     setIsModalConfirmationOpened(false);
   };
 
+  const closeModal = (): void => {
+    setIsOpen(false);
+    setCountedRedCircles(null);
+  };
+
   return (
     <Dialog className={classes.container} open={isOpen} onClose={handleClose}>
       <div>
@@ -153,7 +158,7 @@ const EditAnomalyDetectionDataDialog = ({
           sendCancel={(): void =>
             setIsModalEditAnomalyDetectionConfirmationOpened(true)
           }
-          sendConfirm={(): void => setIsOpen(false)}
+          sendConfirm={closeModal}
           setOpen={setIsModalEditAnomalyDetectionConfirmationOpened}
         >
           {t(labelEditAnomalyDetectionClosing)}

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -270,7 +270,7 @@ export const labelEditAnomalyDetectionConfirmation =
 export const labelMenageEnvelope = 'Manage envelope size';
 export const labelMenageEnvelopeSubTitle =
   'Changes to the envelope size will be applied immediately';
-export const labelUseDefaultValue = 'use default value';
+export const labelUseDefaultValue = 'Set to default value';
 export const labelPointsOutsideOfEnvelopeCount = 'points out of envelope';
 export const labelClose = 'Close';
 export const labelEditAnomalyDetectionClosing =

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -270,7 +270,7 @@ export const labelEditAnomalyDetectionConfirmation =
 export const labelMenageEnvelope = 'Manage envelope size';
 export const labelMenageEnvelopeSubTitle =
   'Changes to the envelope size will be applied immediately';
-export const labelUseDefaultValue = 'Set to default value';
+export const labelSetToDefaultValue = 'Set to default value';
 export const labelPointsOutsideOfEnvelopeCount = 'points out of envelope';
 export const labelClose = 'Close';
 export const labelEditAnomalyDetectionClosing =

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -273,3 +273,6 @@ export const labelMenageEnvelopeSubTitle =
 export const labelUseDefaultValue = 'use default value';
 export const labelPointsOutsideOfEnvelopeCount = 'points out of envelope';
 export const labelClose = 'Close';
+export const labelEditAnomalyDetectionClosing =
+  'you have unsaved changed, do you want to proceed?';
+export const labelConfirm = 'Confirm';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -270,8 +270,9 @@ export const labelEditAnomalyDetectionConfirmation =
 export const labelMenageEnvelope = 'Manage envelope size';
 export const labelMenageEnvelopeSubTitle =
   'Changes to the envelope size will be applied immediately';
-export const labelSetToDefaultValue = 'Set to default value';
-export const labelPointsOutsideOfEnvelopeCount = 'points outside of the envelope';
+export const labelResetToDefaultValue = 'Reset to default value';
+export const labelPointsOutsideOfEnvelopeCount =
+  'points outside of the envelope';
 export const labelClose = 'Close';
 export const labelEditAnomalyDetectionClosing =
   'You have unsaved changes, do you want to proceed?';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -274,5 +274,5 @@ export const labelUseDefaultValue = 'Set to default value';
 export const labelPointsOutsideOfEnvelopeCount = 'points out of envelope';
 export const labelClose = 'Close';
 export const labelEditAnomalyDetectionClosing =
-  'you have unsaved changed, do you want to proceed?';
+  'You have unsaved changes, do you want to proceed?';
 export const labelConfirm = 'Confirm';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -271,7 +271,7 @@ export const labelMenageEnvelope = 'Manage envelope size';
 export const labelMenageEnvelopeSubTitle =
   'Changes to the envelope size will be applied immediately';
 export const labelSetToDefaultValue = 'Set to default value';
-export const labelPointsOutsideOfEnvelopeCount = 'points out of envelope';
+export const labelPointsOutsideOfEnvelopeCount = 'points outside of the envelope';
 export const labelClose = 'Close';
 export const labelEditAnomalyDetectionClosing =
   'You have unsaved changes, do you want to proceed?';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -266,10 +266,10 @@ export const labelEditAnomalyDetectionData = 'Edit anomaly detection data';
 export const labelAnomalyDetection = 'Anomaly detection';
 export const labelPerformanceGraphAD = 'Edit anomaly detection data';
 export const labelEditAnomalyDetectionConfirmation =
-  'Are you sure you want to change the size of the envelope? The new envelope size will be applied immediately.';
+  'Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same.';
 export const labelMenageEnvelope = 'Manage envelope size';
 export const labelMenageEnvelopeSubTitle =
-  'Changes to the envelope size will be applied immediately';
+  'Changes to the envelope size will be applied only from now on.';
 export const labelResetToDefaultValue = 'Reset to default value';
 export const labelPointsOutsideOfEnvelopeCount =
   'points outside of the envelope';


### PR DESCRIPTION
adding modal for closing confirmation : 
Closing the modal (click on cross or outside). If the user has confirmed his choice or made no changes, the modal closes without warning. Otherwise, popin “you have unsaved changed, do you want to proceed? cancel, confirm” (wording TBD)

**video:**

https://user-images.githubusercontent.com/97687698/194581233-9c296fcf-a1cc-43fc-a13a-088b1118ea27.mp4

**screens:**
![image](https://user-images.githubusercontent.com/97687698/194581427-c47fd8ac-9372-4ce0-a73b-f9fed5255cf9.png)

![image](https://user-images.githubusercontent.com/97687698/195390382-0c447e3b-081e-4325-8092-edf932e94256.png)


