### PR TITLE
FIX(security): Sanitize queries in the list of trap groups

### DIFF
--- a/www/include/configuration/configObject/traps-groups/listGroups.php
+++ b/www/include/configuration/configObject/traps-groups/listGroups.php
@@ -56,13 +56,16 @@ if (isset($_POST['searchTM']) || isset($_GET['searchTM'])) {
 
 $searchTool = null;
 if ($search) {
-    $searchTool = " WHERE (traps_group_name LIKE '%" . $search . "%')";
+    $searchTool = " WHERE (traps_group_name LIKE :search )";
 }
-
-$dbResult = $pearDB->query(
-    "SELECT SQL_CALC_FOUND_ROWS * FROM traps_group " . $searchTool .
-    " ORDER BY traps_group_name LIMIT " . $num * $limit . ", " . $limit
-);
+$statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS * FROM traps_group " . $searchTool .
+    " ORDER BY traps_group_name LIMIT  :offset, :limit");
+if ($search) {
+    $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
+$statement->execute();
 
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
@@ -94,7 +97,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-for ($i = 0; $group = $dbResult->fetch(); $i++) {
+for ($i = 0; $group = $statement->fetch(\PDO::FETCH_ASSOC); $i++) {
     $moptions = "";
     $selectedElements = $form->addElement('checkbox', "select[" . $group['traps_group_id'] . "]");
     $moptions = "&nbsp;<input onKeypress=\"if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) " .

--- a/www/include/configuration/configObject/traps-groups/listGroups.php
+++ b/www/include/configuration/configObject/traps-groups/listGroups.php
@@ -63,7 +63,7 @@ $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS * FROM traps_group " .
 if ($search) {
     $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
 }
-$statement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
 $statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
 $statement->execute();
 


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

**Fixes** # MON-15374

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to  Configuration  >  SNMP Traps  >  Group
2. Create a trap group and duplicate it like 20 times
3. check if listing is good and pagination and limit items peer page still works

_additional check:_
in console put the following command and see if there is errors in log : 
`tail -f var/log/php-fpm/centreon-error.log`

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
