### PR TITLE
change module type to module instead of umd in webpack configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@visx/threshold": "^2.12.2",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
-        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -8185,7 +8185,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.10.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#9c83111511f857c2a03fab5650905472640d426f",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#52e08347523a15322249180c58e686bb10b0e7a9",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.3",
@@ -27079,6 +27079,58 @@
         "reduce-css-calc": "^1.3.0"
       }
     },
+    "@visx/threshold": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@visx/threshold/-/threshold-2.12.2.tgz",
+      "integrity": "sha512-Wg33MK8t8m12SRO4W3U6pKmVK7mnIcA8EshmlS8vL/VvKBcyOyw1/7FHmBAdSvyfh4zXAmj5WtG0G8lp5TwkYw==",
+      "requires": {
+        "@types/react": "*",
+        "@visx/clip-path": "2.10.0",
+        "@visx/shape": "2.12.2",
+        "classnames": "^2.3.1",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@visx/clip-path": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/clip-path/-/clip-path-2.10.0.tgz",
+          "integrity": "sha512-YIUQstsHKGysyDISOV5p+fMymkUdHCs89nSY/w6TG9EIl8x2jRhrQdojwtCYvjLkPZiZiKa8MBT6fFzsSfGImg==",
+          "requires": {
+            "@types/react": "*",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@visx/group": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/group/-/group-2.10.0.tgz",
+          "integrity": "sha512-DNJDX71f65Et1+UgQvYlZbE66owYUAfcxTkC96Db6TnxV221VKI3T5l23UWbnMzwFBP9dR3PWUjjqhhF12N5pA==",
+          "requires": {
+            "@types/react": "*",
+            "classnames": "^2.3.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "@visx/shape": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-2.12.2.tgz",
+          "integrity": "sha512-4gN0fyHWYXiJ+Ck8VAazXX0i8TOnLJvOc5jZBnaJDVxgnSIfCjJn0+Nsy96l9Dy/bCMTh4DBYUBv9k+YICBUOA==",
+          "requires": {
+            "@types/d3-path": "^1.0.8",
+            "@types/d3-shape": "^1.3.1",
+            "@types/lodash": "^4.14.172",
+            "@types/react": "*",
+            "@visx/curve": "2.1.0",
+            "@visx/group": "2.10.0",
+            "@visx/scale": "2.2.2",
+            "classnames": "^2.3.1",
+            "d3-path": "^1.0.5",
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.5.10"
+          }
+        }
+      }
+    },
     "@visx/tooltip": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@visx/tooltip/-/tooltip-2.8.0.tgz",
@@ -28322,8 +28374,8 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#9c83111511f857c2a03fab5650905472640d426f",
-      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#52e08347523a15322249180c58e686bb10b0e7a9",
+      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration",
       "requires": {
         "@dnd-kit/core": "^5.0.3",
         "@dnd-kit/modifiers": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@visx/threshold": "^2.12.2",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
-    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#develop",
+    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,9 +11,6 @@ module.exports = (jscTransformConfiguration) =>
     getBaseConfiguration({ jscTransformConfiguration, moduleName: 'centreon' }),
     {
       entry: ['./www/front_src/src/index.tsx'],
-      experiments: {
-        outputModule: true,
-      },
       output: {
         crossOriginLoading: 'anonymous',
         path: path.resolve(`${__dirname}/www/static`),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,9 +11,11 @@ module.exports = (jscTransformConfiguration) =>
     getBaseConfiguration({ jscTransformConfiguration, moduleName: 'centreon' }),
     {
       entry: ['./www/front_src/src/index.tsx'],
+      experiments: {
+        outputModule: true,
+      },
       output: {
         crossOriginLoading: 'anonymous',
-        library: ['name'],
         path: path.resolve(`${__dirname}/www/static`),
         publicPath: './static/',
       },


### PR DESCRIPTION
## Description

Change the webpack configuration libraryTarget from umd to module with the aim to reduce the bundle size


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Validate that user can access to pages (should be validated by cypress and ligthouse)
Execute minimal TNR on legacy / reactJS pages

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
