### PR TITLE
MON-15625 fix widget single metric removed with apt clean

### DIFF
--- a/ci/debian/control
+++ b/ci/debian/control
@@ -54,7 +54,8 @@ Depends:
     centreon-widget-live-top10-memory-usage,
     centreon-widget-service-monitoring,
     centreon-widget-servicegroup-monitoring,
-    centreon-widget-tactical-overview
+    centreon-widget-tactical-overview,
+    centreon-widget-single-metric
 Description: The package contains base configuration for Centreon Engine and Centreon Broker.
  It provides one default monitoring engine running with Centreon Engine and
  two Centreon Broker instances to store real-time information in database and
@@ -62,7 +63,7 @@ Description: The package contains base configuration for Centreon Engine and Cen
 
 Package: centreon-poller
 Architecture: all
-Depends: 
+Depends:
     centreon-common (>= ${centreon:version}~),
     centreon-poller-centreon-engine (>= ${centreon:version}~),
     centreon-trap (>= ${centreon:version}~),
@@ -92,7 +93,7 @@ Depends:
     monitoring-plugins-basic
 Description: This package add rights and default directories for a poller
  managed by Centreon. This includes the default central poller.
- 
+
 Package: centreon-web-common
 Architecture: all
 Depends:


### PR DESCRIPTION
## Description

Add centreon-widget-single-metric as dependency of centreon-central and resolves MON-15625 (https://centreon.atlassian.net/browse/MON-15625)

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
