### PR TITLE
Fix: Bam buttons are not readable in top corner 

### DIFF
--- a/www/Themes/Generic-theme/color.css
+++ b/www/Themes/Generic-theme/color.css
@@ -1,3 +1,6 @@
+.bam_back_btn , .bam_report_btn {
+    color: var(--btc-color)!important;
+}
 .ListTable a:link, #ListTable a:link, .ListTable a:visited, #ListTable a:visited {
     color:var(--table-font-color) ;
 }


### PR DESCRIPTION
## Description

Both colors of the buttons hovered or not are hard to see in Monitoring → BA →  monitoring 
**Fixes** # MON-15345

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

actual look after fix:
![image](https://user-images.githubusercontent.com/108519266/195057775-d40bd40b-e071-4f6b-aa9b-699ce7585330.png)
![light](https://user-images.githubusercontent.com/108519266/195057844-ffd9c3b8-8c2a-4f0d-9359-52be004718f6.PNG)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
