### PR TITLE
fix wrong reload acl button position

### DIFF
--- a/www/include/options/accessLists/reloadACL/reloadACL.ihtml
+++ b/www/include/options/accessLists/reloadACL/reloadACL.ihtml
@@ -26,7 +26,7 @@
 			<td class="ListColLeft">{if $sd.admin == 1}<img src='./img/icons/admin.png' class="ico-18">{else}<img src='./img/icons/user.png' class="ico-18">{/if}&nbsp;&nbsp;<a href='./main.php?p=60302&o=w&contact_id={$sd.user_id}'>{$sd.user_alias}</a></td>
 			<td class="ListColCenter">{$sd.ip_address}</td>
 			<td class="ListColCenter"><a href='./main.php?p={$sd.current_page}'>{$sd.topology_name}</a></td>
-			<td class="ListColCenter" align=right>{$sd.actions}</td>
+			<td class="ListColCenter" align=right><a href="./main.php?p={$p}&o=r">{php}displaySvg("www/img/icons/refresh.svg","var(--help-tool-tip-icon-fill-color)",18,18){/php}</a></td>
 		</tr>
 		{/foreach}
 	</table>

--- a/www/include/options/accessLists/reloadACL/reloadACL.php
+++ b/www/include/options/accessLists/reloadACL/reloadACL.php
@@ -126,13 +126,6 @@ while ($r = $res->fetch()) {
         $session_data[$cpt]["ip_address"] = $r["ip_address"];
         $session_data[$cpt]["current_page"] = $r["current_page"] . $rCP["topology_url_opt"];
         $session_data[$cpt]["topology_name"] = _($rCP["topology_name"]);
-        $session_data[$cpt]["actions"] = "<a href='./main.php?p=" . $p . "&o=r'>" .
-            displaySvg(
-                "www/img/icons/refresh.svg",
-                "var(--help-tool-tip-icon-fill-color)",
-                18,
-                18
-            ) . "</a>";
         $selectedElements = $form->addElement('checkbox', "select[" . $r['user_id'] . "]");
         $session_data[$cpt]["checkbox"] = $selectedElements->toHtml();
         $cpt++;


### PR DESCRIPTION
## Description

jira: MON-15591

**Fixes** #11625 (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

without this PR: 

- connect a non admin user to your centreon
- use private mode or another web brower to log in with an admin user
- with your admin user, go to the administration -> acl  -> reload acl menu
- you'll notice that the reload acl icon is displayed at the top of the page instead of being in the right column of the table

with this patch, the icon is now displayed where it should be

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
