### PR TITLE
Fix(security): Sanitize queries in the list of service groups

### DIFF
--- a/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -59,8 +59,8 @@ $conditionStr = "";
 $sgStrParams = [];
 if (!$acl->admin && $sgString) {
     $sgStrList = explode(',', $sgString);
-    foreach ($sgStrList as $index => $sg_id) {
-        $sgStrParams[':sg_' . $index] = $sg_id;
+    foreach ($sgStrList as $index => $sgId) {
+        $sgStrParams[':sg_' . $index] = (int) str_replace("'", "", $sgId);
     }
     $queryParams = implode(',', array_keys($sgStrParams));
 
@@ -71,22 +71,20 @@ if (!$acl->admin && $sgString) {
     }
 }
 
-if ($search) {
-    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup " .
-        "WHERE (sg_name LIKE :search " .
-        "OR sg_alias LIKE :search) " . $conditionStr .
+if ($search != "") {
+    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate" .
+        " FROM servicegroup WHERE (sg_name LIKE :search  OR sg_alias LIKE :search) " . $conditionStr .
         " ORDER BY sg_name LIMIT :offset, :limit");
 
     $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
 } else {
-    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup "
-        . $conditionStr .
-        " ORDER BY sg_name LIMIT :offset, :limit");
+    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate" .
+        " FROM servicegroup " . $conditionStr . " ORDER BY sg_name LIMIT :offset, :limit");
 }
-foreach ($sgStrParams as $key => $sg_id) {
-    $statement->bindValue($key, str_replace("'", "", $sg_id), \PDO::PARAM_INT);
+foreach ($sgStrParams as $key => $sgId) {
+    $statement->bindValue($key, $sgId, \PDO::PARAM_INT);
 }
-$statement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
 $statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
 $statement->execute();
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();

--- a/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -64,14 +64,14 @@ if (!$acl->admin && $sgString) {
     }
     $queryParams = implode(',', array_keys($sgStrParams));
 
-    if ($search) {
+    if ($search !== '') {
         $conditionStr = "AND sg_id IN (" . $queryParams . ")";
     } else {
         $conditionStr = "WHERE sg_id IN (" . $queryParams . ")";
     }
 }
 
-if ($search != "") {
+if ($search !== '') {
     $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate" .
         " FROM servicegroup WHERE (sg_name LIKE :search  OR sg_alias LIKE :search) " . $conditionStr .
         " ORDER BY sg_name LIMIT :offset, :limit");

--- a/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -55,19 +55,40 @@ if (isset($_POST['searchSG']) || isset($_GET['searchSG'])) {
     $search = $centreon->historySearch[$url]["search"] ?? null;
 }
 
-if ($search) {
-    $rq = "SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup " .
-        "WHERE (sg_name LIKE '%" . $search . "%' " .
-        "OR sg_alias LIKE '%" . $search . "%') " .
-        $acl->queryBuilder('AND', 'sg_id', $sgString) .
-        " ORDER BY sg_name LIMIT " . $num * $limit . ", " . $limit;
-} else {
-    $rq = "SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup " .
-        $acl->queryBuilder('WHERE', 'sg_id', $sgString) .
-        " ORDER BY sg_name LIMIT " . $num * $limit . ", " . $limit;
+$conditionStr = "";
+$sgStrParams = [];
+if (!$acl->admin && $sgString) {
+    $sgStrList = explode(',', $sgString);
+    foreach ($sgStrList as $index => $sg_id) {
+        $sgStrParams[':sg_' . $index] = $sg_id;
+    }
+    $queryParams = implode(',', array_keys($sgStrParams));
+
+    if ($search) {
+        $conditionStr = "AND sg_id IN (" . $queryParams . ")";
+    } else {
+        $conditionStr = "WHERE sg_id IN (" . $queryParams . ")";
+    }
 }
 
-$dbResult = $pearDB->query($rq);
+if ($search) {
+    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup " .
+        "WHERE (sg_name LIKE :search " .
+        "OR sg_alias LIKE :search) " . $conditionStr .
+        " ORDER BY sg_name LIMIT :offset, :limit");
+
+    $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
+} else {
+    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup "
+        . $conditionStr .
+        " ORDER BY sg_name LIMIT :offset, :limit");
+}
+foreach ($sgStrParams as $key => $sg_id) {
+    $statement->bindValue($key, str_replace("'", "", $sg_id), \PDO::PARAM_INT);
+}
+$statement->bindValue(':offset', $num * $limit, \PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
+$statement->execute();
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
 include "./include/common/checkPagination.php";
@@ -101,7 +122,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 $elemArr = array();
 $centreonToken = createCSRFToken();
 
-for ($i = 0; $sg = $dbResult->fetch(); $i++) {
+for ($i = 0; $sg = $statement->fetch(\PDO::FETCH_ASSOC); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $sg['sg_id'] . "]");
     $moptions = "";
     if ($sg["sg_activate"]) {


### PR DESCRIPTION
## Description
Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code


**Fixes** # MON-15379

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. navigate to service groups listing page
2. add multiple sgroups
3. check if sgroups are still visible for both (admin and non admin user)
4. check if there is no error in log file
5. 
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
