### PR TITLE
fix(conf) fix poller pages display depending on acls

### DIFF
--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -38,6 +38,11 @@ if (!isset($centreon)) {
     exit();
 }
 
+if (! $centreon->user->access->checkAction('create_edit_poller_cfg')) {
+    echo "<div class='msg' align='center'>" . _("You are not allowed to reach this page") . "</div>";
+    exit();
+}
+
 require_once _CENTREON_PATH_ . "/www/class/centreon-config/centreonMainCfg.class.php";
 
 $objMain = new CentreonMainCfg();

--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -49,7 +49,7 @@
         <tr class="ToolbarTR">
             <td>
                 {if !$isRemote}
-                    {if $mode_access == 'w' && $can_create_edit == 1}
+                    {if $can_create_edit == 1}
                         <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" isreact="true" target="_top">
                             {$wizardAddBtn.icon} {$wizardAddBtn.text}
                         </a>
@@ -63,17 +63,15 @@
                              {$exportBtn.icon} {$exportBtn.text}
                          </button>
                     {/if}
-                    {if $mode_access == 'w'}
-                        {if $can_create_edit == 1}
-                            <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
-                                {$duplicateBtn.icon} {$duplicateBtn.text}
-                            </button>
-                        {/if}
-                        {if $can_delete == 1}
-                            <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
-                                {$deleteBtn.icon} {$deleteBtn.text}
-                            </button>
-                        {/if}
+                    {if $can_create_edit == 1}
+                        <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
+                            {$duplicateBtn.icon} {$duplicateBtn.text}
+                        </button>
+                    {/if}
+                    {if $can_delete == 1}
+                        <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
+                            {$deleteBtn.icon} {$deleteBtn.text}
+                        </button>
                     {/if}
                 {/if}
             </td>
@@ -110,8 +108,10 @@
         {section name=elem loop=$elemArr}
         <tr class={$elemArr[elem].MenuClass}>
             <td class="ListColPicker">{if !$isRemote}{$elemArr[elem].RowMenu_select} {/if}</td>
-            <td class="ListColLeft">{if $mode_access == 'w'}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_name}{if $mode_access == 'w'}</a>{/if}</td>
-            <td class="ListColCenter">{if $mode_access == 'w'}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $mode_access == 'w'}</a>{/if}</td>
+            <td class="ListColLeft">
+                {if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}
+                    {$elemArr[elem].RowMenu_name}{if $can_create_edit == 1}</a>{/if}</td>
+            <td class="ListColCenter">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $can_create_edit == 1}</a>{/if}</td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
             <td class="ListColCenter">
               <span class="badge {if $elemArr[elem].RowMenu_is_runningFlag}service_ok{else}service_critical{/if}">
@@ -131,7 +131,7 @@
             <td class="ListColCenter">{$elemArr[elem].RowMenu_is_default}</td>
             <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
             <td class="ListColCenter">
-                {if $mode_access == 'w' && $elemArr[elem].RowMenu_cfg_id != "" && !$isRemote}
+                {if $can_create_edit == 1 && $elemArr[elem].RowMenu_cfg_id != "" && !$isRemote}
                 <!-- Link for edit poller monitoring engine configuration -->
                 <a href="./main.php?p=60903&o=c&nagios_id={$elemArr[elem].RowMenu_cfg_id}">
                     <img src="./img/icons/edit_conf.png" class="ico-16" title="Edit monitoring engine configuration">
@@ -146,7 +146,7 @@
                 </span>
                 {/if}
             </td>
-            <td class="ListColRight">{if $mode_access == 'w' && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
+            <td class="ListColRight">{if $can_create_edit == 1 && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
         </tr>
         {/section}
     </table>

--- a/www/include/configuration/configServers/listServers.ihtml
+++ b/www/include/configuration/configServers/listServers.ihtml
@@ -108,9 +108,7 @@
         {section name=elem loop=$elemArr}
         <tr class={$elemArr[elem].MenuClass}>
             <td class="ListColPicker">{if !$isRemote}{$elemArr[elem].RowMenu_select} {/if}</td>
-            <td class="ListColLeft">
-                {if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}
-                    {$elemArr[elem].RowMenu_name}{if $can_create_edit == 1}</a>{/if}</td>
+            <td class="ListColLeft">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_name}{if $can_create_edit == 1}</a>{/if}</td>
             <td class="ListColCenter">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $can_create_edit == 1}</a>{/if}</td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
             <td class="ListColCenter">


### PR DESCRIPTION
## Description

Fix buttons display and forms access depending on access acls 'create_edit_poller_cfg'
<img width="160" alt="image" src="https://user-images.githubusercontent.com/88387848/197728304-fc1b478c-4b00-4aba-8617-96820723dc68.png">

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
