### PR TITLE
fix(ldap): add debug and avoid ldap failures (22.04)

### DIFF
--- a/www/class/centreonContactgroup.class.php
+++ b/www/class/centreonContactgroup.class.php
@@ -117,7 +117,11 @@ class CentreonContactgroup
             $ldapRes = $this->db->query($query);
             while ($ldapRow = $ldapRes->fetch()) {
                 $ldap = new CentreonLDAP($this->db, null, $ldapRow['ar_id']);
-                $ldap->connect(null, $ldapRow['ar_id']);
+                $isConnectedToLdap = $ldap->connect();
+                if ($isConnectedToLdap === false) {
+                    continue;
+                }
+
                 $ldapGroups = $ldap->listOfGroups();
 
                 foreach ($ldapGroups as $ldapGroup) {
@@ -253,12 +257,16 @@ class CentreonContactgroup
             return $ldapGroupId;
         }
 
-        $ldap = new CentreonLDAP($this->db, null, $arId);
-        $ldap->connect();
-        $ldapDn = $ldap->findGroupDn($cgName);
-
         // Reset ldap build cache time
         $this->db->query('UPDATE options SET `value` = 0 WHERE `key` = "ldap_last_acl_update"');
+
+        $ldap = new CentreonLDAP($this->db, null, $arId);
+        $isConnectedToLdap = $ldap->connect();
+        if ($isConnectedToLdap === false) {
+            return null;
+        }
+
+        $ldapDn = $ldap->findGroupDn($cgName);
 
         if ($ldapDn !== false) {
             $this->insertLdapGroupByNameAndDn($arId, $cgName, $ldapDn);
@@ -382,133 +390,134 @@ class CentreonContactgroup
         while ($ldapRow = $ldapRes->fetch()) {
             $ldapConn = new CentreonLDAP($this->db, null, $ldapRow['ar_id']);
             $connectionResult = $ldapConn->connect();
-            if (false != $connectionResult) {
-                $res = $this->db->prepare(
-                    "SELECT cg_id, cg_name, cg_ldap_dn FROM contactgroup " .
-                    "WHERE cg_type = 'ldap' AND ar_id = :arId"
-                );
-                $res->bindValue(':arId', $ldapRow['ar_id'], \PDO::PARAM_INT);
-                $res->execute();
-
-                // insert groups from ldap into centreon
-                $registeredGroupsFromDB = $res->fetchAll();
-                $registeredGroups = [];
-                foreach ($registeredGroupsFromDB as $registeredGroupFromDB) {
-                    $registeredGroups[] = $registeredGroupFromDB['cg_name'];
-                }
-
-                $ldapGroups = $ldapConn->listOfGroups();
-
-                foreach ($ldapGroups as $ldapGroup) {
-                    if (!in_array($ldapGroup['name'], $registeredGroups)) {
-                        $this->insertLdapGroupByNameAndDn(
-                            (int) $ldapRow['ar_id'],
-                            $ldapGroup['name'],
-                            $ldapGroup['dn']
-                        );
-                    }
-                }
-
-                $res = $this->db->prepare(
-                    "SELECT cg_id, cg_name, cg_ldap_dn FROM contactgroup " .
-                    "WHERE cg_type = 'ldap' AND ar_id = :arId"
-                );
-                $res->bindValue(':arId', $ldapRow['ar_id'], \PDO::PARAM_INT);
-                $res->execute();
-
-                $this->db->beginTransaction();
-                try {
-                    while ($row = $res->fetch()) {
-                        // Test is the group has not been moved or deleted in ldap
-                        if ((empty($row['cg_ldap_dn']) || false === $ldapConn->getEntry($row['cg_ldap_dn']))
-                            && ldap_errno($ldapConn->getDs()) != 3
-                        ) {
-                            $dn = $ldapConn->findGroupDn($row['cg_name']);
-                            if (false === $dn && ldap_errno($ldapConn->getDs()) != 3) {
-                                // Delete the ldap group in contactgroup
-                                try {
-                                    $stmt = $this->db->prepare(
-                                        "DELETE FROM contactgroup WHERE cg_id = :cgId"
-                                    );
-                                    $stmt->bindValue('cgId', $row['cg_id'], \PDO::PARAM_INT);
-                                    $stmt->execute();
-                                } catch (\PDOException $e) {
-                                    $msg[] = "Error processing delete contactgroup request of ldap group : " .
-                                        $row['cg_name'];
-                                    throw $e;
-                                }
-                                continue;
-                            } else { // Update the ldap group dn in contactgroup
-                                try {
-                                    $updateDnStatement = $this->db->prepare(
-                                        "UPDATE contactgroup SET cg_ldap_dn = :cg_dn WHERE cg_id = :cg_id"
-                                    );
-                                    $updateDnStatement->bindValue(':cg_dn', $dn, \PDO::PARAM_STR);
-                                    $updateDnStatement->bindValue(':cg_id', $row['cg_id'], \PDO::PARAM_INT);
-                                    $updateDnStatement->execute();
-                                    $row['cg_ldap_dn'] = $dn;
-                                } catch (\PDOException $e) {
-                                    $msg[] = "Error processing update contactgroup request of ldap group : " .
-                                        $row['cg_name'];
-                                    throw $e;
-                                }
-                            }
-                        }
-                        $members = $ldapConn->listUserForGroup($row['cg_ldap_dn']);
-
-                        // Refresh Users Groups.
-                        $deleteStmt = $this->db->prepare(
-                            "DELETE FROM contactgroup_contact_relation
-                            WHERE contactgroup_cg_id = :cgId"
-                        );
-                        $deleteStmt->bindValue(':cgId', $row['cg_id'], \PDO::PARAM_INT);
-                        $deleteStmt->execute();
-                        $contactDns = '';
-                        foreach ($members as $member) {
-                            $contactDns .= $this->db->quote($member) . ',';
-                        }
-                        $contactDns = rtrim($contactDns, ",");
-
-                        if ($contactDns !== '') {
-                            try {
-                                $resContact = $this->db->query(
-                                    "SELECT contact_id FROM contact WHERE contact_ldap_dn IN (" . $contactDns . ")"
-                                );
-                            } catch (\PDOException $e) {
-                                $msg[] = "Error in getting contact id from members.";
-                                throw $e;
-                                continue;
-                            }
-                            while ($rowContact = $resContact->fetch()) {
-                                try {
-                                    $insertStmt = $this->db->prepare(
-                                        "INSERT INTO contactgroup_contact_relation
-                                        (contactgroup_cg_id, contact_contact_id)
-                                        VALUES (:cgId, :contactId)"
-                                    );
-                                    $insertStmt->bindValue(':cgId', $row['cg_id'], \PDO::PARAM_INT);
-                                    $insertStmt->bindValue(':contactId', $rowContact['contact_id'], \PDO::PARAM_INT);
-                                    $insertStmt->execute();
-                                } catch (\PDOException $e) {
-                                    $msg[] = "Error insert relation between contactgroup " . $row['cg_id'] .
-                                        " and contact " . $rowContact['contact_id'];
-                                    throw $e;
-                                }
-                            }
-                        }
-                    }
-                    $updateTime = $this->db->prepare(
-                        "UPDATE `options` SET `value` = :currentTime
-                        WHERE `key` = 'ldap_last_acl_update'"
-                    );
-                    $updateTime->bindValue(':currentTime', time(), \PDO::PARAM_INT);
-                    $updateTime->execute();
-                    $this->db->commit();
-                } catch (\PDOException $e) {
-                    $this->db->rollBack();
-                }
-            } else {
+            if ($connectionResult === false) {
                 $msg[] = "Unable to connect to LDAP server.";
+                continue;
+            }
+
+            $res = $this->db->prepare(
+                "SELECT cg_id, cg_name, cg_ldap_dn FROM contactgroup " .
+                "WHERE cg_type = 'ldap' AND ar_id = :arId"
+            );
+            $res->bindValue(':arId', $ldapRow['ar_id'], \PDO::PARAM_INT);
+            $res->execute();
+
+            // insert groups from ldap into centreon
+            $registeredGroupsFromDB = $res->fetchAll();
+            $registeredGroups = [];
+            foreach ($registeredGroupsFromDB as $registeredGroupFromDB) {
+                $registeredGroups[] = $registeredGroupFromDB['cg_name'];
+            }
+
+            $ldapGroups = $ldapConn->listOfGroups();
+
+            foreach ($ldapGroups as $ldapGroup) {
+                if (!in_array($ldapGroup['name'], $registeredGroups)) {
+                    $this->insertLdapGroupByNameAndDn(
+                        (int) $ldapRow['ar_id'],
+                        $ldapGroup['name'],
+                        $ldapGroup['dn']
+                    );
+                }
+            }
+
+            $res = $this->db->prepare(
+                "SELECT cg_id, cg_name, cg_ldap_dn FROM contactgroup " .
+                "WHERE cg_type = 'ldap' AND ar_id = :arId"
+            );
+            $res->bindValue(':arId', $ldapRow['ar_id'], \PDO::PARAM_INT);
+            $res->execute();
+
+            $this->db->beginTransaction();
+            try {
+                while ($row = $res->fetch()) {
+                    // Test is the group has not been moved or deleted in ldap
+                    if ((empty($row['cg_ldap_dn']) || false === $ldapConn->getEntry($row['cg_ldap_dn']))
+                        && ldap_errno($ldapConn->getDs()) != 3
+                    ) {
+                        $dn = $ldapConn->findGroupDn($row['cg_name']);
+                        if (false === $dn && ldap_errno($ldapConn->getDs()) != 3) {
+                            // Delete the ldap group in contactgroup
+                            try {
+                                $stmt = $this->db->prepare(
+                                    "DELETE FROM contactgroup WHERE cg_id = :cgId"
+                                );
+                                $stmt->bindValue('cgId', $row['cg_id'], \PDO::PARAM_INT);
+                                $stmt->execute();
+                            } catch (\PDOException $e) {
+                                $msg[] = "Error processing delete contactgroup request of ldap group : " .
+                                    $row['cg_name'];
+                                throw $e;
+                            }
+                            continue;
+                        } else { // Update the ldap group dn in contactgroup
+                            try {
+                                $updateDnStatement = $this->db->prepare(
+                                    "UPDATE contactgroup SET cg_ldap_dn = :cg_dn WHERE cg_id = :cg_id"
+                                );
+                                $updateDnStatement->bindValue(':cg_dn', $dn, \PDO::PARAM_STR);
+                                $updateDnStatement->bindValue(':cg_id', $row['cg_id'], \PDO::PARAM_INT);
+                                $updateDnStatement->execute();
+                                $row['cg_ldap_dn'] = $dn;
+                            } catch (\PDOException $e) {
+                                $msg[] = "Error processing update contactgroup request of ldap group : " .
+                                    $row['cg_name'];
+                                throw $e;
+                            }
+                        }
+                    }
+                    $members = $ldapConn->listUserForGroup($row['cg_ldap_dn']);
+
+                    // Refresh Users Groups.
+                    $deleteStmt = $this->db->prepare(
+                        "DELETE FROM contactgroup_contact_relation
+                        WHERE contactgroup_cg_id = :cgId"
+                    );
+                    $deleteStmt->bindValue(':cgId', $row['cg_id'], \PDO::PARAM_INT);
+                    $deleteStmt->execute();
+                    $contactDns = '';
+                    foreach ($members as $member) {
+                        $contactDns .= $this->db->quote($member) . ',';
+                    }
+                    $contactDns = rtrim($contactDns, ",");
+
+                    if ($contactDns !== '') {
+                        try {
+                            $resContact = $this->db->query(
+                                "SELECT contact_id FROM contact WHERE contact_ldap_dn IN (" . $contactDns . ")"
+                            );
+                        } catch (\PDOException $e) {
+                            $msg[] = "Error in getting contact id from members.";
+                            throw $e;
+                            continue;
+                        }
+                        while ($rowContact = $resContact->fetch()) {
+                            try {
+                                $insertStmt = $this->db->prepare(
+                                    "INSERT INTO contactgroup_contact_relation
+                                    (contactgroup_cg_id, contact_contact_id)
+                                    VALUES (:cgId, :contactId)"
+                                );
+                                $insertStmt->bindValue(':cgId', $row['cg_id'], \PDO::PARAM_INT);
+                                $insertStmt->bindValue(':contactId', $rowContact['contact_id'], \PDO::PARAM_INT);
+                                $insertStmt->execute();
+                            } catch (\PDOException $e) {
+                                $msg[] = "Error insert relation between contactgroup " . $row['cg_id'] .
+                                    " and contact " . $rowContact['contact_id'];
+                                throw $e;
+                            }
+                        }
+                    }
+                }
+                $updateTime = $this->db->prepare(
+                    "UPDATE `options` SET `value` = :currentTime
+                    WHERE `key` = 'ldap_last_acl_update'"
+                );
+                $updateTime->bindValue(':currentTime', time(), \PDO::PARAM_INT);
+                $updateTime->execute();
+                $this->db->commit();
+            } catch (\PDOException $e) {
+                $this->db->rollBack();
             }
         }
         return $msg;

--- a/www/class/centreonContactgroup.class.php
+++ b/www/class/centreonContactgroup.class.php
@@ -432,7 +432,9 @@ class CentreonContactgroup
             try {
                 while ($row = $res->fetch()) {
                     // Test is the group has not been moved or deleted in ldap
-                    if ((empty($row['cg_ldap_dn']) || false === $ldapConn->getEntry($row['cg_ldap_dn']))
+                    if (
+                        (empty($row['cg_ldap_dn']) || false === $ldapConn->getEntry($row['cg_ldap_dn']))
+                        && $ldapConn->getDs() instanceof \LDAP\Connection
                         && ldap_errno($ldapConn->getDs()) != 3
                     ) {
                         $dn = $ldapConn->findGroupDn($row['cg_name']);

--- a/www/class/centreonContactgroup.class.php
+++ b/www/class/centreonContactgroup.class.php
@@ -434,7 +434,7 @@ class CentreonContactgroup
                     // Test is the group has not been moved or deleted in ldap
                     if (
                         (empty($row['cg_ldap_dn']) || false === $ldapConn->getEntry($row['cg_ldap_dn']))
-                        && $ldapConn->getDs() instanceof \LDAP\Connection
+                        && is_resource($ldapConn->getDs())
                         && ldap_errno($ldapConn->getDs()) != 3
                     ) {
                         $dn = $ldapConn->findGroupDn($row['cg_name']);

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -824,7 +824,7 @@ class CentreonLDAP
     private function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
     {
         if ($this->ds  instanceof \LDAP\Connection) {
-            if ($errno === 2&& ldap_errno($this->ds) === 4) {
+            if ($errno === 2 && ldap_errno($this->ds) === 4) {
                 /*
                 Silencing : 'size limit exceeded' warnings in the logs
                 As the $searchLimit value needs to be consistent with the ldap server's configuration and

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -198,6 +198,10 @@ class CentreonLDAP
             $this->debug('LDAP Connect : trying url : ' . $url);
             $this->setErrorHandler();
             $this->ds = ldap_connect($url);
+            if (!$this->ds  instanceof \LDAP\Connection) {
+                $this->debug('LDAP Connection failed to : ' . $url);
+                continue;
+            }
             ldap_set_option($this->ds, LDAP_OPT_REFERRALS, 0);
             $protocol_version = 3;
             if (isset($ldap['info']['protocol_version'])) {
@@ -323,6 +327,10 @@ class CentreonLDAP
         $this->setErrorHandler();
         $filter = preg_replace('/%s/', $this->replaceFilter($group), $this->groupSearchInfo['filter']);
         $result = ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
+        if ($result === false) {
+            $this->debug("LDAP Search : cannot retrieve group DN of " . $group);
+            return false;
+        }
         $entries = ldap_get_entries($this->ds, $result);
         restore_error_handler();
         if ($entries['count'] === 0) {
@@ -346,6 +354,9 @@ class CentreonLDAP
         $filter = preg_replace('/%s/', $pattern, $this->groupSearchInfo['filter']);
         $result = @ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
         if (false === $result) {
+            $this->debug(
+                "LDAP Search : cannot retrieve list of groups using filter " . $this->groupSearchInfo['filter']
+            );
             restore_error_handler();
             return [];
         }
@@ -379,6 +390,12 @@ class CentreonLDAP
         $this->setErrorHandler();
         $filter = preg_replace('/%s/', $pattern, $this->userSearchInfo['filter']);
         $result = ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
+        if ($result === false) {
+            $this->debug(
+                "LDAP Search : cannot retrieve list of users using filter " . $this->groupSearchInfo['filter']
+            );
+            return [];
+        }
         $entries = ldap_get_entries($this->ds, $result);
         $nbEntries = $entries['count'];
         $list = array();
@@ -404,6 +421,9 @@ class CentreonLDAP
         }
         $result = ldap_read($this->ds, $dn, '(objectClass=*)', $attr);
         if ($result === false) {
+            $this->debug(
+                "LDAP Search : cannot retrieve entry with DN " . $dn
+            );
             restore_error_handler();
             return false;
         }
@@ -447,6 +467,9 @@ class CentreonLDAP
             '(' . $this->groupSearchInfo['member'] . '=' . $this->replaceFilter($userdn) . '))';
         $result = @ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
         if (false === $result) {
+            $this->debug(
+                "LDAP Search : cannot list groups of user " . $userdn
+            );
             restore_error_handler();
             return array();
         }
@@ -484,6 +507,9 @@ class CentreonLDAP
             $result = @ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
 
             if (false === $result) {
+                $this->debug(
+                    "LDAP Search : cannot list users of group " . $groupdn
+                );
                 restore_error_handler();
                 return array();
             }
@@ -501,6 +527,9 @@ class CentreonLDAP
             $result = @ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
 
             if (false === $result) {
+                $this->debug(
+                    "LDAP Search : cannot list users of group " . $groupdn
+                );
                 restore_error_handler();
                 return array();
             }
@@ -794,21 +823,24 @@ class CentreonLDAP
      */
     private function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
     {
-        if ($errno === 2 && ldap_errno($this->ds) === 4) {
-            /*
-            Silencing : 'size limit exceeded' warnings in the logs
-            As the $searchLimit value needs to be consistent with the ldap server's configuration and
-            as the size limit error thrown is not related with the results.
-                ldap_errno : 4 = LDAP_SIZELIMIT_EXCEEDED
-                $errno     : 2 = PHP_WARNING
-            */
-            $this->debug("LDAP Error : Size limit exceeded error. This error was not added to php log. "
-                . "Kindly, check your LDAP server's configuration and your Centreon's LDAP parameters.");
-            return true;
+        if ($this->ds  instanceof \LDAP\Connection) {
+            if ($errno === 2&& ldap_errno($this->ds) === 4) {
+                /*
+                Silencing : 'size limit exceeded' warnings in the logs
+                As the $searchLimit value needs to be consistent with the ldap server's configuration and
+                as the size limit error thrown is not related with the results.
+                    ldap_errno : 4 = LDAP_SIZELIMIT_EXCEEDED
+                    $errno     : 2 = PHP_WARNING
+                */
+                $this->debug("LDAP Error : Size limit exceeded error. This error was not added to php log. "
+                    . "Kindly, check your LDAP server's configuration and your Centreon's LDAP parameters.");
+                return true;
+            }
+
+            // throwing all errors
+            $this->debug("LDAP Error : " . ldap_error($this->ds));
         }
 
-        // throwing all errors
-        $this->debug("LDAP Error : " . ldap_error($this->ds));
         return false;
     }
 

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -198,7 +198,7 @@ class CentreonLDAP
             $this->debug('LDAP Connect : trying url : ' . $url);
             $this->setErrorHandler();
             $this->ds = ldap_connect($url);
-            if (!$this->ds  instanceof \LDAP\Connection) {
+            if (!$this->ds instanceof \LDAP\Connection) {
                 $this->debug('LDAP Connection failed to : ' . $url);
                 continue;
             }
@@ -823,7 +823,7 @@ class CentreonLDAP
      */
     private function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
     {
-        if ($this->ds  instanceof \LDAP\Connection) {
+        if ($this->ds instanceof \LDAP\Connection) {
             if ($errno === 2 && ldap_errno($this->ds) === 4) {
                 /*
                 Silencing : 'size limit exceeded' warnings in the logs

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -198,7 +198,7 @@ class CentreonLDAP
             $this->debug('LDAP Connect : trying url : ' . $url);
             $this->setErrorHandler();
             $this->ds = ldap_connect($url);
-            if (!$this->ds instanceof \LDAP\Connection) {
+            if (!is_resource($this->ds)) {
                 $this->debug('LDAP Connection failed to : ' . $url);
                 continue;
             }
@@ -267,7 +267,7 @@ class CentreonLDAP
     /**
      * Send back the ldap resource
      *
-     * @return \LDAP\Connection|resource
+     * @return resource
      */
     public function getDs()
     {
@@ -823,7 +823,7 @@ class CentreonLDAP
      */
     private function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
     {
-        if ($this->ds instanceof \LDAP\Connection) {
+        if (is_resource($this->ds)) {
             if ($errno === 2 && ldap_errno($this->ds) === 4) {
                 /*
                 Silencing : 'size limit exceeded' warnings in the logs


### PR DESCRIPTION
## Description

add debug and avoid ldap failures

Handle following error : 
`[15-Sep-2022 10:31:20 GMT] CRITICAL: Uncaught Error: ldap_get_entries(): Argument #2 ($result) must be of type resource, bool given {"exception":"[object] (TypeError(code: 0):
ldap_get_entries(): Argument #2 ($result) must be of type resource, bool given at /usr/share/centreon/www/class/centreonLDAP.class.php:326)"}`

Add debug to avoid to be blind when errors happen

**Fixes** MON-15115

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)