### PR TITLE
fix(performance data): fix array to string conversion

### DIFF
--- a/www/include/Administration/performance/viewData.php
+++ b/www/include/Administration/performance/viewData.php
@@ -84,6 +84,14 @@ $inputGet = array(
     'select' => \HtmlAnalyzer::sanitizeAndRemoveTags($_GET['select'] ?? ''),
     'id' => \HtmlAnalyzer::sanitizeAndRemoveTags($_GET['id'] ?? ''),
 );
+
+$sanitizedPostSelect = [];
+if (isset($_POST['select']) && is_array($_POST['select'])) {
+    foreach ($_POST['select'] as $key => $value) {
+        $sanitizedPostSelect[$key] = \HtmlAnalyzer::sanitizeAndRemoveTags($value);
+    }
+}
+
 $inputPost = array(
     'Search' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['Search'] ?? ''),
     'searchH' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['searchH'] ?? ''),
@@ -94,7 +102,7 @@ $inputPost = array(
     'o' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['o'] ?? ''),
     'o1' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['o1'] ?? ''),
     'o2' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['o2'] ?? ''),
-    'select' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['select'] ?? ''),
+    'select' => $sanitizedPostSelect,
     'id' => \HtmlAnalyzer::sanitizeAndRemoveTags($_POST['id'] ?? ''),
 );
 


### PR DESCRIPTION
## Description

This PR intends to fix a php fatal error due to an array to string conversion

**Fixes** # MON-15390

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Monitor some hosts and services
- go to Administration > Parameters > Data
- check an host
- On More actions Menu > Delete Graphs
- No error should occurs in log and in UI

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
