### PR TITLE
FIX(security): Sanitize queries in service category

### DIFF
--- a/www/include/configuration/configObject/service_categories/DB-Func.php
+++ b/www/include/configuration/configObject/service_categories/DB-Func.php
@@ -157,10 +157,11 @@ function multipleServiceCategorieInDB($sc = [], $nbrDup = [])
                 $maxId = $statement->fetch();
                 $scAcl[$maxId['maxid']] = $key;
                 $query = "INSERT INTO service_categories_relation (service_service_id, sc_id) " .
-                    "(SELECT service_service_id, " . $maxId['maxid'] .
+                    "(SELECT service_service_id, :max_id" .
                     " FROM service_categories_relation WHERE sc_id = :sc_id)";
                 $statement = $pearDB->prepare($query);
                 $statement->bindValue(':sc_id', $key, \PDO::PARAM_INT);
+                $statement->bindValue(':max_id', $maxId['maxid'], \PDO::PARAM_INT);
                 $statement->execute();
             }
         }


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code


**Fixes** # MON-15370

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- navigate to configuration -> Services -> Categories
- try to duplicate a service category and see if it works and there is no errors in log

`tail -f var/log/php-fpm/centreon-error.log`
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
