### PR TITLE
fix(smarty): fix php warning in poller configuration form

### DIFF
--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -29,14 +29,14 @@
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_ip_address"> {$form.ns_ip_address.label}</td><td class="FormRowValue">{$form.ns_ip_address.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="localhost"> {$form.localhost.label}</td><td class="FormRowValue">{$form.localhost.html}</td></tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="is_default"> {$form.is_default.label}</td><td class="FormRowValue">{$form.is_default.html}</td></tr>
-        {if $form.remote_id.label}
+        {if isset($form.remote_id)}
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="remote_id"> {$form.remote_id.label}</td><td class="FormRowValue">{$form.remote_id.html}</td></tr>
         <tr class="list_two">
             <td class="FormRowField"><img class="helpTooltip" name="remote_additional_id"> {$form.remote_additional_id.label}</td>
             <td class="FormRowValue">{$form.remote_additional_id.html}</td>
         </tr>
         {/if}
-        {if $form.ssh_port.label}
+        {if isset($form.ssh_port)}
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ssh_port"> {$form.ssh_port.label}</td><td class="FormRowValue">{$form.ssh_port.html}</td></tr>
         {/if}
         {if isset($form.header.Remote_Configuration)}
@@ -64,7 +64,7 @@
                 <td class="FormRowValue">{$form.gorgone_port.html}</td>
             </tr>
 
-            {if $form.remote_server_use_as_proxy.label}
+            {if isset($form.remote_server_use_as_proxy)}
             <tr class="list_one">
                 <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
                 <td class="FormRowValue">{$form.remote_server_use_as_proxy.html}</td>


### PR DESCRIPTION
## Description

This PR intends to fix php warning in poller configuration form due to a wrong way to check variable existence.

**Fixes** # MON-15471

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

In Configuration > Pollers:
- Click on your Central
- When the update form displays, no php warning should occurs.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
