### PR TITLE
MON-14992-in-performance-graphs-missing-space-between-buttons

### DIFF
--- a/www/include/monitoring/downtime/template/listDowntime.ihtml
+++ b/www/include/monitoring/downtime/template/listDowntime.ihtml
@@ -29,7 +29,7 @@
 <table class="ToolbarTable table">
 	<tr class="ToolbarTR">
         <td>
-            {if $msgs2}<a class="btc bt_success" href="{$msgs2.addL2}">{$msgs2.addT2}</a>{/if}
+            {if $msgs2}<a class="btc bt_success mr-1" href="{$msgs2.addL2}">{$msgs2.addT2}</a>{/if}
             {if $nb_downtime_svc && $msgs2}<input type="submit" name="submit2" value="{$cancel}" class="btc bt_danger" onclick="doAction('select[name=\'o1\']', 'cs','{$msgs2.delConfirm}')">{/if}
         </td>
         {php}

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -107,7 +107,7 @@ const templateGraph = ({ graphId, graphType, graphTitle, hostId, serviceId }) =>
                 <span>${graphTitle}</span>
                 {/literal}
                 {if $topologyAccess.2040101 || $admin == 1}
-                <a class="btc bt_info actions-simple" data-href="./main.get.php?p=2040101">
+                <a class="btc bt_info actions-simple mr-1" data-href="./main.get.php?p=2040101">
                     {t}Split chart{/t}
                 </a>
                 {/if}


### PR DESCRIPTION
## Description
Adding margins between buttons into performances graph header.
Adding margins between buttons into dowtime buttons.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
