### PR TITLE
fix(resource): duplicated lines displayed on resource status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,14 +10,11 @@ def devBranch = "develop"
 env.REF_BRANCH = stableBranch
 env.PROJECT='centreon-web'
 
-
-
-
 if (env.BRANCH_NAME.startsWith('release-22.10.0-next')) {
   env.BUILD = 'QA'
   env.REPO = 'unstable'
   env.DELIVERY_STAGE = 'Delivery to unstable'
-} else if (env.BRANCH_NAME.startsWith('release-')) {
+} else if (env.BRANCH_NAME.startsWith('hotfix-') || env.BRANCH_NAME.startsWith('release-')) {
   env.BUILD = 'RELEASE'
   env.REPO = 'testing'
   env.DELIVERY_STAGE = 'Delivery to testing'

--- a/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -171,7 +171,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         FROM `:dbstg`.`resources`
         LEFT JOIN `:dbstg`.`resources` parent_resource
             ON parent_resource.id = resources.parent_id
-        LEFT JOIN `:dbstg`.`severities`
+            AND parent_resource.type = ' . self::RESOURCE_TYPE_HOST .
+        'LEFT JOIN `:dbstg`.`severities`
             ON `severities`.severity_id = `resources`.severity_id
         LEFT JOIN `:dbstg`.`resources_tags` AS rtags
             ON `rtags`.resource_id = `resources`.resource_id

--- a/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -172,7 +172,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         LEFT JOIN `:dbstg`.`resources` parent_resource
             ON parent_resource.id = resources.parent_id
             AND parent_resource.type = ' . self::RESOURCE_TYPE_HOST .
-        "LEFT JOIN `:dbstg`.`severities`
+        " LEFT JOIN `:dbstg`.`severities`
             ON `severities`.severity_id = `resources`.severity_id
         LEFT JOIN `:dbstg`.`resources_tags` AS rtags
             ON `rtags`.resource_id = `resources`.resource_id

--- a/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -127,7 +127,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
     ): string {
         $this->sqlRequestTranslator->setConcordanceArray($this->resourceConcordances);
 
-        $request = "SELECT SQL_CALC_FOUND_ROWS DISTINCT
+        $request = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT
             resources.resource_id,
             resources.name,
             resources.alias,
@@ -172,7 +172,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         LEFT JOIN `:dbstg`.`resources` parent_resource
             ON parent_resource.id = resources.parent_id
             AND parent_resource.type = ' . self::RESOURCE_TYPE_HOST .
-        'LEFT JOIN `:dbstg`.`severities`
+        "LEFT JOIN `:dbstg`.`severities`
             ON `severities`.severity_id = `resources`.severity_id
         LEFT JOIN `:dbstg`.`resources_tags` AS rtags
             ON `rtags`.resource_id = `resources`.resource_id

--- a/tests/php/Core/Resources/Infrastructure/Repository/DbReadResourceRepositoryTest.php
+++ b/tests/php/Core/Resources/Infrastructure/Repository/DbReadResourceRepositoryTest.php
@@ -111,7 +111,7 @@ function generateExpectedSQLQuery(string $accessGroupRequest): string
         LEFT JOIN `centreon-monitoring`.`resources` parent_resource
             ON parent_resource.id = resources.parent_id
             AND parent_resource.type = 1' .
-        "LEFT JOIN `centreon-monitoring`.`severities`
+        " LEFT JOIN `centreon-monitoring`.`severities`
             ON `severities`.severity_id = `resources`.severity_id
         LEFT JOIN `centreon-monitoring`.`resources_tags` AS rtags
             ON `rtags`.resource_id = `resources`.resource_id

--- a/tests/php/Core/Resources/Infrastructure/Repository/DbReadResourceRepositoryTest.php
+++ b/tests/php/Core/Resources/Infrastructure/Repository/DbReadResourceRepositoryTest.php
@@ -110,12 +110,13 @@ function generateExpectedSQLQuery(string $accessGroupRequest): string
         FROM `centreon-monitoring`.`resources`
         LEFT JOIN `centreon-monitoring`.`resources` parent_resource
             ON parent_resource.id = resources.parent_id
-        LEFT JOIN `centreon-monitoring`.`severities`
+            AND parent_resource.type = 1' .
+        "LEFT JOIN `centreon-monitoring`.`severities`
             ON `severities`.severity_id = `resources`.severity_id
         LEFT JOIN `centreon-monitoring`.`resources_tags` AS rtags
             ON `rtags`.resource_id = `resources`.resource_id
         INNER JOIN `centreon-monitoring`.`instances`
-            ON `instances`.instance_id = `resources`.poller_id WHERE ' .
+            ON `instances`.instance_id = `resources`.poller_id WHERE " .
         " resources.name NOT LIKE '\_Module\_%'
             AND resources.parent_name NOT LIKE '\_Module\_BAM%'
             AND resources.enabled = 1 AND resources.type != 3 " .

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '22.10.0');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '22.10.1');
 
 --
 -- Contenu de la table `contact`

--- a/www/install/php/Update-22.10.1.php
+++ b/www/install/php/Update-22.10.1.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+

--- a/www/install/php/Update-22.10.1.php
+++ b/www/install/php/Update-22.10.1.php
@@ -18,4 +18,3 @@
  * For more information : contact@centreon.com
  *
  */
-


### PR DESCRIPTION
## Description
This issue occurs when resources parent_id and id are equal among all the resources stored in centreon_storage.resources. This implies that when we try to retrieve the host of a service in LEFT JOIN statement, the host is returned but the service itself too which creates the duplicates.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
