### PR TITLE
fix(resources): limit data sent for disack action on resources

### DIFF
--- a/www/front_src/src/Resources/Actions/Resource/Disacknowledge/api/index.ts
+++ b/www/front_src/src/Resources/Actions/Resource/Disacknowledge/api/index.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse, CancelToken } from 'axios';
-import { map, pick, equals } from 'ramda';
+import { equals } from 'ramda';
 
 import { resourcesEndpoint } from '../../../../api/endpoint';
 import { Resource, ResourceType, ResourceCategory } from '../../../../models';

--- a/www/front_src/src/Resources/Actions/Resource/Disacknowledge/api/index.ts
+++ b/www/front_src/src/Resources/Actions/Resource/Disacknowledge/api/index.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosResponse, CancelToken } from 'axios';
-import { map, pick } from 'ramda';
+import { map, pick, equals } from 'ramda';
 
 import { resourcesEndpoint } from '../../../../api/endpoint';
-import { Resource } from '../../../../models';
+import { Resource, ResourceType, ResourceCategory } from '../../../../models';
 
 const disacknowledgeEndpoint = `${resourcesEndpoint}/acknowledgements`;
 
@@ -17,13 +17,19 @@ const disacknowledgeResources =
     resources,
     disacknowledgeAttachedResources,
   }: ResourcesWithDisacknowledgeParams): Promise<Array<AxiosResponse>> => {
+    const payload = resources.map(({ type, id, parent, service_id }) => ({
+      id: equals(type, ResourceType.anomalydetection) ? service_id : id,
+      parent: parent ? { id: parent?.id } : null,
+      type: ResourceCategory[type],
+    }));
+
     return axios.delete(disacknowledgeEndpoint, {
       cancelToken,
       data: {
         disacknowledgement: {
           with_services: disacknowledgeAttachedResources,
         },
-        resources: map(pick(['type', 'id', 'parent']), resources),
+        resources: payload,
       },
     });
   };


### PR DESCRIPTION
## Description

This PR intends to limit the data sent by the frontend to the API when disacknowledging a resource on Resource Status


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
