### PR TITLE
Mon 15269 order roles conditions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8185,7 +8185,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.10.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#389d772e475f2577f8a3e7cc6096b3cc4332d133",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#7f7709e4b772fe0620d30f153d01b77a866c095b",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.3",
@@ -28374,7 +28374,7 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#389d772e475f2577f8a3e7cc6096b3cc4332d133",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#7f7709e4b772fe0620d30f153d01b77a866c095b",
       "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
       "requires": {
         "@dnd-kit/core": "^5.0.3",

--- a/setupTest.js
+++ b/setupTest.js
@@ -17,7 +17,7 @@ import fetchMock from 'jest-fetch-mock';
 
 window.ResizeObserver = ResizeObserver;
 
-jest.setTimeout(10000);
+jest.setTimeout(15000);
 
 dayjs.extend(localizedFormat);
 dayjs.extend(utcPlugin);

--- a/www/front_src/src/Authentication/Openid/Form/inputs.ts
+++ b/www/front_src/src/Authentication/Openid/Form/inputs.ts
@@ -250,6 +250,8 @@ const rolesMapping: Array<InputProps> = [
         claimValue: '',
       },
       deleteLabel: labelDeleteRelation,
+      getSortable: (values: FormikValues): boolean =>
+        prop('applyOnlyFirstRole', values?.rolesMapping),
     },
     group: labelRolesMapping,
     label: labelDefineRelationBetweenRolesAndAcl,

--- a/www/front_src/src/Authentication/Openid/models.ts
+++ b/www/front_src/src/Authentication/Openid/models.ts
@@ -12,11 +12,13 @@ export interface NamedEntity {
 export interface RolesRelation {
   accessGroup: NamedEntity;
   claimValue: string;
+  priority: number;
 }
 
 export interface RolesRelationToAPI {
   access_group_id: number;
   claim_value: string;
+  priority: number;
 }
 
 export interface GroupsRelation {

--- a/www/front_src/src/Authentication/api/adapters.ts
+++ b/www/front_src/src/Authentication/api/adapters.ts
@@ -109,9 +109,10 @@ const adaptRolesRelationsToAPI = (
   relations: Array<RolesRelation>,
 ): Array<RolesRelationToAPI> =>
   map(
-    ({ claimValue, accessGroup }) => ({
+    ({ claimValue, accessGroup, priority }) => ({
       access_group_id: accessGroup.id,
       claim_value: claimValue,
+      priority,
     }),
     relations,
   );

--- a/www/front_src/src/Authentication/api/decoders.ts
+++ b/www/front_src/src/Authentication/api/decoders.ts
@@ -79,11 +79,13 @@ const rolesRelation = JsonDecoder.object<RolesRelation>(
   {
     accessGroup: getNamedEntityDecoder('Access group'),
     claimValue: JsonDecoder.string,
+    priority: JsonDecoder.number,
   },
   'Role Relation',
   {
     accessGroup: 'access_group',
     claimValue: 'claim_value',
+    priority: 'priority',
   },
 );
 


### PR DESCRIPTION
## Description

**Make the role mapping `FieldsTable` sortable on OIDC configuration form.**

This PR add the make the role mapping `FieldsTable` from OIDC configuration form sortable when `Apply only first` role is activated.

https://user-images.githubusercontent.com/6154460/196887724-dfaf583f-a208-46ea-b246-efb3fdf03075.mp4

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to `centreon-dev-eco-system` then run `npm run start:storybook`,
- Go to `[centreon portail](http://localhost:4000/)`,
- Open the `Administration` menu then click on `Authentication`,
- Go to Openid connect configuration tab,
- Open Role mapping panel then active the switch `Apply only first role`
- Now you can add roles then change the order of the fields table items.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
