### PR TITLE
FIX(security) :Sanitized queries in the list of meta service

### DIFF
--- a/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -107,13 +107,13 @@ if (!$acl->admin && $metaStr) {
     }
     $queryParams = implode(',', array_keys($metaStrParams));
 
-    if ($search) {
+    if ($search !== '') {
         $conditionStr = "AND meta_id IN (" . $queryParams . ")";
     } else {
         $conditionStr = "WHERE meta_id IN (" . $queryParams . ")";
     }
 }
-if ($search != "") {
+if ($search !== '') {
     $statement = $pearDB->prepare("SELECT * FROM meta_service " .
         "WHERE meta_name LIKE :search " . $conditionStr .
         " ORDER BY meta_name LIMIT :offset, :limit");
@@ -125,7 +125,7 @@ if ($search != "") {
 foreach ($metaStrParams as $key => $metaId) {
     $statement->bindValue($key, $metaId, \PDO::PARAM_INT);
 }
-$statement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
 $statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
 $statement->execute();
 

--- a/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -102,8 +102,8 @@ $metaStrParams = [];
 //binding query params for non admin  acl rules
 if (!$acl->admin && $metaStr) {
     $metaStrList = explode(',', $metaStr);
-    foreach ($metaStrList as $index => $meta_id) {
-        $metaStrParams[':meta_' . $index] = $meta_id;
+    foreach ($metaStrList as $index => $metaId) {
+        $metaStrParams[':meta_' . $index] = (int) str_replace("'", "", $metaId);
     }
     $queryParams = implode(',', array_keys($metaStrParams));
 
@@ -113,7 +113,7 @@ if (!$acl->admin && $metaStr) {
         $conditionStr = "WHERE meta_id IN (" . $queryParams . ")";
     }
 }
-if ($search) {
+if ($search != "") {
     $statement = $pearDB->prepare("SELECT * FROM meta_service " .
         "WHERE meta_name LIKE :search " . $conditionStr .
         " ORDER BY meta_name LIMIT :offset, :limit");
@@ -122,8 +122,8 @@ if ($search) {
     $statement = $pearDB->prepare("SELECT * FROM meta_service " . $conditionStr .
         " ORDER BY meta_name LIMIT :offset, :limit");
 }
-foreach ($metaStrParams as $key => $meta_id) {
-    $statement->bindValue($key, str_replace("'", "", $meta_id), \PDO::PARAM_INT);
+foreach ($metaStrParams as $key => $metaId) {
+    $statement->bindValue($key, $metaId, \PDO::PARAM_INT);
 }
 $statement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
 $statement->bindValue(':limit', $limit, \PDO::PARAM_INT);


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code 




**Fixes** # MON-15371

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Navigate to Configuration -> Services -> Meta Services
2. Create a meta service
3. Duplicate it like 15 times
4. See if pagination and search is still working 

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
