### PR TITLE
enh(ResourcesListing):Use upper and lower case typography allows better reading/distinction and understanding information

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/Status.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Status.tsx
@@ -129,13 +129,16 @@ const StatusColumn = ({
 
     const statusName = row.status.name;
 
+    const lowerLetter = (name: string): string =>
+      name.charAt(0) + name.slice(1).toLocaleLowerCase();
+
     return (
       <div className={classes.statusColumn}>
         {isHovered ? (
           <StatusColumnOnHover actions={actions} row={row} />
         ) : (
           <StatusChip
-            label={t(statusName)}
+            label={lowerLetter(t(statusName))}
             severityCode={row.status.severity_code}
             style={{ height: 20, width: '100%' }}
           />


### PR DESCRIPTION
use lowerCase for status name of resources status 

**screens**

![resoursoo](https://user-images.githubusercontent.com/97687698/196223469-b0f41c33-9c9b-4c85-8195-6caa09b71289.PNG)
