### PR TITLE
(fix) (debian) MON-15511 add dependencies and locales configuration

### DIFF
--- a/ci/debian/centreon-web-common.postinst
+++ b/ci/debian/centreon-web-common.postinst
@@ -2,6 +2,16 @@
 
 if [ "$1" = "configure" ] ; then
     update-alternatives --set php /usr/bin/php8.0
+
+    # Set locales on system to use in translation
+    sed -i \
+        -e '/^#.* en_US.UTF-8 /s/^#//' \
+        -e '/^#.* fr_FR.UTF-8 /s/^#//' \
+        -e '/^#.* pt_PT.UTF-8 /s/^#//' \
+        -e '/^#.* pt_BR.UTF-8 /s/^#//' \
+        -e '/^#.* es_ES.UTF-8 /s/^#//' \
+        /etc/locale.gen && \
+    locale-gen
 fi
 
 exit 0

--- a/ci/debian/control
+++ b/ci/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Luiz Costa <me@luizgustavo.pro.br>
 Standards-Version: 4.5.0
 Homepage: https://www.centreon.com
-Build-Depends: 
+Build-Depends:
     debhelper-compat (=12),
     php8.0-curl,
     php8.0-intl,
@@ -15,7 +15,7 @@ Build-Depends:
 
 Package: centreon
 Architecture: all
-Depends: 
+Depends:
     centreon-central (>= ${centreon:version}~),
     centreon-database (>= ${centreon:version}~)
 Description: Centreon is a network, system, applicative supervision and monitoring tool,
@@ -32,7 +32,7 @@ Description: Centreon is a network, system, applicative supervision and monitori
 
 Package: centreon-central
 Architecture: all
-Depends: 
+Depends:
     centreon-poller-centreon-engine (>= ${centreon:version}~),
     centreon-license-manager (>= ${centreon:version}~),
     centreon-pp-manager (>= ${centreon:version}~),
@@ -62,7 +62,7 @@ Description: The package contains base configuration for Centreon Engine and Cen
 
 Package: centreon-poller
 Architecture: all
-Depends: 
+Depends:
     centreon-common (>= ${centreon:version}~),
     centreon-poller-centreon-engine (>= ${centreon:version}~),
     centreon-trap (>= ${centreon:version}~),
@@ -95,16 +95,18 @@ Description: This package add rights and default directories for a poller
 
 Package: centreon-web-common
 Architecture: all
-Depends: 
+Depends:
     centreon-common (>= ${centreon:version}~),
     centreon-perl-libs (>= ${centreon:version}~),
     php8.0,
-    php8.0-cli
+    php8.0-cli,
+    locales,
+    gettext
 Description: Centreon installation entry point.
 
 Package: centreon-web
 Architecture: all
-Depends: 
+Depends:
     ${misc:Depends},
     lsb-release,
     centreon-web-common (>= ${centreon:version}~),
@@ -129,7 +131,7 @@ Suggests: nagios-images
 Description: This package contains WebUI files.
 
 Package: centreon-perl-libs
-Depends:    
+Depends:
     ${misc:Depends},
     centreon-common (>= ${centreon:version}~),
     libconfig-inifiles-perl,
@@ -150,7 +152,7 @@ Description: Base package for all Centreon installations.
 
 Package: centreon-database
 Architecture: all
-Depends: 
+Depends:
     centreon-common (>= ${centreon:version}~),
     mariadb-server,
     ${misc:Depends}
@@ -158,7 +160,7 @@ Description: Install a database server optimized for use with Centreon.
 
 Package: centreon-web-apache
 Architecture: all
-Depends: 
+Depends:
     apache2,
     php8.0-fpm,
     centreon-web (>= ${centreon:version}~),
@@ -169,7 +171,7 @@ Description: Centreon is a network, system, applicative supervision and monitori
 
 Package: centreon-trap
 Architecture: all
-Depends: 
+Depends:
     centreon-common (>= ${centreon:version}~),
     snmptrapd,
     snmpd,
@@ -178,7 +180,7 @@ Description: This package contains Centreon Trap engine
 
 Package: centreon-poller-centreon-engine
 Architecture: any
-Depends: 
+Depends:
     centreon-broker (>= ${centreon:version}~),
     centreon-engine (>= ${centreon:version}~),
     centreon-gorgone (>= ${centreon:version}~),
@@ -205,7 +207,7 @@ Description: This package add rights and default directories for a poller
 
 Package: centreon-plugins-sudoers
 Architecture: all
-Depends: 
+Depends:
     centreon-common (>= ${centreon:version}~),
     centreon-engine (>= ${centreon:version}~),
     centreon-gorgone (>= ${centreon:version}~),


### PR DESCRIPTION
## Description

In order for the translations of the pages in the Centreon-web to work properly in environments with Debian, it is necessary to configure the environment variables of the languages available for the translation, this PR fixes this problem.

Resolves https://centreon.atlassian.net/browse/MON-15511

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
