### PR TITLE
Fix typo

### DIFF
--- a/www/class/centreonPurgeEngine.class.php
+++ b/www/class/centreonPurgeEngine.class.php
@@ -200,7 +200,7 @@ class CentreonPurgeEngine
         foreach ($this->tablesToPurge[$table]['partitions'] as $partName => $partTimestamp) {
             if ($partTimestamp < $this->tablesToPurge[$table]['retention']) {
                 $dropPartitions[] = '`' . $partName . '`';
-                echo "[" . date(DATE_RFC822) . "] Partition will be delete " . $partName . "\n";
+                echo "[" . date(DATE_RFC822) . "] Partition will be deleted " . $partName . "\n";
             }
         }
 


### PR DESCRIPTION
## Description

Fix typo, but still leave the word untouched to be detected by grep. I was considering changing the wording to "Partition will be purged" but that will not be picked up by monitoring tools based on grep.
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Run 
```
php /usr/share/centreon/cron/centstorage_purge.php
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
