### PR TITLE
Issue 11673: unify parseShowParameters between CentreonRtDowntime  and CentreonRtAcknowledgement 

### DIFF
--- a/www/class/centreon-clapi/centreonRtAcknowledgement.class.php
+++ b/www/class/centreon-clapi/centreonRtAcknowledgement.class.php
@@ -176,10 +176,10 @@ class CentreonRtAcknowledgement extends CentreonObject
         }
         $type = $parameters[0];
 
-        return [
+        return array(
             'type' => $type,
             'resource' => $resource,
-        ];
+        );
     }
 
     /**

--- a/www/class/centreon-clapi/centreonRtDowntime.class.php
+++ b/www/class/centreon-clapi/centreonRtDowntime.class.php
@@ -171,7 +171,15 @@ class CentreonRtDowntime extends CentreonObject
      */
     private function parseShowParameters($parameters)
     {
-        list($type, $resource) = explode(';', $parameters);
+        $parameters = explode(';', $parameters);
+        if (count($parameters) === 1) {
+            $resource = '';
+        } elseif (count($parameters) === 2) {
+            $resource = $parameters[1];
+        } else {
+            throw new CentreonClapiException('Bad parameters');
+        }
+        $type = $parameters[0];
 
         return array(
             'type' => $type,


### PR DESCRIPTION
## Description

This PR unifies parseShowParameters between CentreonRtDowntime  and CentreonRtAcknowledgement classes für CLAPI to get rid of the following message:
```
PHP Warning:  Undefined array key 1 in /usr/share/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php on line 174
```
From CentreonRtAcknowledgement  we use the more sophisticated handling to parse parameters into type and ressouce
From CentreonRtDowntime  we use the style to generate the return value

**Partially Fixes** #11673

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use CLAPI to add and remove Host and Service-Downtimes

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

The PR is based on the develop branch because that seems is the current default branch.
