### PR TITLE
enh(resources): in detail, fetch downtime only if needed

### DIFF
--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -152,11 +152,13 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      */
     public function enrichHostWithDetails(ResourceEntity $resource): void
     {
-        $downtimes = $this->monitoringRepository->findDowntimes(
-            $resource->getId(),
-            0
-        );
-        $resource->setDowntimes($downtimes);
+        if ($resource->getInDowntime() === true) {
+            $downtimes = $this->monitoringRepository->findDowntimes(
+                $resource->getId(),
+                0
+            );
+            $resource->setDowntimes($downtimes);
+        }
 
         if ($resource->getAcknowledged()) {
             $acknowledgements = $this->monitoringRepository->findAcknowledgements(
@@ -196,11 +198,13 @@ class ResourceService extends AbstractCentreonService implements ResourceService
             throw new ResourceException(_('Parent of resource type service cannot be null'));
         }
 
-        $downtimes = $this->monitoringRepository->findDowntimes(
-            $resource->getParent()->getId(),
-            $resource->getId()
-        );
-        $resource->setDowntimes($downtimes);
+        if ($resource->getInDowntime() === true) {
+            $downtimes = $this->monitoringRepository->findDowntimes(
+                $resource->getParent()->getId(),
+                $resource->getId()
+            );
+            $resource->setDowntimes($downtimes);
+        }
 
         if ($resource->getAcknowledged()) {
             $acknowledgements = $this->monitoringRepository->findAcknowledgements(
@@ -236,11 +240,13 @@ class ResourceService extends AbstractCentreonService implements ResourceService
      */
     public function enrichMetaServiceWithDetails(ResourceEntity $resource): void
     {
-        $downtimes = $this->monitoringRepository->findDowntimes(
-            $resource->getHostId(),
-            $resource->getServiceId()
-        );
-        $resource->setDowntimes($downtimes);
+        if ($resource->getInDowntime() === true) {
+            $downtimes = $this->monitoringRepository->findDowntimes(
+                $resource->getHostId(),
+                $resource->getServiceId()
+            );
+            $resource->setDowntimes($downtimes);
+        }
 
         if ($resource->getAcknowledged()) {
             $acknowledgements = $this->monitoringRepository->findAcknowledgements(


### PR DESCRIPTION
## Description

This PR intends to only fetch downtimes for resources if needed !

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
See Jira ticket for this

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
