### PR TITLE
enh(UI): adding cypress tests for local authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@visx/threshold": "^2.12.2",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
-        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#enh-update-datatestid-and-id",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -8185,7 +8185,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.10.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#9c83111511f857c2a03fab5650905472640d426f",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#e6f6ffa3ea4b6ddc3d91cbc5eeeae2002bc0c310",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.3",
@@ -27079,6 +27079,58 @@
         "reduce-css-calc": "^1.3.0"
       }
     },
+    "@visx/threshold": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@visx/threshold/-/threshold-2.12.2.tgz",
+      "integrity": "sha512-Wg33MK8t8m12SRO4W3U6pKmVK7mnIcA8EshmlS8vL/VvKBcyOyw1/7FHmBAdSvyfh4zXAmj5WtG0G8lp5TwkYw==",
+      "requires": {
+        "@types/react": "*",
+        "@visx/clip-path": "2.10.0",
+        "@visx/shape": "2.12.2",
+        "classnames": "^2.3.1",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@visx/clip-path": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/clip-path/-/clip-path-2.10.0.tgz",
+          "integrity": "sha512-YIUQstsHKGysyDISOV5p+fMymkUdHCs89nSY/w6TG9EIl8x2jRhrQdojwtCYvjLkPZiZiKa8MBT6fFzsSfGImg==",
+          "requires": {
+            "@types/react": "*",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@visx/group": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/group/-/group-2.10.0.tgz",
+          "integrity": "sha512-DNJDX71f65Et1+UgQvYlZbE66owYUAfcxTkC96Db6TnxV221VKI3T5l23UWbnMzwFBP9dR3PWUjjqhhF12N5pA==",
+          "requires": {
+            "@types/react": "*",
+            "classnames": "^2.3.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "@visx/shape": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-2.12.2.tgz",
+          "integrity": "sha512-4gN0fyHWYXiJ+Ck8VAazXX0i8TOnLJvOc5jZBnaJDVxgnSIfCjJn0+Nsy96l9Dy/bCMTh4DBYUBv9k+YICBUOA==",
+          "requires": {
+            "@types/d3-path": "^1.0.8",
+            "@types/d3-shape": "^1.3.1",
+            "@types/lodash": "^4.14.172",
+            "@types/react": "*",
+            "@visx/curve": "2.1.0",
+            "@visx/group": "2.10.0",
+            "@visx/scale": "2.2.2",
+            "classnames": "^2.3.1",
+            "d3-path": "^1.0.5",
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.5.10"
+          }
+        }
+      }
+    },
     "@visx/tooltip": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@visx/tooltip/-/tooltip-2.8.0.tgz",
@@ -28322,8 +28374,8 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#9c83111511f857c2a03fab5650905472640d426f",
-      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#e6f6ffa3ea4b6ddc3d91cbc5eeeae2002bc0c310",
+      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#enh-update-datatestid-and-id",
       "requires": {
         "@dnd-kit/core": "^5.0.3",
         "@dnd-kit/modifiers": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@visx/threshold": "^2.12.2",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
-    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#enh-update-datatestid-and-id",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",

--- a/tests/e2e/cypress/fixtures/resources/clapi/config-ACL/local-authentication-acl-user.json
+++ b/tests/e2e/cypress/fixtures/resources/clapi/config-ACL/local-authentication-acl-user.json
@@ -1,0 +1,48 @@
+[
+    {
+        "action": "ADD",
+        "object": "CONTACT",
+        "values": "user1;User1;user1@test.com;Centreon!2021User1;0;1;en_US;local"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLGROUP",
+        "values": "ACL Group test;CYPRESS"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLMENU",
+        "values": "acl_menu_test;;"
+    },
+    {
+        "action": "ADDMENU",
+        "object": "ACLGROUP",
+        "values": "ACL Group test;acl_menu_test"
+    },
+    {
+        "action": "SETCONTACT",
+        "object": "ACLGROUP",
+        "values": "ACL Group test;user1"
+    },
+    {
+        "action": "GRANTRW",
+        "object": "ACLMENU",
+        "values": "acl_menu_test;1;Home"
+    },
+    {
+        "action": "GRANTRW",
+        "object": "ACLMENU",
+        "values": "acl_menu_test;1;Monitoring"
+    },
+    {
+        "action": "GRANTRW",
+        "object": "ACLMENU",
+        "values": "acl_menu_test;1;Administration"
+    },
+    {
+        "action": "RELOAD",
+        "object": "ACL",
+        "values": ""
+    }
+
+]

--- a/tests/e2e/cypress/integration/Autologin/01-autologin/index.ts
+++ b/tests/e2e/cypress/integration/Autologin/01-autologin/index.ts
@@ -15,11 +15,16 @@ beforeEach(() => {
     method: 'GET',
     url: '/centreon/include/common/userTimezone.php',
   }).as('getTimeZone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/latest/users/filters/events-view?page=1&limit=100',
+  }).as('getLastesUserFilters');
 });
 
 Given('an administrator is logged in the platform', () => {
   cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true })
     .wait('@getNavigationList')
+    .wait('@getLastesUserFilters')
     .navigateTo({
       page: 'Centreon UI',
       rootItemNumber: 4,

--- a/tests/e2e/cypress/integration/Local-authentication/01-local-authentication.feature
+++ b/tests/e2e/cypress/integration/Local-authentication/01-local-authentication.feature
@@ -1,0 +1,18 @@
+Feature: Local authentication
+    As a user
+    I want to be able to manage password security policies on a Centreon platform for users going through local authentication
+    So that platform administrators can rely on better password practices and and increased security
+    
+Scenario: Default password policy
+    Given an administrator deploying a new Centreon platform
+    When the administrator first open authentication configuration menu
+    Then a default password policy and default excluded users must be preset
+    
+Scenario: Enforcing a password case policy
+    Given an administrator configuring a Centreon platform and an existing user account
+    When the administrator sets a valid password length and a sets all the letter cases
+    Then the existing user can not define a password that does not match the password case policy defined by the administrator and is notified about it
+    
+Scenario: Enforcing a password expiration policy
+Scenario: Enforcing a password blocking policy
+Scenario: Enforcing

--- a/tests/e2e/cypress/integration/Local-authentication/01-local-authentication.feature
+++ b/tests/e2e/cypress/integration/Local-authentication/01-local-authentication.feature
@@ -5,7 +5,7 @@ Feature: Local authentication
     
 Scenario: Default password policy
     Given an administrator deploying a new Centreon platform
-    When the administrator first open authentication configuration menu
+    When the administrator opens the authentication configuration menu
     Then a default password policy and default excluded users must be preset
     
 Scenario: Enforcing a password case policy

--- a/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
+++ b/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
@@ -27,7 +27,7 @@ Given('an administrator deploying a new Centreon platform', () =>
     .wait('@getNavigationList'),
 );
 
-When('the administrator first open authentication configuration menu', () => {
+When('the administrator opens the authentication configuration menu', () => {
   cy.navigateTo({
     page: 'Authentication',
     rootItemNumber: 4,

--- a/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
+++ b/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
@@ -1,0 +1,133 @@
+import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
+
+import {
+  removeContact,
+  initializeConfigACLAndGetLoginPage,
+  checkDefaultsValueForm,
+} from '../common';
+
+before(() => {
+  initializeConfigACLAndGetLoginPage();
+});
+
+beforeEach(() => {
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList',
+  }).as('getNavigationList');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/main.php?p=50104',
+  }).as('getIframeReload');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php',
+  }).as('getTimeZone');
+});
+
+Given('an administrator deploying a new Centreon platform', () =>
+  cy
+    .loginByTypeOfUser({ jsonName: 'admin', preserveToken: true })
+    .wait('@getNavigationList'),
+);
+
+When('the administrator first open authentication configuration menu', () => {
+  cy.navigateTo({
+    page: 'Authentication',
+    rootItemNumber: 4,
+  })
+    .get('div[role="tablist"] button')
+    .eq(0)
+    .contains('Password security policy');
+});
+
+Then(
+  'a default password policy and default excluded users must be preset',
+  () => {
+    checkDefaultsValueForm.forEach(({ selector, value, custom }) => {
+      cy.get(selector).should('exist').and('have.value', value);
+      if (custom) {
+        custom();
+      }
+    });
+    cy.logout().reload();
+  },
+);
+
+Given(
+  'an administrator configuring a Centreon platform and an existing user account',
+  () => {
+    cy.loginByTypeOfUser({ jsonName: 'user', preserveToken: false })
+      .wait('@getNavigationList')
+      .isInProfileMenu('Edit profile')
+      .logout()
+      .reload();
+  },
+);
+
+When(
+  'the administrator sets a valid password length and a sets all the letter cases',
+  () => {
+    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: false })
+      .wait('@getNavigationList')
+      .navigateTo({
+        page: 'Authentication',
+        rootItemNumber: 4,
+      })
+      .get('div[role="tablist"] button')
+      .eq(0)
+      .contains('Password security policy');
+    cy.get('#Minimumpasswordlength').should('exist').and('have.value', '12');
+    cy.get('#Passwordmustcontainlowercase').should(
+      'have.class',
+      'MuiButton-containedPrimary',
+    );
+    cy.get('#Passwordmustcontainuppercase').should(
+      'have.class',
+      'MuiButton-containedPrimary',
+    );
+    cy.get('#Passwordmustcontainnumbers').should(
+      'have.class',
+      'MuiButton-containedPrimary',
+    );
+    cy.get('#Passwordmustcontainspecialcharacters').should(
+      'have.class',
+      'MuiButton-containedPrimary',
+    );
+    cy.get('#Save').click({ force: true });
+    cy.logout().reload();
+  },
+);
+
+Then(
+  'the existing user can not define a password that does not match the password case policy defined by the administrator and is notified about it',
+  () => {
+    cy.loginByTypeOfUser({ jsonName: 'user', preserveToken: false })
+      .wait('@getNavigationList')
+      .isInProfileMenu('Edit profile')
+      .should('be.visible')
+      .visit('/centreon/main.php?p=50104&o=c')
+      .wait('@getTimeZone')
+      .getIframeBody()
+      .find('form')
+      .within(() => {
+        cy.get('#passwd1').should('be.visible').type('azerty');
+        cy.get('#passwd2').should('be.visible').type('azerty');
+      })
+      .find('#validForm input[name="submitC"]')
+      .click();
+    cy.wait(3000);
+    cy.getIframeBody()
+      .find('#Form')
+      .find('#tab1 #passwd1')
+      .parent()
+      .contains(
+        "Your password must be 12 characters long and must contain : uppercase characters, lowercase characters, numbers, special characters among '@$!%*?&'.",
+      );
+  },
+);
+
+after(() => {
+  cy.removeACL();
+  removeContact();
+});

--- a/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
+++ b/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
@@ -101,8 +101,9 @@ Then(
     cy.loginByTypeOfUser({ jsonName: 'user', preserveToken: false })
       .wait('@getNavigationList')
       .isInProfileMenu('Edit profile')
-      .should('be.visible')
-      .visit('/centreon/main.php?p=50104&o=c')
+      .should('be.visible');
+      
+    cy.visit('/centreon/main.php?p=50104&o=c')
       .wait('@getTimeZone')
       .getIframeBody()
       .find('form')

--- a/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
+++ b/tests/e2e/cypress/integration/Local-authentication/01-local-authentication/index.ts
@@ -17,10 +17,6 @@ beforeEach(() => {
   }).as('getNavigationList');
   cy.intercept({
     method: 'GET',
-    url: '/centreon/main.php?p=50104',
-  }).as('getIframeReload');
-  cy.intercept({
-    method: 'GET',
     url: '/centreon/include/common/userTimezone.php',
   }).as('getTimeZone');
 });
@@ -77,7 +73,7 @@ When(
       .get('div[role="tablist"] button')
       .eq(0)
       .contains('Password security policy');
-    cy.get('#Minimumpasswordlength').should('exist').and('have.value', '12');
+    cy.get('#Minimumpasswordlength').clear().type('12');
     cy.get('#Passwordmustcontainlowercase').should(
       'have.class',
       'MuiButton-containedPrimary',
@@ -116,8 +112,8 @@ Then(
       })
       .find('#validForm input[name="submitC"]')
       .click();
-    cy.wait(3000);
-    cy.getIframeBody()
+    cy.getRefreshDataOnIframe()
+      .getIframeBody()
       .find('#Form')
       .find('#tab1 #passwd1')
       .parent()

--- a/tests/e2e/cypress/integration/Local-authentication/common.ts
+++ b/tests/e2e/cypress/integration/Local-authentication/common.ts
@@ -1,0 +1,87 @@
+import {
+  applyConfigurationViaClapi,
+  executeActionViaClapi,
+} from '../../commons';
+
+interface DataToUseForCheckForm {
+  custom?: () => void;
+  selector: string;
+  value?: string;
+}
+
+const initializeConfigACLAndGetLoginPage = (): Cypress.Chainable => {
+  return cy
+    .executeCommandsViaClapi(
+      'resources/clapi/config-ACL/local-authentication-acl-user.json',
+    )
+    .then(applyConfigurationViaClapi)
+    .then(() => cy.visit(`${Cypress.config().baseUrl}`))
+    .then(() => cy.fixture('users/admin.json'));
+};
+
+const removeContact = (): Cypress.Chainable => {
+  return cy.setUserTokenApiV1().then(() => {
+    executeActionViaClapi({
+      action: 'DEL',
+      object: 'CONTACT',
+      values: 'user1',
+    });
+  });
+};
+
+const checkDefaultsValueForm: Array<DataToUseForCheckForm> = [
+  {
+    selector: '#Minimumpasswordlength',
+    value: '12',
+  },
+  {
+    selector: '#PasswordexpiresafterpasswordExpirationexpirationDelayMonth',
+    value: '6',
+  },
+  {
+    selector: '#PasswordexpiresafterpasswordExpirationexpirationDelayDay',
+    value: '0',
+  },
+  {
+    custom: (): void => {
+      cy.get('div[name="excludedUsers"]')
+        .find('span')
+        .contains('centreon-gorgone');
+    },
+    selector: '#Excludedusers',
+    value: '',
+  },
+  {
+    selector: '#MinimumtimebetweenpasswordchangesdelayBeforeNewPasswordDay',
+    value: '0',
+  },
+  {
+    selector: '#MinimumtimebetweenpasswordchangesdelayBeforeNewPasswordHour',
+    value: '1',
+  },
+  {
+    selector: '#Last3passwordscanbereused',
+    value: 'on',
+  },
+  {
+    selector: '#Numberofattemptsbeforeuserisblocked',
+    value: '5',
+  },
+  {
+    selector:
+      '#TimethatmustpassbeforenewconnectionisallowedblockingDurationDay',
+    value: '0',
+  },
+  {
+    selector:
+      '#TimethatmustpassbeforenewconnectionisallowedblockingDurationHour',
+    value: '0',
+  },
+];
+
+export {
+  removeContact,
+  initializeConfigACLAndGetLoginPage,
+  checkDefaultsValueForm,
+  DataToUseForCheckForm,
+};

--- a/tests/e2e/cypress/integration/Local-authentication/common.ts
+++ b/tests/e2e/cypress/integration/Local-authentication/common.ts
@@ -35,6 +35,49 @@ const checkDefaultsValueForm: Array<DataToUseForCheckForm> = [
     value: '12',
   },
   {
+    custom: (): void => {
+      cy.get('#Passwordmustcontainlowercase').should(
+        'have.class',
+        'MuiButton-containedPrimary',
+      );
+    },
+    selector: '#Passwordmustcontainlowercase',
+    value: '',
+  },
+  {
+    custom: (): void => {
+      cy.get('#Passwordmustcontainuppercase').should(
+        'have.class',
+        'MuiButton-containedPrimary',
+      );
+    },
+
+    selector: '#Passwordmustcontainuppercase',
+    value: '',
+  },
+  {
+    custom: (): void => {
+      cy.get('#Passwordmustcontainnumbers').should(
+        'have.class',
+        'MuiButton-containedPrimary',
+      );
+    },
+
+    selector: '#Passwordmustcontainnumbers',
+    value: '',
+  },
+  {
+    custom: (): void => {
+      cy.get('#Passwordmustcontainspecialcharacters').should(
+        'have.class',
+        'MuiButton-containedPrimary',
+      );
+    },
+
+    selector: '#Passwordmustcontainspecialcharacters',
+    value: '',
+  },
+  {
     selector: '#PasswordexpiresafterpasswordExpirationexpirationDelayMonth',
     value: '6',
   },

--- a/tests/e2e/cypress/support/Commands.ts
+++ b/tests/e2e/cypress/support/Commands.ts
@@ -112,13 +112,6 @@ Cypress.Commands.add('getIframeBody', (): Cypress.Chainable => {
 });
 
 Cypress.Commands.add(
-  'getFormFieldByIndex',
-  (rootItemNumber: number): Cypress.Chainable => {
-    return cy.getIframeBody().find('#Form').find('tr').eq(rootItemNumber);
-  },
-);
-
-Cypress.Commands.add(
   'isInProfileMenu',
   (targetedMenu: string): Cypress.Chainable => {
     return cy
@@ -168,6 +161,10 @@ Cypress.Commands.add('removeACL', (): Cypress.Chainable => {
   });
 });
 
+Cypress.Commands.add('getRefreshDataOnIframe', () => {
+  return cy.wait('@getTimeZone').wait('@getTimeZone');
+});
+
 interface GetByLabelProps {
   label: string;
   tag?: string;
@@ -189,8 +186,8 @@ declare global {
     interface Chainable {
       executeCommandsViaClapi: (fixtureFile: string) => Cypress.Chainable;
       getByLabel: ({ tag, label }: GetByLabelProps) => Cypress.Chainable;
-      getFormFieldByIndex: (rootItemNumber: number) => Cypress.Chainable;
       getIframeBody: () => Cypress.Chainable;
+      getRefreshDataOnIframe: () => Cypress.Chainable;
       hoverRootMenuItem: (rootItemNumber: number) => Cypress.Chainable;
       isInProfileMenu: (targetedMenu: string) => Cypress.Chainable;
       loginByTypeOfUser: ({

--- a/www/front_src/src/Authentication/Local/Form/Attempts.tsx
+++ b/www/front_src/src/Authentication/Local/Form/Attempts.tsx
@@ -79,6 +79,7 @@ const Attempts = (): JSX.Element => {
       <div className={classes.input}>
         <TextField
           fullWidth
+          dataTestId={labelNumberOfAttemptsBeforeUserIsBlocked}
           error={attemptsError}
           helperText={attemptsError}
           inputProps={{

--- a/www/front_src/src/Authentication/Local/Form/CaseButtons/index.tsx
+++ b/www/front_src/src/Authentication/Local/Form/CaseButtons/index.tsx
@@ -109,6 +109,8 @@ const CaseButtons = (): JSX.Element => {
             aria-label={t(labelPasswordMustContainLowerCase)}
             className={clsx(classes.lowerCaseButton, classes.button)}
             color="primary"
+            data-testid={labelPasswordMustContainLowerCase}
+            id={labelPasswordMustContainLowerCase?.replace(/ /g, '')}
             size="small"
             variant="outlined"
             onClick={selectCase(hasLowerCaseName)}
@@ -123,6 +125,8 @@ const CaseButtons = (): JSX.Element => {
             aria-label={t(labelPasswordMustContainUpperCase)}
             className={classes.button}
             color="primary"
+            data-testid={labelPasswordMustContainUpperCase}
+            id={labelPasswordMustContainUpperCase?.replace(/ /g, '')}
             size="small"
             variant="outlined"
             onClick={selectCase(hasUpperCaseName)}
@@ -137,6 +141,8 @@ const CaseButtons = (): JSX.Element => {
             aria-label={t(labelPasswordMustContainNumbers)}
             className={classes.button}
             color="primary"
+            data-testid={labelPasswordMustContainNumbers}
+            id={labelPasswordMustContainNumbers?.replace(/ /g, '')}
             size="small"
             variant="outlined"
             onClick={selectCase(hasNumberName)}
@@ -151,6 +157,8 @@ const CaseButtons = (): JSX.Element => {
             aria-label={t(labelPasswordMustContainSpecialCharacters)}
             className={classes.button}
             color="primary"
+            data-testid={labelPasswordMustContainSpecialCharacters}
+            id={labelPasswordMustContainSpecialCharacters.replace(/ /g, '')}
             size="small"
             variant="outlined"
             onClick={selectCase(hasSpecialCharacterName)}

--- a/www/front_src/src/Authentication/Local/Form/inputs.tsx
+++ b/www/front_src/src/Authentication/Local/Form/inputs.tsx
@@ -22,6 +22,7 @@ const inputs: Array<InputProps> = [
       alignItems: 'center',
       columns: [
         {
+          dataTestId: labelMinimumPasswordLength,
           fieldName: 'passwordMinLength',
           label: labelMinimumPasswordLength,
           text: {
@@ -81,6 +82,7 @@ const inputs: Array<InputProps> = [
     type: InputType.Custom,
   },
   {
+    dataTestId: labelLast3PasswordsCanBeReused,
     fieldName: 'canReusePasswords',
     group: labelPasswordExpirationPolicy,
     label: labelLast3PasswordsCanBeReused,

--- a/www/front_src/src/Authentication/Local/TimeInputs/TimeInput.tsx
+++ b/www/front_src/src/Authentication/Local/TimeInputs/TimeInput.tsx
@@ -158,6 +158,7 @@ const TimeInput = ({
     Component: (
       <div className={classes.timeInput}>
         <SelectField
+          dataTestId={`${inputLabel} ${name}`}
           inputProps={{
             'aria-label': `${t(inputLabel)} ${t(label)}`,
           }}

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -551,7 +551,7 @@ describe('Password expiration policy', () => {
       expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(2);
     });
 
-    userEvent.click(screen.getAllByLabelText(labelExcludedUsers));
+    userEvent.click(screen.getByLabelText(labelExcludedUsers));
 
     await waitFor(() => {
       expect(getFetchCall(0)).toEqual(

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -423,7 +423,7 @@ describe('Password expiration policy', () => {
       ),
     ).toHaveTextContent('1');
 
-    expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(1);
+    expect(screen.getByLabelText(labelExcludedUsers)).toBeInTheDocument();
   });
 
   it('does not display any error message when the password expiration time is cleared', async () => {
@@ -548,10 +548,10 @@ describe('Password expiration policy', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(1);
+      expect(screen.getByLabelText(labelExcludedUsers)).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByLabelText(labelExcludedUsers)[0]);
+    userEvent.click(screen.getByLabelText(labelExcludedUsers));
 
     await waitFor(() => {
       expect(getFetchCall(0)).toEqual(

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -423,7 +423,7 @@ describe('Password expiration policy', () => {
       ),
     ).toHaveTextContent('1');
 
-    expect(screen.getAllByText(labelExcludedUsers)).toBeInTheDocument();
+    expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(2);
   });
 
   it('does not display any error message when the password expiration time is cleared', async () => {
@@ -548,10 +548,10 @@ describe('Password expiration policy', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText(labelExcludedUsers)).toBeInTheDocument();
+      expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(2);
     });
 
-    userEvent.click(screen.getByLabelText(labelExcludedUsers));
+    userEvent.click(screen.getAllByLabelText(labelExcludedUsers));
 
     await waitFor(() => {
       expect(getFetchCall(0)).toEqual(

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -423,7 +423,7 @@ describe('Password expiration policy', () => {
       ),
     ).toHaveTextContent('1');
 
-    expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(2);
+    expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(1);
   });
 
   it('does not display any error message when the password expiration time is cleared', async () => {
@@ -548,10 +548,10 @@ describe('Password expiration policy', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(2);
+      expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(1);
     });
 
-    userEvent.click(screen.getByLabelText(labelExcludedUsers));
+    userEvent.click(screen.getByLabelText(labelExcludedUsers)[1]);
 
     await waitFor(() => {
       expect(getFetchCall(0)).toEqual(

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -423,7 +423,7 @@ describe('Password expiration policy', () => {
       ),
     ).toHaveTextContent('1');
 
-    expect(screen.getByText(labelExcludedUsers)).toBeInTheDocument();
+    expect(screen.getAllByText(labelExcludedUsers)).toBeInTheDocument();
   });
 
   it('does not display any error message when the password expiration time is cleared', async () => {

--- a/www/front_src/src/Authentication/Local/index.test.tsx
+++ b/www/front_src/src/Authentication/Local/index.test.tsx
@@ -551,7 +551,7 @@ describe('Password expiration policy', () => {
       expect(screen.getAllByLabelText(labelExcludedUsers)).toHaveLength(1);
     });
 
-    userEvent.click(screen.getByLabelText(labelExcludedUsers)[1]);
+    userEvent.click(screen.getByLabelText(labelExcludedUsers)[0]);
 
     await waitFor(() => {
       expect(getFetchCall(0)).toEqual(


### PR DESCRIPTION
## Description

Adding new cypress scenario for local authentication and refacto some cypress commands. 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch cypress test on local authentication.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
