### PR TITLE
fix(export) fix serviceTemplate cache reset when export

### DIFF
--- a/www/class/config-generate/servicetemplate.class.php
+++ b/www/class/config-generate/servicetemplate.class.php
@@ -251,6 +251,7 @@ class ServiceTemplate extends AbstractService
         $this->current_service_description = null;
         $this->current_service_id = null;
         $this->loop_stpl = array();
+        $this->service_cache = [];
         parent::reset();
     }
 }


### PR DESCRIPTION
## Description

Fix error when exporting two pollers at the same time sharing the same severity
![export_pollers_with criticity](https://user-images.githubusercontent.com/88387848/196946511-082c6559-e78e-41a4-8f22-2795f1d372ea.jpg)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
